### PR TITLE
Checkpoint: handle pagination

### DIFF
--- a/Checkpoint/CHANGELOG.md
+++ b/Checkpoint/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 2023-11-29 - 1.1.5
+
+#### Fixed
+
+- Handle the pagination when listing the alerts
+- Add 1 milliseconds to the start date when requested the last alerts, in order to exclude the last collected event
+
 ### 2023-11-28 - 1.1.4
 
 #### Fixed

--- a/Checkpoint/client/http_client.py
+++ b/Checkpoint/client/http_client.py
@@ -1,5 +1,6 @@
 """Contains http client."""
 from datetime import datetime, timezone
+from urllib.parse import urljoin
 
 from aiolimiter import AsyncLimiter
 from loguru import logger
@@ -70,7 +71,7 @@ class CheckpointHttpClient(HttpClient):
         Returns:
             list[HarmonyMobileSchema]:
         """
-        url = "{0}/app/SBM/external_api/v3/alert/".format(self.base_url)
+        url = urljoin(self.base_url, "/app/SBM/external_api/v3/alert/")
         formatted_start_date = start_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         logger.info("Fetch events with limit {0} starting from: {1}", limit, formatted_start_date)
 

--- a/Checkpoint/client/http_client.py
+++ b/Checkpoint/client/http_client.py
@@ -1,4 +1,5 @@
 """Contains http client."""
+from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 from urllib.parse import urljoin
 
@@ -60,7 +61,7 @@ class CheckpointHttpClient(HttpClient):
 
     async def get_harmony_mobile_alerts(
         self, start_from: datetime = datetime.now(), limit: int = 100
-    ) -> list[HarmonyMobileSchema]:
+    ) -> AsyncGenerator[list[HarmonyMobileSchema], None, None]:
         """
         Get Harmony Mobile alerts.
 
@@ -69,43 +70,41 @@ class CheckpointHttpClient(HttpClient):
             limit: int
 
         Returns:
-            list[HarmonyMobileSchema]:
+            AsyncGenerator[list[HarmonyMobileSchema]]:
         """
-        url = urljoin(self.base_url, "/app/SBM/external_api/v3/alert/")
+        base_url = urljoin(self.base_url, "/app/SBM")
         formatted_start_date = start_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        endpoint = f"/external_api/v3/alert/?backend_last_updated__gte={formatted_start_date}&limit={limit}"
         logger.info("Fetch events with limit {0} starting from: {1}", limit, formatted_start_date)
-
-        params = {
-            "backend_last_updated__gte": formatted_start_date,
-            "limit": limit,
-        }
 
         token_refresher = await self.get_token_refresher(CheckpointServiceType.HARMONY_MOBILE)
 
-        async with token_refresher.with_access_token() as token:
-            async with self.session() as session:
-                async with session.get(
-                    url=url,
-                    headers={"Authorization": f"Bearer {token.token.token}"},
-                    params=params,
-                ) as response:
-                    response_json = await response.json()
+        while endpoint is not None:
+            async with token_refresher.with_access_token() as token:
+                async with self.session() as session:
+                    async with session.get(
+                        url=f"{base_url}{endpoint}",
+                        headers={"Authorization": f"Bearer {token.token.token}"},
+                    ) as response:
+                        response_json = await response.json()
 
-        if response_json.get("objects") is None:
-            logger.error("Failed to get events from server. Invalid response : {0}", response_json)
+            if response_json.get("objects") is None:
+                logger.error("Failed to get events from server. Invalid response : {0}", response_json)
 
-            return []
+                return
 
-        return [
-            HarmonyMobileSchema(
-                **{
-                    **data,
-                    "event_timestamp": self.parse_date(data.get("event_timestamp")),
-                    "backend_last_updated": self.parse_date(data.get("backend_last_updated")),
-                }
-            )
-            for data in response_json["objects"]
-        ]
+            yield [
+                HarmonyMobileSchema(
+                    **{
+                        **data,
+                        "event_timestamp": self.parse_date(data.get("event_timestamp")),
+                        "backend_last_updated": self.parse_date(data.get("backend_last_updated")),
+                    }
+                )
+                for data in response_json["objects"]
+            ]
+
+            endpoint = response_json.get("meta", {}).get("next")
 
     @staticmethod
     def parse_date(value: str | None) -> datetime | None:

--- a/Checkpoint/connectors/checkpoint_harmony.py
+++ b/Checkpoint/connectors/checkpoint_harmony.py
@@ -16,6 +16,8 @@ from connectors import CheckpointModule
 
 from .metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, OUTCOMING_EVENTS
 
+ONE_MILLISECOND = timedelta(milliseconds=1)
+
 
 class CheckpointHarmonyConfiguration(DefaultConnectorConfiguration):
     """The CheckpointHarmony configuration."""
@@ -86,7 +88,7 @@ class CheckpointHarmonyConnector(AsyncConnector):
         Returns:
             tuple[list[str], float]: result event ids and new latest event date in timestamp
         """
