### PR TITLE
fix(vadesecure/m365): Build remote URL using `urljoin` to prevent bad format

### DIFF
--- a/VadeSecure/tests/test_m365_events_trigger.py
+++ b/VadeSecure/tests/test_m365_events_trigger.py
@@ -40,6 +40,18 @@ def test_fetch_events(trigger):
     assert len(trigger._fetch_next_events.call_args_list) == len(EVENT_TYPES)
 
 
+def test_fetch_events_bad_url(trigger):
+    trigger.module.configuration.api_host = "https://api-test.vadesecure.com/////"
+    trigger._get_authorization = MagicMock(return_value="Bearer 123456")
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://api-test.vadesecure.com/api/v1/tenants/e49e7162-0df6-48e9-a75e-237d54871e8b/logs/emails/search",
+            json={"result": {"total": 2, "messages": [{}, {}]}},
+        )
+        trigger._fetch_next_events(last_message_id="1", last_message_date=datetime.utcnow(), event_type="emails")
+        assert mock.called_once
+
+
 def test_fetch_next_emails_events(trigger):
     url = (
         f"{trigger.module.configuration.api_host}/api/v1/tenants/"

--- a/VadeSecure/vadesecure_modules/trigger_m365_events.py
+++ b/VadeSecure/vadesecure_modules/trigger_m365_events.py
@@ -4,6 +4,7 @@ import uuid
 from collections.abc import Generator, Sequence
 from datetime import datetime, timedelta
 from typing import Deque
+from urllib.parse import urljoin
 
 import orjson
 import requests
@@ -171,11 +172,13 @@ class M365EventsTrigger(Trigger):
             ],
         }
 
+        url = urljoin(
+            base=self.module.configuration.api_host,
+            url=f"/api/v1/tenants/{self.configuration.tenant_id}/logs/{event_type}/search",
+        )
+
         response = self.http_session.post(
-            url=(
-                f"{self.module.configuration.api_host}/api/v1/tenants/"
-                f"{self.configuration.tenant_id}/logs/{event_type}/search"
-            ),
+            url=url,
             json=payload_json,
             headers={"Authorization": self._get_authorization()},
         )


### PR DESCRIPTION
fix `example.host.net/` instead of `example.host.net` willl construct an url containing two slashes `example.host.net//api/path`