### PR TITLE
AWS: Connectors performance

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2023-12-01 - 1.28.1
+
+### Fixed
+
+- Only pause, temporary, the connector if no events were forwarded
+
 ## 2023-12-01 - 1.28.0
 
 ### Changed

--- a/AWS/connectors/__init__.py
+++ b/AWS/connectors/__init__.py
@@ -89,18 +89,15 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
                         )
 
                     OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(message_ids))
-
-                    log_message = "No records to forward"
-                    if len(message_ids) > 0:
-                        log_message = "Pushed {0} records".format(len(message_ids))
-
-                    self.log(message=log_message, level="info")
-
                     FORWARD_EVENTS_DURATION.labels(intake_key=self.configuration.intake_key).observe(
                         processing_end - processing_start
                     )
 
-                    time.sleep(self.configuration.frequency)
+                    if len(message_ids) > 0:
+                        self.log(message="Pushed {0} records".format(len(message_ids)), level="info")
+                    else:
+                        self.log(message="No records to forward", level="info")
+                        time.sleep(self.configuration.frequency)
 
             except Exception as e:
                 self.log_exception(e)

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,5 +29,5 @@
     "name": "AWS",
     "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
     "slug": "aws",
-    "version": "1.28.0"
+    "version": "1.28.1"
 }


### PR DESCRIPTION
Change the `time.sleep` to only wait when no events were forwarded.