### PR TITLE
Okta: ensure we save the progression 

### DIFF
--- a/Okta/CHANGELOG.md
+++ b/Okta/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### 2023-07-25 - 2.4.1
+
+### Changed
+
+- Save the most recent date seen when an exception is raised in the loop

--- a/Okta/manifest.json
+++ b/Okta/manifest.json
@@ -26,5 +26,5 @@
     "name": "Okta",
     "uuid": "4ef895d1-3f21-4678-8d0a-5c39c37210fe",
     "slug": "okta",
-    "version": "2.4"
+    "version": "2.4.1"
 }


### PR DESCRIPTION
Add a try-catch around the generator from `__fetch_next_events` to ensure to save the most recent date seen in the context when an exception is raised when getting events from Okta.