### PR TITLE
fix(Sekoia.io): Websockets

### DIFF
--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.50.2"
+    "version": "2.51"
 }


### PR DESCRIPTION
* Add reconnect option so the socket can connect again on error
* Don't sleep on error since we may lose events
* On stop properly close the socket
* On close reset the socket state so the next `run_forever` call will start from a clean state
* Add debug logs on ping and pong
  * Will allow to check if the trigger is still running properly or not
*  Remove `_must_stop` that is redundant with the `_stop_event` attribute