### PR TITLE
AWS: change how the pause are computed

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2023-12-01 - 1.31.1
+
+### Changed
+
+- Change the way to pause the connectors
+
 ## 2024-05-28 - 1.31.0
 
 ### Changed

--- a/AWS/connectors/__init__.py
+++ b/AWS/connectors/__init__.py
@@ -69,7 +69,7 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
         """
         raise NotImplementedError("next_batch method must be implemented")
 
-    def _next_batch(self, loop):
+    def _next_batch(self, loop: asyncio.AbstractEventLoop) -> None:
         processing_start = time.time()
 
         batch_result: tuple[list[str], list[int]] = loop.run_until_complete(self.next_batch())
@@ -86,7 +86,7 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
         current_lag = 0
         if len(messages_timestamp) > 0:
             last_message_timestamp = max(messages_timestamp)
-            current_lag = processing_end - (last_message_timestamp / 1000)
+            current_lag = int(processing_end) - int(last_message_timestamp / 1000)
             EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(current_lag)
 
         if len(message_ids) > 0:

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,5 +29,5 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.31.0"
+  "version": "1.31.1"
 }

--- a/AWS/tests/connectors/test_abstract_aws_connector.py
+++ b/AWS/tests/connectors/test_abstract_aws_connector.py
@@ -1,9 +1,12 @@
 """Test abstract AWS connector."""
 
 from pathlib import Path
+from unittest.mock import patch
+import asyncio
 
 from sekoia_automation.aio.helpers.aws.client import AwsClient
 from sekoia_automation.connector import DefaultConnectorConfiguration
+import pytest
 
 from connectors import AbstractAwsConnector, AwsModule
 
@@ -19,3 +22,102 @@ def test_abstract_aws_connector(aws_module: AwsModule, symphony_storage: Path, i
     connector.configuration = DefaultConnectorConfiguration(intake_key=intake_key)
 
     assert isinstance(connector.aws_client, AwsClient)
+
+
+class FakeAWSConnector(AbstractAwsConnector):
+    def __init__(self, module, data_path, messages_ids: list, messages_timestamp: list):
+        super().__init__(module=module, data_path=data_path)
+        self.messages_ids = messages_ids
+        self.messages_timestamp = messages_timestamp
+
+    async def next_batch(self) -> tuple[list[str], list[int]]:
+        """
+        Get next batch of messages.
+
+        Contains main logic of the connector.
+
+        Returns:
+            tuple[list[str], int]:
+        """
+        return ( self.messages_ids, self.messages_timestamp)
+
+
+def test_connector_run_should_pause(aws_module: AwsModule, symphony_storage: Path, intake_key: str):
+    """
+    Test abstract AWS connector.
+
+    Args:
+        aws_module: AwsModule
+    """
+    connector = FakeAWSConnector(
+        module=aws_module,
+        data_path=symphony_storage,
+        messages_ids=[],
+        messages_timestamp=[]
+    )
+    connector.configuration = DefaultConnectorConfiguration(intake_key=intake_key)
+    event_loop = asyncio.get_event_loop()
+
+    with patch("connectors.time") as mock_time, patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]):
+        batch_duration = 16  # the batch lasts 16 seconds
+        start_time = 1701862800.0
+        end_time = start_time + batch_duration
+        mock_time.time.side_effect = [start_time, end_time]
+
+        connector._next_batch(event_loop)
+
+        mock_time.sleep.assert_called_once_with(44)
+
+
+def test_connector_run_should_not_pause(aws_module: AwsModule, symphony_storage: Path, intake_key: str):
+    """
+    Test abstract AWS connector.
+
+    Args:
+        aws_module: AwsModule
+    """
+    connector = FakeAWSConnector(
+        module=aws_module,
+        data_path=symphony_storage,
+        messages_ids=["f5ca74e3-13ea-4a9b-875d-6c79c33e9aaa", "e0381838-84da-47e2-9a57-a560d72ed0eb", "b718257b-1cec-4905-bf4a-cee2e9f27bcf"],
+        messages_timestamp=[1701819000, 1701862822, 1701845760]
+    )
+    connector.configuration = DefaultConnectorConfiguration(intake_key=intake_key)
+    event_loop = asyncio.get_event_loop()
+
+    with patch("connectors.time") as mock_time, patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]):
+        batch_duration = 73  # the batch lasts 73 seconds
+        start_time = 1701862800.0
+        end_time = start_time + batch_duration
+        mock_time.time.side_effect = [start_time, end_time]
+
+        connector._next_batch(event_loop)
+
+        assert mock_time.sleep.call_count == 0
+
+
+def test_connector_run_with_lag_should_not_pause(aws_module: AwsModule, symphony_storage: Path, intake_key: str):
+    """
+    Test abstract AWS connector.
+
+    Args:
+        aws_module: AwsModule
+    """
+    connector = FakeAWSConnector(
+        module=aws_module,
+        data_path=symphony_storage,
+        messages_ids=["f5ca74e3-13ea-4a9b-875d-6c79c33e9aaa", "e0381838-84da-47e2-9a57-a560d72ed0eb", "b718257b-1cec-4905-bf4a-cee2e9f27bcf"],
+        messages_timestamp=[1701819000, 1701862822, 1701845760]
+    )
+    connector.configuration = DefaultConnectorConfiguration(intake_key=intake_key)
+    event_loop = asyncio.get_event_loop()
+
+    with patch("connectors.time") as mock_time, patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]):
+        batch_duration = 16  # the batch lasts 16 seconds
+        start_time = 1701845760.0
+        end_time = start_time + batch_duration
+        mock_time.time.side_effect = [start_time, end_time]
+
+        connector._next_batch(event_loop)
+
+        assert mock_time.sleep.call_count == 0

--- a/AWS/tests/connectors/test_abstract_aws_connector.py
+++ b/AWS/tests/connectors/test_abstract_aws_connector.py
@@ -39,7 +39,7 @@ class FakeAWSConnector(AbstractAwsConnector):
         Returns:
             tuple[list[str], int]:
         """
