### PR TITLE
Introduce an optional parameter to specify the SQS url

### DIFF
--- a/CrowdStrike/CHANGELOG.md
+++ b/CrowdStrike/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0] - 2023-06-20
+
+### Added
+
+- Introduce the optional configuration parameter `queue_url` to specify the url of the SQS queue

--- a/CrowdStrike/aws/sqs.py
+++ b/CrowdStrike/aws/sqs.py
@@ -17,6 +17,7 @@ class SqsConfiguration(AwsConfiguration):
     delete_consumed_messages: bool = Field(default=True, description="Delete consumed messages from queue")
     is_fifo: bool = Field(default=False, description="Is queue fifo, might ")
     queue_name: str = Field(description="AWS SQS queue name")
+    queue_url: str | None = Field(descripton="AWS SQS queue url")
 
 
 class SqsWrapper(AwsClient[SqsConfiguration]):
@@ -52,11 +53,17 @@ class SqsWrapper(AwsClient[SqsConfiguration]):
         """
         Get SQS queue url.
 
+        If defined, returns the value in the configuration
         If it is fifo then use postfix .fifo to initialize url, based on configuration.
 
         Returns:
             str:
         """
+
+        queue_url = self._configuration.queue_url
+        if queue_url:
+            return queue_url
+
         queue_name = self._configuration.queue_name
         if self._configuration.is_fifo:
             queue_name = self._configuration.queue_name + ".fifo"

--- a/CrowdStrike/manifest.json
+++ b/CrowdStrike/manifest.json
@@ -26,5 +26,5 @@
   "name": "CrowdStrike",
   "uuid": "4ffe6bd9-6693-414d-ade0-5ec9fb1b8b2c",
   "slug": "crowdstrike",
-  "version": "1.0.8"
+  "version": "1.1.0"
 }

--- a/CrowdStrike/trigger_crowdstrike_telemetry_events.json
+++ b/CrowdStrike/trigger_crowdstrike_telemetry_events.json
@@ -29,6 +29,10 @@
         "type": "string",
         "description": "The name of the SQS queue that received messages with files information"
       },
+      "queue_url": {
+        "type": "string",
+        "description": "The URL of the SQS queue that received messages with files information"
+      },
       "intake_server": {
         "description": "Server of the intake server (e.g. 'https://intake.sekoia.io')",
         "default": "https://intake.sekoia.io",


### PR DESCRIPTION
This PR introduces queue_url, an optional trigger configuration parameter.
The user can specify the `queue_url` to hardcode the AWS SQL Url to limit the required permissions on the AWS Tenant.

