### PR TITLE
Netskope: improve observability

### DIFF
--- a/Netskope/manifest.json
+++ b/Netskope/manifest.json
@@ -18,5 +18,5 @@
     "name": "Netskope",
     "uuid": "1e3f2e33-fb9c-4387-bcf7-8d7ece37f913",
     "slug": "netskope",
-    "version": "1.6"
+    "version": "1.6.1"
 }

--- a/Netskope/netskope_modules/connector_pull_events_v2.py
+++ b/Netskope/netskope_modules/connector_pull_events_v2.py
@@ -138,7 +138,6 @@ class NetskopeEventConnector(Connector):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._exporter = None
 
     @cached_property
     def tenant_hostname(self):

--- a/Netskope/netskope_modules/connector_pull_events_v2.py
+++ b/Netskope/netskope_modules/connector_pull_events_v2.py
@@ -9,7 +9,6 @@ from netskope_api.iterator.const import Const
 from netskope_api.iterator.netskope_iterator import NetskopeIterator
 from pydantic import Field
 from sekoia_automation.connector import Connector, DefaultConnectorConfiguration
-from sekoia_automation.metrics import PrometheusExporterThread, make_exporter
 
 from netskope_modules import NetskopeModule
 from netskope_modules.constants import MESSAGE_CANNOT_CONSUME_SERVICE
@@ -268,20 +267,6 @@ class NetskopeEventConnector(Connector):
             if consumer is not None and consumer.is_alive():
                 self.log(message=f"Stop {name} consumer", level="info")
                 consumers[name].stop()
-
-    def start_monitoring(self):
-        super().start_monitoring()
-        # start the prometheus exporter
-        self._exporter = make_exporter(
-            PrometheusExporterThread,
-            int(os.environ.get("WORKER_PROM_LISTEN_PORT", "8010"), 10),
-        )
-        self._exporter.start()
-
-    def stop_monitoring(self):
-        super().stop_monitoring()
-        if self._exporter:
-            self._exporter.stop()
 
     def run(self):
         try:

--- a/Netskope/netskope_modules/connector_pull_events_v2.py
+++ b/Netskope/netskope_modules/connector_pull_events_v2.py
@@ -106,7 +106,9 @@ class NetskopeEventConsumer(Thread):
         if most_recent_timestamp > 0:
             now = time.time()
             current_lag = now - most_recent_timestamp
-            EVENTS_LAG.labels(intake_key=self.connector.configuration.intake_key, type=self.name).observe(int(current_lag))
+            EVENTS_LAG.labels(intake_key=self.connector.configuration.intake_key, type=self.name).observe(
+                int(current_lag)
+            )
 
         # get the sleeping time from the response. Otherwise, compute the remaining sleeping time.
         delta_sleep = content.get("wait_time", 30 - batch_duration)

--- a/Netskope/netskope_modules/metrics.py
+++ b/Netskope/netskope_modules/metrics.py
@@ -10,6 +10,13 @@ OUTCOMING_EVENTS = Counter(
     labelnames=["intake_key", "type"],
 )
 
+EVENTS_LAG = Histogram(
+    name="events_lags",
+    documentation="The delay, in seconds, from the date of the last event",
+    namespace=prom_namespace,
+    labelnames=["intake_key", "type"],
+)
+
 FORWARD_EVENTS_DURATION = Histogram(
     name="forward_events_duration",
     documentation="Duration to collect and forward events from eventhub",

--- a/Netskope/netskope_modules/metrics.py
+++ b/Netskope/netskope_modules/metrics.py
@@ -1,7 +1,7 @@
 from prometheus_client import Counter, Histogram
 
 # Declare prometheus metrics
-prom_namespace = "symphony_module_netskope"
+prom_namespace = "symphony_module_common"
 
 OUTCOMING_EVENTS = Counter(
     name="forwarded_events",

--- a/Netskope/tests/test_pull_events_v2_connector.py
+++ b/Netskope/tests/test_pull_events_v2_connector.py
@@ -68,7 +68,7 @@ def test_next_batch_sleep_until_next_round(trigger):
         batch_duration = 16  # the batch lasts 16 seconds
         start_time = 1666711174.0
         end_time = start_time + batch_duration
-        mock_time.time.side_effect = [start_time, end_time]
+        mock_time.time.side_effect = [start_time, end_time, end_time]
 
         consumer.next_batch()
 
@@ -110,7 +110,7 @@ def test_next_batch_sleep_according_the_response(trigger):
         batch_duration = 16  # the batch lasts 16 seconds
         start_time = 1666711174.0
         end_time = start_time + batch_duration
-        mock_time.time.side_effect = [start_time, end_time]
+        mock_time.time.side_effect = [start_time, end_time, end_time]
 
         consumer.next_batch()
 
@@ -150,7 +150,7 @@ def test_long_next_batch_should_not_sleep(trigger):
         batch_duration = 45  # the batch lasts 45 seconds
         start_time = 1666711174.0
         end_time = start_time + batch_duration
-        mock_time.time.side_effect = [start_time, end_time]
+        mock_time.time.side_effect = [start_time, end_time, end_time]
 
         consumer.next_batch()
 


### PR DESCRIPTION
Improve the observability of the Netskope connector:
- Harmonize the namespace of the metrics 
- Remove metrics exporter in connectors. The parent class now defines an exporter.
- add a metric to observe the lag