### PR TITLE
feat(Sekoia.io): Add limit parameter to get events action

### DIFF
--- a/Sekoia.io/action_get_event_field_common_values.json
+++ b/Sekoia.io/action_get_event_field_common_values.json
@@ -23,6 +23,10 @@
             "fields": {
                 "type": "string",
                 "description": "Fields to compute the most common values (use a coma between fields)"
+            },
+            "limit": {
+                "type": "number",
+                "description": "Maximum number of events to retrieve"
             }
         },
         "required": [

--- a/Sekoia.io/action_get_events.json
+++ b/Sekoia.io/action_get_events.json
@@ -19,6 +19,10 @@
             "latest_time": {
                 "description": "The latest time of the time range of the search",
                 "type": "string"
+            },
+            "limit": {
+                "type": "number",
+                "description": "Maximum number of events to retrieve"
             }
         },
         "required": [

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.44.1"
+    "version": "2.45"
 }

--- a/Sekoia.io/sekoiaio/operation_center/base_get_event.py
+++ b/Sekoia.io/sekoiaio/operation_center/base_get_event.py
@@ -39,15 +39,20 @@ class BaseGetEvents(Action):
             }
         )
 
-    def trigger_event_search_job(self, query: str, earliest_time: str, latest_time: str) -> str:
+    def trigger_event_search_job(
+        self, query: str, earliest_time: str, latest_time: str, limit: int | None = None
+    ) -> str:
+        data = {
+            "term": query,
+            "earliest_time": earliest_time,
+            "latest_time": latest_time,
+            "visible": False,
+        }
+        if limit is not None:
+            data["max_last_events"] = limit
         response_start = self.http_session.post(
             f"{self.events_api_path}/search/jobs",
-            json={
-                "term": query,
-                "earliest_time": earliest_time,
-                "latest_time": latest_time,
-                "visible": False,
-            },
+            json=data,
         )
         response_start.raise_for_status()
 

--- a/Sekoia.io/sekoiaio/operation_center/get_event_field_common_values.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_event_field_common_values.py
@@ -9,6 +9,7 @@ class GetEventFieldCommonValues(BaseGetEvents):
             query=arguments["query"],
             earliest_time=arguments["earliest_time"],
             latest_time=arguments["latest_time"],
+            limit=arguments.get("limit"),
         )
 
         self.wait_for_search_job_execution(event_search_job_uuid=event_search_job_uuid)

--- a/Sekoia.io/sekoiaio/operation_center/get_events.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_events.py
@@ -11,13 +11,14 @@ class GetEvents(BaseGetEvents):
             query=arguments["query"],
             earliest_time=arguments["earliest_time"],
             latest_time=arguments["latest_time"],
+            limit=arguments.get("limit"),
         )
 
         self.wait_for_search_job_execution(event_search_job_uuid=event_search_job_uuid)
 
         results: list[dict[str, Any]] | None = None
         response_content: dict[str, Any] = {}
-        limit: int = 1000
+        limit: int = min(1000, arguments.get("limit")) if "limit" in arguments else 1000
         offset: int = 0
 
         while results is None or response_content["total"] > offset + limit:

--- a/Sekoia.io/tests/operation_center/test_get_events.py
+++ b/Sekoia.io/tests/operation_center/test_get_events.py
@@ -14,6 +14,7 @@ def test_get_events(requests_mock):
         "earliest_time": "-1d",
         "latest_time": "now",
         "fields": "event.dialect,action.outcome,action.id",
+        "limit": 6,
     }
 
     requests_mock.post(
@@ -95,7 +96,7 @@ def test_get_events(requests_mock):
     requests_mock.get(
         (
             "https://fake.url/api/v1/sic/conf/events/search/jobs/"
-            "483d36a5-8538-49c4-be19-49b669f90bf8/events?limit=1000&offset=0"
+            "483d36a5-8538-49c4-be19-49b669f90bf8/events?limit=6&offset=0"
         ),
         json={
             "items": events,


### PR DESCRIPTION
Add an optional limit parameter for actions querying events.