### PR TITLE
Get the real userAccountControl

### DIFF
--- a/MicrosoftActiveDirectory/microsoft_ad/base.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/base.py
@@ -40,14 +40,16 @@ class MicrosoftADAction(Action):
             f"(|(samaccountname={username})(userPrincipalName={username})(mail={username})(givenName={username}))"
         )
 
-        self.client.search(search_base=basedn, search_filter=SEARCHFILTER, attributes=["cn", "mail"])
-        users_dn = []
+        self.client.search(
+            search_base=basedn, search_filter=SEARCHFILTER, attributes=["cn", "mail", "userAccountControl"]
+        )
+        users_query = []
         for entry in self.client.response:
             if entry.get("dn") and entry.get("attributes"):
                 if entry.get("attributes").get("cn"):
-                    users_dn.append(entry.get("dn"))
+                    users_query.append([entry.get("dn"), entry.get("attributes").get("userAccountControl")])
 
-        return users_dn
+        return users_query
 
 
 class UserAccountArguments(BaseModel):

--- a/MicrosoftActiveDirectory/microsoft_ad/user.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/user.py
@@ -6,16 +6,20 @@ class ResetUserPasswordAction(MicrosoftADAction):
     description = "Reset password with an rdp connection with an admin account"
 
     def run(self, arguments: ResetPassUserArguments):
-        users_dn = self.search_userdn_query(arguments.username, arguments.basedn)
+        user_query = self.search_userdn_query(arguments.username, arguments.basedn)
 
-        if len(users_dn) == 0:
+        if len(user_query) == 0:
             raise Exception(f"There's no one with this name !!")
 
-        if len(users_dn) > 1:
-            raise Exception(f"There's {len(users_dn)} persons with the same name !!")
+        if len(user_query) > 1:
+            raise Exception(f"There's {len(user_query)} persons with the same name !!")
 
         try:
-            self.client.extend.microsoft.modify_password(users_dn[0], arguments.new_password)
+            user_dn = user_query[0][0]
+            self.client.extend.microsoft.modify_password(user_dn, arguments.new_password)
+
+            if self.client.result.get("description") != "success":
+                raise Exception(f"Reset password action failed : {self.client.result.get('description')}")
         except:
             self.log(f"Failed to reset {arguments.username} password account!!!")
 
@@ -25,16 +29,22 @@ class EnableUserAction(MicrosoftADAction):
     description = "Enable an Azure Active Directory user"
 
     def run(self, arguments: UserAccountArguments):
-        users_dn = self.search_userdn_query(arguments.username, arguments.basedn)
+        user_query = self.search_userdn_query(arguments.username, arguments.basedn)
 
-        if len(users_dn) == 0:
+        if len(user_query) == 0:
             raise Exception(f"There's no one with this name !!")
 
-        if len(users_dn) > 1:
-            raise Exception(f"There's {len(users_dn)} persons with the same name !!")
+        if len(user_query) > 1:
+            raise Exception(f"There's {len(user_query)} persons with the same name !!")
 
         try:
-            self.client.modify(users_dn[0], {"userAccountControl": [("MODIFY_REPLACE", (512))]}, None)
+            userADAccountControlFlag = 2
+            user_dn = user_query[0][0]
+            userAccountControl = user_query[0][1] & ~userADAccountControlFlag
+            self.client.modify(user_dn, {"userAccountControl": [("MODIFY_REPLACE", (userAccountControl))]}, None)
+
+            if self.client.result.get("description") != "success":
+                raise Exception(f"Enable action failed : {self.client.result.get('description')}")
         except:
             self.log(f"Failed to Enable {arguments.username} account!!!")
 
@@ -44,15 +54,22 @@ class DisableUserAction(MicrosoftADAction):
     description = "Disable an Azure Active Directory user"
 
     def run(self, arguments: UserAccountArguments):
-        users_dn = self.search_userdn_query(arguments.username, arguments.basedn)
+        user_query = self.search_userdn_query(arguments.username, arguments.basedn)
 
-        if len(users_dn) == 0:
+        if len(user_query) == 0:
             raise Exception(f"There's no one with this name !!")
 
-        if len(users_dn) > 1:
-            raise Exception(f"There's {len(users_dn)} persons with the same name !!")
+        if len(user_query) > 1:
+            raise Exception(f"There's {len(user_query)} persons with the same name !!")
 
         try:
-            self.client.modify(users_dn[0], {"userAccountControl": [("MODIFY_REPLACE", (514))]}, None)
+            userADAccountControlFlag = 2
+            user_dn = user_query[0][0]
+            userAccountControl = user_query[0][1] | userADAccountControlFlag
+            self.client.modify(user_dn, {"userAccountControl": [("MODIFY_REPLACE", (userAccountControl))]}, None)
+
+            if self.client.result.get("description") != "success":
+                raise Exception(f"Disable action failed : {self.client.result.get('description')}")
+
         except:
             self.log(f"Failed to Disable {arguments.username} account!!!")

--- a/MicrosoftActiveDirectory/tests/test_user.py
+++ b/MicrosoftActiveDirectory/tests/test_user.py
@@ -24,14 +24,14 @@ def configured_action(action: MicrosoftADAction):
 
 @pytest.fixture
 def one_user_dn():
-    return ["CN=integration_test,CN=Users,DC=lab,DC=test,DC=com"]
+    return [["CN=integration_test,CN=Users,DC=lab,DC=test,DC=com", 512]]
 
 
 @pytest.fixture
 def two_users_dn():
     return [
-        "CN=integration_test,CN=Users,DC=lab,DC=test,DC=com",
-        "CN=integration test1,CN=Users,DC=lab,DC=test,DC=com",
+        ["CN=integration_test,CN=Users,DC=lab,DC=test,DC=com", 512],
+        ["CN=integration test1,CN=Users,DC=lab,DC=test,DC=com", 514],
     ]
 
 


### PR DESCRIPTION
- Improve the way to disable and enable account by getting the real userAccountControl. (We used just 514 and 512 numbers)
- Add an Exception if there's no permission to do some actions