### PR TITLE
declare queue_url as a connector parameter in Crowdstrike module

### DIFF
--- a/CrowdStrike/CHANGELOG.md
+++ b/CrowdStrike/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2023-06-21
+
+### Fixed
+
+- Properly declare the `queue_url` parameter in the collector configuration
+
 ## [1.1.0] - 2023-06-20
 
 ### Added

--- a/CrowdStrike/aws/sqs.py
+++ b/CrowdStrike/aws/sqs.py
@@ -40,12 +40,14 @@ class SqsWrapper(AwsClient[SqsConfiguration]):
                     chunk_size = {chunk_size}
                     delete_consumed_messages = {delete_consumed_messages}
                     is_fifo = {is_fifo}
+                    queue_url = {queue_url}
             """,
             queue_name=configuration.queue_name,
             frequency=configuration.frequency,
             chunk_size=configuration.chunk_size,
             delete_consumed_messages=configuration.delete_consumed_messages,
             is_fifo=configuration.is_fifo,
+            queue_url=configuration.queue_url,
         )
 
     @alru_cache

--- a/CrowdStrike/crowdstrike_telemetry/pull_telemetry_events.py
+++ b/CrowdStrike/crowdstrike_telemetry/pull_telemetry_events.py
@@ -15,6 +15,7 @@ from .schemas import CrowdStrikeNotificationSchema
 
 class CrowdStrikeTelemetryConfig(DefaultConnectorConfiguration):
     queue_name: str
+    queue_url: str | None = None
     chunk_size: int | None = None
     frequency: int | None = None
     delete_consumed_messages: bool | None = None

--- a/CrowdStrike/manifest.json
+++ b/CrowdStrike/manifest.json
@@ -26,5 +26,5 @@
   "name": "CrowdStrike",
   "uuid": "4ffe6bd9-6693-414d-ade0-5ec9fb1b8b2c",
   "slug": "crowdstrike",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/CrowdStrike/tests/crowdstrike_telemetry/test_crowdstrike.py
+++ b/CrowdStrike/tests/crowdstrike_telemetry/test_crowdstrike.py
@@ -173,3 +173,32 @@ async def test_get_crowdstrike_events(crowdstrike_connector, session_faker):
 
         assert crowdstrike_connector.push_events_to_intakes.called
         assert not crowdstrike_connector.log_exception.called
+
+
+@pytest.mark.asyncio
+async def test_specify_queue_url(session_faker):
+    queue_url = session_faker.url()
+
+    module = CrowdStrikeTelemetryModule()
+    module.configuration = CrowdStrikeTelemetryModuleConfig(
+        aws_access_key_id=session_faker.word(),
+        aws_secret_access_key=session_faker.word(),
+        aws_region=session_faker.word(),
+    )
+
+    connector = CrowdStrikeTelemetryConnector(module)
+    connector.configuration = CrowdStrikeTelemetryConfig(
+        queue_name=session_faker.word(),
+        queue_url=queue_url,
+        intake_key=session_faker.word(),
+        chunk_size=session_faker.random.randint(1, 10),
+        frequency=session_faker.random.randint(0, 20),
+        delete_consumed_messages=True,
+        is_fifo=False,
+    )
+    connector.push_events_to_intakes = MagicMock()
+    connector.log = MagicMock()
+    connector.log_exception = MagicMock()
+
+    sqs_wrapper = connector.sqs_wrapper
+    assert await sqs_wrapper.queue_url() == queue_url


### PR DESCRIPTION
This PR fixes the queue_url declaration in the CrowdStrike module.
