### PR TITLE
fix: Fixes docker related attributes in manifests

### DIFF
--- a/AzureActiveDirectory/action_disable_user.json
+++ b/AzureActiveDirectory/action_disable_user.json
@@ -2,7 +2,7 @@
   "name": "Disable User",
   "description": "Disable an Azure Active Directory user. Requires the User.ReadWrite.All permission.",
   "uuid": "df34b4c8-f570-5c70-a986-e1c649aedf42",
-  "slug": "DisableUserAction",
+  "docker_parameters": "DisableUserAction",
   "arguments": {
     "title": "RequiredSingleUserArguments",
     "type": "object",

--- a/AzureActiveDirectory/action_enable_user.json
+++ b/AzureActiveDirectory/action_enable_user.json
@@ -2,7 +2,7 @@
   "name": "Enable User",
   "description": "Enable an Azure Active Directory user. Requires the User.ReadWrite.All permission.",
   "uuid": "b0722afd-470c-5963-a111-b30804965b37",
-  "slug": "EnableUserAction",
+  "docker_parameters": "EnableUserAction",
   "arguments": {
     "title": "RequiredSingleUserArguments",
     "type": "object",

--- a/AzureActiveDirectory/action_get_signins.json
+++ b/AzureActiveDirectory/action_get_signins.json
@@ -2,7 +2,7 @@
   "name": "Get SignIns",
   "description": "Get the last sign ins of an Azure AD user. Requires the AuditLog.Read.All and Directory.Read.All permissions.",
   "uuid": "02d6dbc8-6622-5718-9925-ae032dfa5208",
-  "slug": "GetSignInsAction",
+  "docker_parameters": "GetSignInsAction",
   "arguments": {
     "title": "SingleUserArguments",
     "type": "object",

--- a/AzureActiveDirectory/action_get_user.json
+++ b/AzureActiveDirectory/action_get_user.json
@@ -2,7 +2,7 @@
   "name": "Get User",
   "description": "Get information about an Azure Active Directory user. Requires the User.Read.All permission.",
   "uuid": "edbe4896-aefd-5429-95c3-eab869e207c4",
-  "slug": "GetUserAction",
+  "docker_parameters": "GetUserAction",
   "arguments": {
     "title": "RequiredSingleUserArguments",
     "type": "object",

--- a/AzureActiveDirectory/action_get_user_authentication_methods.json
+++ b/AzureActiveDirectory/action_get_user_authentication_methods.json
@@ -2,7 +2,7 @@
   "name": "Get User Authentication Methods",
   "description": "Get information about an user's authentication methods (such as their MFA status). Requires the UserAuthenticationMethod.Read.All permission.",
   "uuid": "ae7ec26b-7a57-54f1-908b-011240ffd5c7",
-  "slug": "GetUserAuthenticationMethodsAction",
+  "docker_parameters": "GetUserAuthenticationMethodsAction",
   "arguments": {
     "title": "RequiredSingleUserArguments",
     "type": "object",

--- a/CrowdStrike Telemetry/manifest.json
+++ b/CrowdStrike Telemetry/manifest.json
@@ -23,8 +23,8 @@
       ]
   },
   "description": "[CrowdStrike] CrowdStrike provides cloud workload and endpoint security, threat intelligence, and cyberattack response services and products.\n This module provides triggers to collect events from CrowdStrike",
-  "name": "CrowdStrike",
+  "name": "CrowdStrike Telemetry",
+  "slug": "crowdstrike-telemetry",
   "uuid": "10999b99-9a8d-4b92-9fbd-01e3fac01cd5",
-  "docker": "symphony-module-crowstrike-telemetry",
   "version": "2.0.0"
 }


### PR DESCRIPTION
* In `CrowdStrike` module add a slug and remove the docker parameter
  * The slug is used to push the images in the docker registry
* In `AzureActiveDirectory ` , in the actions replace `slug` by `docker_parameters`.
  * SymphonyAPI is expecting a `docker_parameters` attribute when an action is created/updated 
  * Later we may change the sync library script to convert `slug` to `docker_parameters` in actions