### PR TITLE
Proofpoint: change the way to handle user provided datetime

### DIFF
--- a/Proofpoint/CHANGELOG.md
+++ b/Proofpoint/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2023-12-14 - 1.14.1
+
+### Fixed
+
+- Fix the way to handle user-provided datetime
+
 ## 2023-11-22 - 1.14
 
 ### Changed

--- a/Proofpoint/manifest.json
+++ b/Proofpoint/manifest.json
@@ -8,5 +8,5 @@
     "name": "Proofpoint",
     "uuid": "eaa52274-2664-47fa-978e-af87a4222cba",
     "slug": "proofpoint",
-    "version": "1.14"
+    "version": "1.14.1"
 }

--- a/Proofpoint/proofpoint_modules/helpers.py
+++ b/Proofpoint/proofpoint_modules/helpers.py
@@ -47,12 +47,12 @@ def normalize_since_time(initial_since_time: str | None) -> datetime:
     """
     now = datetime.now(timezone.utc)
 
-    # if the initial since time is undefined, return now
-    if initial_since_time is None:
-        return now
-
     # parse the date
     date = parse_user_date(initial_since_time)
+
+    # if the initial since time is undefined, return now
+    if date is None:
+        return now
 
     # check if the date is older than the 30 days ago
     thirsty_days_ago = now - timedelta(days=30)

--- a/Proofpoint/proofpoint_modules/helpers.py
+++ b/Proofpoint/proofpoint_modules/helpers.py
@@ -37,7 +37,7 @@ def normalize_since_time(initial_since_time: str | None) -> datetime:
         return now
 
     # parse the date
-    date = parse(initial_since_time)
+    date = parse_user_date(initial_since_time)
 
     # check if the date is older than the 30 days ago
     thirsty_days_ago = now - timedelta(days=30)

--- a/Proofpoint/proofpoint_modules/helpers.py
+++ b/Proofpoint/proofpoint_modules/helpers.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
 
 import orjson
 from dateutil.parser import parse
@@ -9,6 +9,24 @@ RFC3339_STRICT_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 def format_datetime(date: datetime) -> str:
     return date.astimezone(timezone.utc).strftime(RFC3339_STRICT_FORMAT)
+
+
+def parse_user_date(user_date: str | None, default_tzinfo: tzinfo = timezone.utc) -> datetime | None:
+    """
+    Parse the date provided by the user and return an offset-aware datetime
+
+    :param str or None user_date: The date provided by the user
+    :param tzinfo default_tzinfo: The default timezone to apply for offset-naive date
+    """
+    if user_date is None or len(user_date) == 0:
+        return None
+
+    parsed_date = parse(user_date)
+
+    if parsed_date.tzinfo is None:
+        parsed_date = parsed_date.replace(tzinfo=default_tzinfo)
+
+    return parsed_date
 
 
 def normalize_since_time(initial_since_time: str | None) -> datetime:

--- a/Proofpoint/proofpoint_modules/helpers.py
+++ b/Proofpoint/proofpoint_modules/helpers.py
@@ -8,6 +8,12 @@ RFC3339_STRICT_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 def format_datetime(date: datetime) -> str:
+    """
+    Format the date according to the RFC3339 representation
+
+    :rtype: str
+    :return: The RFC3339 representation of the datetime
+    """
     return date.astimezone(timezone.utc).strftime(RFC3339_STRICT_FORMAT)
 
 
@@ -17,6 +23,8 @@ def parse_user_date(user_date: str | None, default_tzinfo: tzinfo = timezone.utc
 
     :param str or None user_date: The date provided by the user
     :param tzinfo default_tzinfo: The default timezone to apply for offset-naive date
+    :rtype: datetime or None
+    :return: None for null or empty date. An offset-aware datetime, otherwise
     """
     if user_date is None or len(user_date) == 0:
         return None
@@ -30,6 +38,13 @@ def parse_user_date(user_date: str | None, default_tzinfo: tzinfo = timezone.utc
 
 
 def normalize_since_time(initial_since_time: str | None) -> datetime:
+    """
+    Parse and normalize the since_time datetime. This datetime cannot be older than 30 days from now.
+
+    :param str or None initial_since_time: The since_time datetime
+    :rtype: datetime
+    :return: The normalized datetime
+    """
     now = datetime.now(timezone.utc)
 
     # if the initial since time is undefined, return now

--- a/Proofpoint/tests/test_helpers.py
+++ b/Proofpoint/tests/test_helpers.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
-from proofpoint_modules.helpers import format_datetime, normalize_since_time
+from proofpoint_modules.helpers import format_datetime, normalize_since_time, parse_user_date
 
 
 def test_format_datetime():
@@ -12,3 +12,13 @@ def test_normalize_since_time():
     assert normalize_since_time(None) >= now - timedelta(minutes=1)
     assert normalize_since_time("2050-09-01T13:45:23+01:00") == datetime(2050, 9, 1, 12, 45, 23, tzinfo=timezone.utc)
     assert normalize_since_time("2021-09-01T13:45:23+01:00") > now - timedelta(days=30)
+
+
+def test_parse_user_date():
+    assert parse_user_date("2050-09-01T13:45:23+01:00") == datetime(
+        2050, 9, 1, 13, 45, 23, tzinfo=timezone(timedelta(hours=1))
+    )
+    assert parse_user_date("2050-09-01T12:45:23+00:00") == datetime(2050, 9, 1, 12, 45, 23, tzinfo=timezone.utc)
+    assert parse_user_date("2050-09-01") == datetime(2050, 9, 1, tzinfo=timezone.utc)
+    assert parse_user_date("") == None
+    assert parse_user_date(None) == None

--- a/Proofpoint/tests/test_helpers.py
+++ b/Proofpoint/tests/test_helpers.py
@@ -12,6 +12,7 @@ def test_normalize_since_time():
     assert normalize_since_time(None) >= now - timedelta(minutes=1)
     assert normalize_since_time("2050-09-01T13:45:23+01:00") == datetime(2050, 9, 1, 12, 45, 23, tzinfo=timezone.utc)
     assert normalize_since_time("2021-09-01T13:45:23+01:00") > now - timedelta(days=30)
+    assert normalize_since_time("2021-09-01") > now - timedelta(days=30)
 
 
 def test_parse_user_date():


### PR DESCRIPTION
Consider that user can provide naive-offset datetime as input