### PR TITLE
feat(CrowdStrikeFalcon): Increase time to wait without events

### DIFF
--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -305,6 +305,8 @@ class EventStreamTrigger(Connector):
     module: CrowdStrikeFalconModule
     configuration: CrowdStrikeFalconEventStreamConfiguration
 
+    seconds_without_events = 3600 * 24  # Time to wait without events before restarting the pod
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
     "name": "CrowdStrike Falcon",
     "slug": "crowdstrike-falcon",
     "description": "Integrates with CrowdStrike Falcon EDR",
-    "version": "1.11.1",
+    "version": "1.12",
     "configuration": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {


### PR DESCRIPTION
This connector is not forwarding events very often, so we can increase the time to wait without events before restarting the pod. 