### PR TITLE
Trellix: fix the configuration

### DIFF
--- a/Trellix/CHANGELOG.md
+++ b/Trellix/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2023-08-18 - 1.2.1
+
+### Changed
+
+- Fix the configuration for the connector
+
 ## 2023-07-05 - 1.0.0
 
 ### Added

--- a/Trellix/manifest.json
+++ b/Trellix/manifest.json
@@ -9,5 +9,5 @@
     "name": "Trellix",
     "uuid": "888071f8-1456-11ee-be56-0242ac120002",
     "slug": "trellix",
-    "version": "1.2"
+    "version": "1.2.1"
 }

--- a/Trellix/tests/trellix/test_connector.py
+++ b/Trellix/tests/trellix/test_connector.py
@@ -67,7 +67,8 @@ def connector(symphony_storage, pushed_events_ids, session_faker):
     trigger.push_events_to_intakes = MagicMock()
     trigger.push_events_to_intakes.return_value = pushed_events_ids
 
-    trigger.module.configuration = {
+    trigger.module.configuration = {}
+    trigger.configuration = {
         "client_id": session_faker.word(),
         "client_secret": session_faker.word(),
         "api_key": session_faker.word(),
@@ -152,7 +153,7 @@ async def test_trellix_connector_get_epo_events(
         expected_edr_result = [edr_epo_event_response.dict() for _ in range(0, session_faker.pyint(max_value=100))]
 
         mocked_responses.get(
-            http_client.epo_events_url(current_date, limit=connector.module.configuration.records_per_request),
+            http_client.epo_events_url(current_date, limit=connector.configuration.records_per_request),
             status=200,
             payload={
                 "data": orjson.loads(orjson.dumps(expected_edr_result).decode("utf-8")),

--- a/Trellix/trellix/connector.py
+++ b/Trellix/trellix/connector.py
@@ -33,6 +33,7 @@ class TrellixConfig(DefaultConnectorConfiguration):
 
 class TrellixModule(Module):
     """TrellixModule."""
+
     pass
 
 


### PR DESCRIPTION
Fix the configuration of the connector as the manifest files indicates that the configuration should be in the connector configuration while the code indicates that the configuration should be in the module configuration.