-        _last_event_date = self.last_event_date
+        _last_event_date = self.last_event_date + ONE_MILLISECOND
         list_of_events = self.get_checkpoint_client().get_harmony_mobile_alerts(_last_event_date, 100)
         events = [event async for events in list_of_events for event in events]
 

--- a/Checkpoint/connectors/checkpoint_harmony.py
+++ b/Checkpoint/connectors/checkpoint_harmony.py
@@ -87,7 +87,8 @@ class CheckpointHarmonyConnector(AsyncConnector):
             tuple[list[str], float]: result event ids and new latest event date in timestamp
         """
         _last_event_date = self.last_event_date
-        events = await self.get_checkpoint_client().get_harmony_mobile_alerts(_last_event_date, 100)
+        list_of_events = self.get_checkpoint_client().get_harmony_mobile_alerts(_last_event_date, 100)
+        events = [event async for events in list_of_events for event in events]
 
         logger.info("Fetched {0} events from source", len(events))
 

--- a/Checkpoint/manifest.json
+++ b/Checkpoint/manifest.json
@@ -35,5 +35,5 @@
     "name": "Check Point",
     "uuid": "096f4eda-68dd-11ee-8c99-0242ac120002",
     "slug": "checkpoint",
-    "version": "1.1.4"
+    "version": "1.1.5"
 }

--- a/Checkpoint/tests/client/test_http_client.py
+++ b/Checkpoint/tests/client/test_http_client.py
@@ -1,6 +1,6 @@
 """Tests related to http client."""
-from typing import Any
 from datetime import timezone
+from typing import Any
 from urllib.parse import urljoin
 
 import pytest
@@ -69,13 +69,13 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_empty(
         limit = session_faker.pyint(min_value=100, max_value=1000)
         get_events_url = urljoin(
             http_client.base_url,
-            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}"
+            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
         )
 
         events_data = {
             "meta": {
                 "limit": limit,
-                "next": session_faker.word(),
+                "next": None,
                 "previous": session_faker.word(),
                 "offset": 0,
                 "total_count": 0,
@@ -86,7 +86,8 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_empty(
         mocked.post(http_client.auth_url, status=200, payload=token_data)
         mocked.get(get_events_url, status=200, payload=events_data)
 
-        result = await http_client.get_harmony_mobile_alerts(time_events_from, limit)
+        list_of_events = http_client.get_harmony_mobile_alerts(time_events_from, limit)
+        result = [event async for events in list_of_events for event in events]
 
         assert result == events_data["objects"]
 
@@ -110,7 +111,7 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success(
         limit = session_faker.pyint(min_value=100, max_value=1000)
         get_events_url = urljoin(
             http_client.base_url,
-            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}"
+            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
         )
 
         events = [
@@ -138,7 +139,7 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success(
         events_data = {
             "meta": {
                 "limit": limit,
-                "next": session_faker.word(),
+                "next": None,
                 "previous": session_faker.word(),
                 "offset": 0,
                 "total_count": 0,
@@ -149,7 +150,8 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success(
         mocked.post(http_client.auth_url, status=200, payload=token_data)
         mocked.get(get_events_url, status=200, payload=events_data)
 
-        result = await http_client.get_harmony_mobile_alerts(time_events_from, limit)
+        list_of_events = http_client.get_harmony_mobile_alerts(time_events_from, limit)
+        result = [event async for events in list_of_events for event in events]
 
         assert len(result) == len(events)
         assert [event.dict() for event in result] == [
@@ -176,13 +178,13 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success_1(
         limit = session_faker.pyint(min_value=100, max_value=1000)
         get_events_url = urljoin(
             http_client.base_url,
-            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}"
+            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
         )
 
         events_data = {
             "meta": {
                 "limit": limit,
-                "next": session_faker.word(),
+                "next": None,
                 "previous": session_faker.word(),
                 "offset": 0,
                 "total_count": 0,
@@ -192,4 +194,79 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success_1(
         mocked.post(http_client.auth_url, status=200, payload=token_data)
         mocked.get(get_events_url, status=200, payload=events_data)
 
-        assert await http_client.get_harmony_mobile_alerts(time_events_from, limit) == []
+        list_of_events = http_client.get_harmony_mobile_alerts(time_events_from, limit)
+        result = [event async for events in list_of_events for event in events]
+
+        assert result == []
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_http_client_get_harmony_mobile_alerts_with_pagination_success(
+    session_faker: Faker, http_client: CheckpointHttpClient, http_token: tuple[CheckpointToken, dict[str, Any]]
+):
+    """
+    Test `get_harmony_mobile_alerts` method.
+
+    Args:
+        session_faker: Faker
+        http_client: CheckpointHttpClient
+        http_token: tuple[CheckpointToken, dict[str, Any]]
+    """
+    _, token_data = http_token
+    with aioresponses() as mocked:
+        mocked.post(http_client.auth_url, status=200, payload=token_data)
+
+        base_url = urljoin(http_client.base_url, "/app/SBM")
+        time_events_from = session_faker.date_time()
+        time_events_from_str = time_events_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        limit = session_faker.pyint(min_value=100, max_value=1000)
+        endpoints = [
+            f"/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
+            f"/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}&offset={limit}",
+            f"/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}&offset={limit*2}",
+        ]
+
+        events = []
+        for index, endpoint in enumerate(endpoints):
+            objects = [
+                {
+                    "id": session_faker.pyint(min_value=1, max_value=1000),
+                    "device_rooted": session_faker.pybool(),
+                    "attack_vector": session_faker.word(),
+                    "backend_last_updated": session_faker.word(),
+                    "details": session_faker.word(),
+                    "device_id": session_faker.word(),
+                    "email": session_faker.word(),
+                    "event": session_faker.word(),
+                    "event_timestamp": session_faker.word(),
+                    "mdm_uuid": session_faker.word(),
+                    "name": session_faker.word(),
+                    "number": session_faker.word(),
+                    "severity": session_faker.word(),
+                    "threat_factors": session_faker.word(),
+                    "device_model": session_faker.word(),
+                    "client_version": session_faker.word(),
+                }
+                for _ in range(session_faker.pyint(min_value=1, max_value=limit))
+            ]
+            events.extend(objects)
+
+            events_data = {
+                "meta": {
+                    "limit": limit,
+                    "next": endpoints[index + 1] if index + 1 < len(endpoints) else None,
+                    "previous": session_faker.word(),
+                    "offset": 0,
+                    "total_count": 0,
+                },
+                "objects": objects,
+            }
+            mocked.get(f"{base_url}{endpoint}", status=200, payload=events_data)
+
+        list_of_events = http_client.get_harmony_mobile_alerts(time_events_from, limit)
+        result = [event async for events in list_of_events for event in events]
+
+        assert len(result) == len(events)
+        assert [event.dict() for event in result] == [
+            {**event, "event_timestamp": None, "backend_last_updated": None} for event in events
+        ]

--- a/Checkpoint/tests/client/test_http_client.py
+++ b/Checkpoint/tests/client/test_http_client.py
@@ -1,6 +1,7 @@
 """Tests related to http client."""
 from typing import Any
 from datetime import timezone
+from urllib.parse import urljoin
 
 import pytest
 from aioresponses import aioresponses
@@ -64,11 +65,11 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_empty(
     _, token_data = http_token
     with aioresponses() as mocked:
         time_events_from = session_faker.date_time()
+        time_events_from_str = time_events_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         limit = session_faker.pyint(min_value=100, max_value=1000)
-        get_events_url = "{0}/app/SBM/external_api/v3/alert/?backend_last_updated__gte={1}&limit={2}".format(
+        get_events_url = urljoin(
             http_client.base_url,
-            time_events_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            limit,
+            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}"
         )
 
         events_data = {
@@ -105,11 +106,11 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success(
     _, token_data = http_token
     with aioresponses() as mocked:
         time_events_from = session_faker.date_time()
+        time_events_from_str = time_events_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         limit = session_faker.pyint(min_value=100, max_value=1000)
-        get_events_url = "{0}/app/SBM/external_api/v3/alert/?backend_last_updated__gte={1}&limit={2}".format(
+        get_events_url = urljoin(
             http_client.base_url,
-            time_events_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            limit,
+            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}"
         )
 
         events = [
@@ -171,11 +172,11 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success_1(
     _, token_data = http_token
     with aioresponses() as mocked:
         time_events_from = session_faker.date_time()
+        time_events_from_str = time_events_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         limit = session_faker.pyint(min_value=100, max_value=1000)
-        get_events_url = "{0}/app/SBM/external_api/v3/alert/?backend_last_updated__gte={1}&limit={2}".format(
+        get_events_url = urljoin(
             http_client.base_url,
-            time_events_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            limit,
+            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}"
         )
 
         events_data = {

--- a/Checkpoint/tests/connectors/test_checkpoint_harmony_connector.py
+++ b/Checkpoint/tests/connectors/test_checkpoint_harmony_connector.py
@@ -158,11 +158,10 @@ async def test_checkpoint_harmony_connector_get_checkpoint_harmony_events(
         base_url = checkpoint_harmony_connector.module.configuration.base_url
         auth_url = checkpoint_harmony_connector.module.configuration.authentication_url
         intake_post_url = urljoin(checkpoint_harmony_connector.configuration.intake_server, "/batch")
-
-        get_events_url = "{0}/app/SBM/external_api/v3/alert/?backend_last_updated__gte={1}&limit={2}".format(
+        half_hour_ago_str = half_hour_ago.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        get_events_url = urljoin(
             base_url,
-            half_hour_ago.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            limit,
+            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={half_hour_ago_str}&limit={limit}"
         )
 
         # all events except last one have event_timestamp < current date

--- a/Checkpoint/tests/connectors/test_checkpoint_harmony_connector.py
+++ b/Checkpoint/tests/connectors/test_checkpoint_harmony_connector.py
@@ -159,7 +159,7 @@ async def test_checkpoint_harmony_connector_get_checkpoint_harmony_events(
         auth_url = checkpoint_harmony_connector.module.configuration.authentication_url
         intake_post_url = urljoin(checkpoint_harmony_connector.configuration.intake_server, "/batch")
 
-        half_hour_ago_str = half_hour_ago.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        half_hour_ago_str = (half_hour_ago + timedelta(milliseconds=1)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         endpoints = [
             f"/external_api/v3/alert/?backend_last_updated__gte={half_hour_ago_str}&limit={limit}",
             f"/external_api/v3/alert/?backend_last_updated__gte={half_hour_ago_str}&limit={limit}&offset={limit}",


### PR DESCRIPTION
- Handle the pagination when listing the alerts
- Add 1 milliseconds to the start_date, when requesting the alerts, to exclude the last collected alert.