-        return ( self.messages_ids, self.messages_timestamp)
+        return (self.messages_ids, self.messages_timestamp)
 
 
 def test_connector_run_should_pause(aws_module: AwsModule, symphony_storage: Path, intake_key: str):
@@ -49,16 +49,14 @@ def test_connector_run_should_pause(aws_module: AwsModule, symphony_storage: Pat
     Args:
         aws_module: AwsModule
     """
-    connector = FakeAWSConnector(
-        module=aws_module,
-        data_path=symphony_storage,
-        messages_ids=[],
-        messages_timestamp=[]
-    )
+    connector = FakeAWSConnector(module=aws_module, data_path=symphony_storage, messages_ids=[], messages_timestamp=[])
     connector.configuration = DefaultConnectorConfiguration(intake_key=intake_key)
     event_loop = asyncio.get_event_loop()
 
-    with patch("connectors.time") as mock_time, patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]):
+    with (
+        patch("connectors.time") as mock_time,
+        patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]),
+    ):
         batch_duration = 16  # the batch lasts 16 seconds
         start_time = 1701862800.0
         end_time = start_time + batch_duration
@@ -79,13 +77,20 @@ def test_connector_run_should_not_pause(aws_module: AwsModule, symphony_storage:
     connector = FakeAWSConnector(
         module=aws_module,
         data_path=symphony_storage,
-        messages_ids=["f5ca74e3-13ea-4a9b-875d-6c79c33e9aaa", "e0381838-84da-47e2-9a57-a560d72ed0eb", "b718257b-1cec-4905-bf4a-cee2e9f27bcf"],
-        messages_timestamp=[1701819000, 1701862822, 1701845760]
+        messages_ids=[
+            "f5ca74e3-13ea-4a9b-875d-6c79c33e9aaa",
+            "e0381838-84da-47e2-9a57-a560d72ed0eb",
+            "b718257b-1cec-4905-bf4a-cee2e9f27bcf",
+        ],
+        messages_timestamp=[1701819000, 1701862822, 1701845760],
     )
     connector.configuration = DefaultConnectorConfiguration(intake_key=intake_key)
     event_loop = asyncio.get_event_loop()
 
-    with patch("connectors.time") as mock_time, patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]):
+    with (
+        patch("connectors.time") as mock_time,
+        patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]),
+    ):
         batch_duration = 73  # the batch lasts 73 seconds
         start_time = 1701862800.0
         end_time = start_time + batch_duration
@@ -106,13 +111,20 @@ def test_connector_run_with_lag_should_not_pause(aws_module: AwsModule, symphony
     connector = FakeAWSConnector(
         module=aws_module,
         data_path=symphony_storage,
-        messages_ids=["f5ca74e3-13ea-4a9b-875d-6c79c33e9aaa", "e0381838-84da-47e2-9a57-a560d72ed0eb", "b718257b-1cec-4905-bf4a-cee2e9f27bcf"],
-        messages_timestamp=[1701819000, 1701862822, 1701845760]
+        messages_ids=[
+            "f5ca74e3-13ea-4a9b-875d-6c79c33e9aaa",
+            "e0381838-84da-47e2-9a57-a560d72ed0eb",
+            "b718257b-1cec-4905-bf4a-cee2e9f27bcf",
+        ],
+        messages_timestamp=[1701819000, 1701862822, 1701845760],
     )
     connector.configuration = DefaultConnectorConfiguration(intake_key=intake_key)
     event_loop = asyncio.get_event_loop()
 
-    with patch("connectors.time") as mock_time, patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]):
+    with (
+        patch("connectors.time") as mock_time,
+        patch("connectors.AbstractAwsConnector.running", side_effect=[True, True, False]),
+    ):
         batch_duration = 16  # the batch lasts 16 seconds
         start_time = 1701845760.0
         end_time = start_time + batch_duration


### PR DESCRIPTION
Change the way how and when the connector can go to pause. I propose to use the lag of the collection of events to know if the connector can take a break.