### PR TITLE
Darktrace: Allow unverify connections

### DIFF
--- a/Darktrace/CHANGELOG.md
+++ b/Darktrace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2023-06-30 - 1.3.2
+
+### Added
+
+- Add a parameter to verify or not the server certificate for TLS connections
+
 ## 2023-06-30 - 1.3.1
 
 ### Added

--- a/Darktrace/darktrace_modules/threat_visualizer_log_trigger.py
+++ b/Darktrace/darktrace_modules/threat_visualizer_log_trigger.py
@@ -21,6 +21,7 @@ class ThreatVisualizerLogConnectorConfiguration(DefaultConnectorConfiguration):
     ratelimit_per_minute: int = 30
     filter: str | None = None
     q: str | None = None
+    verify_certificate: bool = True
 
 
 class ThreatVisualizerLogConnector(Connector):
@@ -66,7 +67,7 @@ class ThreatVisualizerLogConnector(Connector):
         params = {"starttime": str(self.last_ts), "includeallpinned": "false"}
         url = urljoin(self.module.configuration.api_url, "modelbreaches")
 
-        response = self.client.get(url, params=params)
+        response = self.client.get(url, params=params, verify=self.configuration.verify_certificate)
         return response
 
     def refine_response(self, response: list) -> list:

--- a/Darktrace/manifest.json
+++ b/Darktrace/manifest.json
@@ -30,5 +30,5 @@
     "name": "Darktrace",
     "uuid": "0637f7c2-d68b-49cc-a1fc-ab7d0836e7ee",
     "slug": "darktrace",
-    "version": "1.3.1"
+    "version": "1.3.2"
 }

--- a/Darktrace/trigger_threat_visualizer_log.json
+++ b/Darktrace/trigger_threat_visualizer_log.json
@@ -19,6 +19,11 @@
                 "description": "Intake key to use when sending events",
                 "type": "string"
             },
+            "verify_certificate": {
+                "description": "Is the server certificate is verified",
+                "type": "boolean",
+		"default": true
+            },
             "ratelimit_per_minute": {
                 "description": "The number of requests allowed to the API in one minute",
                 "type": "integer",


### PR DESCRIPTION
Add an option to not verify the server certificate when requesting over a TLS connection