### PR TITLE
fix(Sekoia.io): Do not start thread if still alive

### DIFF
--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.52"
+    "version": "2.52.1"
 }

--- a/Sekoia.io/sekoiaio/triggers/base.py
+++ b/Sekoia.io/sekoiaio/triggers/base.py
@@ -71,7 +71,8 @@ class _SEKOIANotificationBaseTrigger(Trigger):
 
         self._validate_api_key(base_url, api_key)
 
-        self._message_processor.start()
+        if not self._message_processor.is_alive():
+            self._message_processor.start()
 
         setdefaulttimeout(10)  # socket timeout
         self._websocket = WebSocketApp(


### PR DESCRIPTION
Prevent error `RuntimeError: threads can only be started once` from happening