### PR TITLE
fix(Sekoia.io): Fix limit param and pagination of results

### DIFF
--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.45"
+    "version": "2.45.1"
 }

--- a/Sekoia.io/sekoiaio/operation_center/get_events.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_events.py
@@ -4,24 +4,27 @@ from .base_get_event import BaseGetEvents
 
 
 class GetEvents(BaseGetEvents):
+    SEARCH_JOB_LIMIT = 5000
+
     def run(self, arguments):
+        action_limit = arguments.get("limit")
         self.configure_http_session()
 
         event_search_job_uuid: str = self.trigger_event_search_job(
             query=arguments["query"],
             earliest_time=arguments["earliest_time"],
             latest_time=arguments["latest_time"],
-            limit=arguments.get("limit"),
+            limit=action_limit,
         )
 
         self.wait_for_search_job_execution(event_search_job_uuid=event_search_job_uuid)
 
-        results: list[dict[str, Any]] | None = None
-        response_content: dict[str, Any] = {}
-        limit: int = min(1000, arguments.get("limit")) if "limit" in arguments else 1000
+        results: list[dict[str, Any]] = []
+        limit: int = min(1000, action_limit) if "limit" in arguments else 1000
         offset: int = 0
+        total: None | int = None
 
-        while results is None or response_content["total"] > offset + limit:
+        while total is None or total > offset:
             response_events = self.http_session.get(
                 f"{self.events_api_path}/search/jobs/{event_search_job_uuid}/events",
                 params={"limit": limit, "offset": offset},
@@ -29,9 +32,22 @@ class GetEvents(BaseGetEvents):
             response_events.raise_for_status()
 
             response_content = response_events.json()
-            if results is None:
-                results = []
+            if not response_content["items"]:
+                max_possible_results = (
+                    min(self.SEARCH_JOB_LIMIT, action_limit) if action_limit else self.SEARCH_JOB_LIMIT
+                )
+                num_results = len(results)
+                if num_results < response_content["total"] and num_results < max_possible_results:
+                    self.log(
+                        "Number of fetched results doesn't match total",
+                        level="error",
+                        num_results=num_results,
+                        total=response_content["total"],
+                        search_job=event_search_job_uuid,
+                    )
+                break
             results += response_content["items"]
+            total = min(response_content["total"], action_limit) if action_limit else response_content["total"]
 
             offset += limit
 

--- a/Sekoia.io/tests/operation_center/test_get_events.py
+++ b/Sekoia.io/tests/operation_center/test_get_events.py
@@ -142,3 +142,41 @@ def test_not_events_found(requests_mock):
 
     results: dict = action.run(arguments)
     assert results["events"] == []
+
+
+def test_not_events_found_but_total(requests_mock):
+    action = GetEvents()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+
+    arguments = {
+        "query": 'source.ip:"127.0.0.1" OR destination.ip:"127.0.0.1"',
+        "earliest_time": "-1d",
+        "latest_time": "now",
+        "fields": "event.dialect,action.outcome,action.id",
+    }
+
+    requests_mock.post(
+        "https://fake.url/api/v1/sic/conf/events/search/jobs",
+        json={"uuid": "483d36a5-8538-49c4-be19-49b669f90bf8"},
+    )
+
+    requests_mock.get(
+        "https://fake.url/api/v1/sic/conf/events/search/jobs/483d36a5-8538-49c4-be19-49b669f90bf8",
+        json={"status": 2, "uuid": "483d36a5-8538-49c4-be19-49b669f90bf8"},
+    )
+
+    requests_mock.get(
+        (
+            "https://fake.url/api/v1/sic/conf/events/search/jobs/"
+            "483d36a5-8538-49c4-be19-49b669f90bf8/events?limit=1000&offset=0"
+        ),
+        json={
+            "items": [],
+            "total": 100,
+        },
+    )
+
+    results: dict = action.run(arguments)
+    assert results["events"] == []
+    assert len(action._logs) == 1
+    assert action._logs[0]["level"] == "error"


### PR DESCRIPTION
* When the user specified a limit the `total` value must be ignored if bigger than the limit.
* Fix pagination that is not working for the last page because `offset` has already been incremented with `limit` at the end of the previous loop
* If total is bigger than 5 000 then the current code will cause multiple iterations returning nothing because a search job is limited to 5 000 results.

A log has also been added in case we exit early and the number of results doesn't match the total
