### PR TITLE
fix: Rely on posixpath instead of urllib.parse to join urls

### DIFF
--- a/Checkpoint/client/http_client.py
+++ b/Checkpoint/client/http_client.py
@@ -1,7 +1,7 @@
 """Contains http client."""
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from aiolimiter import AsyncLimiter
 from loguru import logger
@@ -72,7 +72,7 @@ class CheckpointHttpClient(HttpClient):
         Returns:
             AsyncGenerator[list[HarmonyMobileSchema]]:
         """
-        base_url = urljoin(self.base_url, "/app/SBM")
+        base_url = urljoin(self.base_url, "app/SBM")
         formatted_start_date = start_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         endpoint = f"/external_api/v3/alert/?backend_last_updated__gte={formatted_start_date}&limit={limit}"
         logger.info("Fetch events with limit {0} starting from: {1}", limit, formatted_start_date)

--- a/Checkpoint/manifest.json
+++ b/Checkpoint/manifest.json
@@ -35,5 +35,5 @@
     "name": "Check Point",
     "uuid": "096f4eda-68dd-11ee-8c99-0242ac120002",
     "slug": "checkpoint",
-    "version": "1.1.7"
+    "version": "1.1.8"
 }

--- a/Checkpoint/tests/client/test_http_client.py
+++ b/Checkpoint/tests/client/test_http_client.py
@@ -1,7 +1,7 @@
 """Tests related to http client."""
 from datetime import timezone
 from typing import Any
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import pytest
 from aioresponses import aioresponses
@@ -69,7 +69,7 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_empty(
         limit = session_faker.pyint(min_value=100, max_value=1000)
         get_events_url = urljoin(
             http_client.base_url,
-            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
+            f"app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
         )
 
         events_data = {
@@ -111,7 +111,7 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success(
         limit = session_faker.pyint(min_value=100, max_value=1000)
         get_events_url = urljoin(
             http_client.base_url,
-            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
+            f"app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
         )
 
         events = [
@@ -178,7 +178,7 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_success_1(
         limit = session_faker.pyint(min_value=100, max_value=1000)
         get_events_url = urljoin(
             http_client.base_url,
-            f"/app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
+            f"app/SBM/external_api/v3/alert/?backend_last_updated__gte={time_events_from_str}&limit={limit}",
         )
 
         events_data = {
@@ -216,7 +216,7 @@ async def test_checkpoint_http_client_get_harmony_mobile_alerts_with_pagination_
     with aioresponses() as mocked:
         mocked.post(http_client.auth_url, status=200, payload=token_data)
 
-        base_url = urljoin(http_client.base_url, "/app/SBM")
+        base_url = urljoin(http_client.base_url, "app/SBM")
         time_events_from = session_faker.date_time()
         time_events_from_str = time_events_from.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         limit = session_faker.pyint(min_value=100, max_value=1000)

--- a/Checkpoint/tests/connectors/test_checkpoint_harmony_mobile_connector.py
+++ b/Checkpoint/tests/connectors/test_checkpoint_harmony_mobile_connector.py
@@ -2,7 +2,7 @@
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import pytest
 from aioresponses import aioresponses
@@ -155,9 +155,9 @@ async def test_checkpoint_harmony_connector_get_checkpoint_harmony_events(
         # Right now it is default value in limit count when we get events
         limit = 100
 
-        base_url = urljoin(checkpoint_harmony_connector.module.configuration.base_url, "/app/SBM")
+        base_url = urljoin(checkpoint_harmony_connector.module.configuration.base_url, "app/SBM")
         auth_url = checkpoint_harmony_connector.module.configuration.authentication_url
-        intake_post_url = urljoin(checkpoint_harmony_connector.configuration.intake_server, "/batch")
+        intake_post_url = urljoin(checkpoint_harmony_connector.configuration.intake_server, "batch")
 
         half_hour_ago_str = (half_hour_ago + timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         endpoints = [

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 from typing import Any
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests.auth import AuthBase, HTTPBasicAuth
@@ -38,7 +38,7 @@ class ApiClient(requests.Session):
             self.headers.update(default_headers)
 
     def get_url(self, endpoint: str) -> str:
-        return urljoin(self._base_url, endpoint)
+        return urljoin(self._base_url, endpoint.lstrip("/"))
 
     def request_endpoint(self, method: str, endpoint: str, **kwargs) -> Generator[Any, None, None]:
         """

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/auth.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/auth.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests.auth import AuthBase
@@ -31,7 +31,7 @@ class CrowdStrikeFalconApiAuthentication(AuthBase):
         default_headers: dict[str, str] | None = None,
         ratelimit_per_second: int = 10,
     ):
-        self.__authorization_url = urljoin(base_url, "/oauth2/token")
+        self.__authorization_url = urljoin(base_url, "oauth2/token")
         self.__client_id = client_id
         self.__client_secret = client_secret
         self.__api_credentials: CrowdStrikeFalconApiCredentials | None = None

--- a/CrowdStrikeFalcon/crowdstrike_falcon/custom_iocs.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/custom_iocs.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from typing import Dict, List
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from crowdstrike_falcon.action import CrowdstrikeAction
 from crowdstrike_falcon.helpers import stix_to_indicators

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
     "name": "CrowdStrike Falcon",
     "slug": "crowdstrike-falcon",
     "description": "Integrates with CrowdStrike Falcon EDR",
-    "version": "1.15.2",
+    "version": "1.15.3",
     "configuration": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {

--- a/Cybereason/cybereason_modules/client/auth.py
+++ b/Cybereason/cybereason_modules/client/auth.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
@@ -21,7 +21,7 @@ class CybereasonApiAuthentication(AuthBase):
     """
 
     def __init__(self, base_url: str, username: str, password: str):
-        self.__authorization_url = urljoin(base_url, "/login.html")
+        self.__authorization_url = urljoin(base_url, "login.html")
         self.__username = username
         self.__password = password
         self.__api_credentials: CybereasonApiCredentials | None = None

--- a/Cybereason/cybereason_modules/connector_pull_events.py
+++ b/Cybereason/cybereason_modules/connector_pull_events.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 from functools import cached_property
 from threading import Event
 from typing import Any
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import orjson
 import requests

--- a/Cybereason/cybereason_modules/connector_pull_events_new.py
+++ b/Cybereason/cybereason_modules/connector_pull_events_new.py
@@ -1,5 +1,5 @@
 from typing import Any
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 

--- a/Cybereason/manifest.json
+++ b/Cybereason/manifest.json
@@ -32,5 +32,5 @@
     "name": "Cybereason",
     "uuid": "b96361fb-a01b-4ae7-8927-9622b9ea0acf",
     "slug": "cybereason",
-    "version": "1.11"
+    "version": "1.11.1"
 }

--- a/Darktrace/darktrace_modules/threat_visualizer_log_trigger.py
+++ b/Darktrace/darktrace_modules/threat_visualizer_log_trigger.py
@@ -2,7 +2,7 @@ import time
 import traceback
 from functools import cached_property
 from threading import Event, Thread
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import orjson
 import requests

--- a/Darktrace/manifest.json
+++ b/Darktrace/manifest.json
@@ -30,5 +30,5 @@
     "name": "Darktrace",
     "uuid": "0637f7c2-d68b-49cc-a1fc-ab7d0836e7ee",
     "slug": "darktrace",
-    "version": "1.5"
+    "version": "1.5.1"
 }

--- a/Github/github_modules/audit_log_trigger.py
+++ b/Github/github_modules/audit_log_trigger.py
@@ -5,7 +5,7 @@ import traceback
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, AsyncGenerator, Optional
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import orjson
 from aiohttp import ClientSession
@@ -158,7 +158,7 @@ class AuditLogConnector(Connector):
             list[str]:
         """
         self._last_events_time = datetime.utcnow()
-        batch_api = urljoin(self.configuration.intake_server, "/batch")
+        batch_api = urljoin(self.configuration.intake_server, "batch")
 
         logger.info("Pushing total: {count} events to intakes", count=len(events))
 

--- a/Github/manifest.json
+++ b/Github/manifest.json
@@ -33,5 +33,5 @@
     "name": "Github",
     "uuid": "7a951812-28a2-445a-a257-f26deae34d44",
     "slug": "github",
-    "version": "1.7"
+    "version": "1.7.1"
 }

--- a/Github/tests/test_audit_log_trigger.py
+++ b/Github/tests/test_audit_log_trigger.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 from unittest.mock import MagicMock
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import pytest
 from aioresponses import aioresponses
@@ -140,7 +140,7 @@ async def test_next_batch_with_api_key(connector_with_api_key, github_response, 
         )
 
         mocked_responses.post(
-            urljoin(connector_with_api_key.configuration.intake_server, "/batch"),
+            urljoin(connector_with_api_key.configuration.intake_server, "batch"),
             status=200,
             payload=intake_response,
         )
@@ -182,7 +182,7 @@ async def test_next_batch_with_pem_file(connector_with_pem_file, github_response
         )
 
         mocked_responses.post(
-            urljoin(connector_with_pem_file.configuration.intake_server, "/batch"),
+            urljoin(connector_with_pem_file.configuration.intake_server, "batch"),
             status=200,
             payload=intake_response,
         )

--- a/IKnowWhatYouDownload/iknowwhatyoudownload/action_iknow_iphistory.py
+++ b/IKnowWhatYouDownload/iknowwhatyoudownload/action_iknow_iphistory.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/IKnowWhatYouDownload/iknowwhatyoudownload/action_iknow_iplist.py
+++ b/IKnowWhatYouDownload/iknowwhatyoudownload/action_iknow_iplist.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/IKnowWhatYouDownload/manifest.json
+++ b/IKnowWhatYouDownload/manifest.json
@@ -25,5 +25,5 @@
     "name": "IKnowWhatYouDownload",
     "uuid": "3c334ccd-91be-49d5-9267-915db6ab588e",
     "slug": "iknowwhatyoudownload",
-    "version": "1.23"
+    "version": "1.23.1"
 }

--- a/Imperva/imperva/fetch_logs.py
+++ b/Imperva/imperva/fetch_logs.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import cached_property
 from typing import Any
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 import urllib3
@@ -299,7 +299,7 @@ class LogsDownloader(Trigger):
         self._error_count = 0
         self._last_events_time = datetime.utcnow()
         intake_host = os.environ.get("SEKOIAIO_INTAKE_HOST", "https://intake.sekoia.io")
-        batch_api = urljoin(intake_host, "/batch")
+        batch_api = urljoin(intake_host, "batch")
 
         # Collect event_ids
         event_ids: list = []

--- a/Imperva/manifest.json
+++ b/Imperva/manifest.json
@@ -44,5 +44,5 @@
     "name": "Imperva",
     "uuid": "ee0e5c81-5410-48d4-b155-135679c5ebb8",
     "slug": "imperva",
-    "version": "1.18"
+    "version": "1.18.1"
 }

--- a/Jumpcloud/jumpcloud_modules/jumpcloud_pull_events.py
+++ b/Jumpcloud/jumpcloud_modules/jumpcloud_pull_events.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from typing import Any
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import orjson
 import requests
@@ -109,7 +109,7 @@ failed with status {response.status_code} - {response.reason}"
 
         # get the first page of events
         headers = {"Accept": "application/json", "Content-type": "application/json"}
-        url = urljoin(self.module.configuration.base_url, "/insights/directory/v1/events")
+        url = urljoin(self.module.configuration.base_url, "insights/directory/v1/events")
         response = self.client.post(url, json=params, headers=headers)
 
         while self.running:

--- a/Jumpcloud/manifest.json
+++ b/Jumpcloud/manifest.json
@@ -26,5 +26,5 @@
     "name": "Jumpcloud Directory Insights",
     "uuid": "fb8568bd-8b80-4c84-bde4-2d24275ce34f",
     "slug": "jumpcloud-directory-insights",
-    "version": "1.6"
+    "version": "1.6.1"
 }

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,5 +8,5 @@
     "name": "Microsoft Office365",
     "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
     "slug": "office365",
-    "version": "2.13"
+    "version": "2.13.1"
 }

--- a/Office365/office365/message_trace/trigger_office365_messagetrace_oauth.py
+++ b/Office365/office365/message_trace/trigger_office365_messagetrace_oauth.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import msal
 import requests
@@ -35,7 +35,7 @@ class Office365MessageTraceTrigger(Office365MessageTraceBaseTrigger):
     def _get_access_token(self) -> str | None:  # pragma: no cover
         client_id: str = self.configuration.client_id
         client_secret: str = self.configuration.client_secret
-        authority = urljoin(self.base_url, self.configuration.tenant_id)
+        authority = urljoin(self.base_url, self.configuration.tenant_id.lstrip("/"))
 
         app = msal.ConfidentialClientApplication(
             client_id,

--- a/Okta/manifest.json
+++ b/Okta/manifest.json
@@ -26,5 +26,5 @@
     "name": "Okta",
     "uuid": "4ef895d1-3f21-4678-8d0a-5c39c37210fe",
     "slug": "okta",
-    "version": "2.6"
+    "version": "2.6.1"
 }

--- a/Okta/okta_modules/system_log_trigger.py
+++ b/Okta/okta_modules/system_log_trigger.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from threading import Event
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import orjson
 import requests
@@ -111,7 +111,7 @@ class SystemLogConnector(Connector):
 
         # get the first page of events
         headers = {"Accept": "application/json"}
-        url = urljoin(self.module.configuration.base_url, "/api/v1/logs")
+        url = urljoin(self.module.configuration.base_url, "api/v1/logs")
         response = self.client.get(url, params=params, headers=headers)
 
         while not self._stop_event.is_set():

--- a/Onyphe/manifest.json
+++ b/Onyphe/manifest.json
@@ -18,5 +18,5 @@
     "name": "Onyphe",
     "uuid": "3d20c308-bc7f-492f-99b0-211614a58116",
     "slug": "onyphe",
-    "version": "1.22"
+    "version": "1.22.1"
 }

--- a/Onyphe/onyphe/action_onyphe_ctl.py
+++ b/Onyphe/onyphe/action_onyphe_ctl.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_datascan.py
+++ b/Onyphe/onyphe/action_onyphe_datascan.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_forward.py
+++ b/Onyphe/onyphe/action_onyphe_forward.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_geoloc.py
+++ b/Onyphe/onyphe/action_onyphe_geoloc.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/Onyphe/onyphe/action_onyphe_inetnum.py
+++ b/Onyphe/onyphe/action_onyphe_inetnum.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_ip.py
+++ b/Onyphe/onyphe/action_onyphe_ip.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_md5.py
+++ b/Onyphe/onyphe/action_onyphe_md5.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_onionscan.py
+++ b/Onyphe/onyphe/action_onyphe_onionscan.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_pastries.py
+++ b/Onyphe/onyphe/action_onyphe_pastries.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_reverse.py
+++ b/Onyphe/onyphe/action_onyphe_reverse.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_sniffer.py
+++ b/Onyphe/onyphe/action_onyphe_sniffer.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_synscan.py
+++ b/Onyphe/onyphe/action_onyphe_synscan.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Onyphe/onyphe/action_onyphe_threatlist.py
+++ b/Onyphe/onyphe/action_onyphe_threatlist.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.56.1"
+    "version": "2.56.2"
 }

--- a/Sekoia.io/sekoiaio/operation_center/base_get_event.py
+++ b/Sekoia.io/sekoiaio/operation_center/base_get_event.py
@@ -1,5 +1,5 @@
 import time
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Session
@@ -19,7 +19,7 @@ class BaseGetEvents(Action):
         super().__init__(*args, **kwargs)
 
     def configure_http_session(self):
-        self.events_api_path = urljoin(self.module.configuration["base_url"], "/api/v1/sic/conf/events")
+        self.events_api_path = urljoin(self.module.configuration["base_url"], "api/v1/sic/conf/events")
 
         # Configure http with retry strategy
         retry_strategy = Retry(

--- a/Sekoia.io/sekoiaio/operation_center/get_aggregation_query.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_aggregation_query.py
@@ -1,5 +1,5 @@
 import json
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
 from websocket._core import create_connection

--- a/Sekoia.io/sekoiaio/operation_center/push_event_to_intake.py
+++ b/Sekoia.io/sekoiaio/operation_center/push_event_to_intake.py
@@ -1,5 +1,5 @@
 import json
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from sekoia_automation.action import Action
@@ -39,7 +39,7 @@ class PushEventToIntake(Action):
 
         # pushing the events
         intake_host = arguments.get("intake_server", "https://intake.sekoia.io")
-        batch_api = urljoin(intake_host, "/batch")
+        batch_api = urljoin(intake_host, "batch")
         content = {"intake_key": arguments["intake_key"], "jsons": events}
         res = requests.post(batch_api, json=content, headers={"User-Agent": user_agent()})
 

--- a/Sekoia.io/sekoiaio/triggers/intelligence.py
+++ b/Sekoia.io/sekoiaio/triggers/intelligence.py
@@ -1,7 +1,7 @@
 import signal
 import time
 from threading import Event
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from sekoia_automation.storage import PersistentJSON, write

--- a/VadeSecure/manifest.json
+++ b/VadeSecure/manifest.json
@@ -36,5 +36,5 @@
     "name": "Vade Secure",
     "uuid": "1411df5b-5de1-40bd-a988-725cfe692aff",
     "slug": "vadesecure",
-    "version": "1.49"
+    "version": "1.49.1"
 }

--- a/VadeSecure/vadesecure_modules/trigger_m365_events.py
+++ b/VadeSecure/vadesecure_modules/trigger_m365_events.py
@@ -5,7 +5,7 @@ from collections.abc import Generator, Sequence
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Deque, Tuple
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import orjson
 import requests
@@ -235,8 +235,8 @@ class M365EventsTrigger(Trigger):
         }
 
         url = urljoin(
-            base=self.module.configuration.api_host,
-            url=f"/api/v1/tenants/{self.configuration.tenant_id}/logs/{event_type.value}/search",
+            self.module.configuration.api_host.rstrip("/"),
+            f"api/v1/tenants/{self.configuration.tenant_id}/logs/{event_type.value}/search",
         )
 
         response = self.http_session.post(

--- a/Virustotal/manifest.json
+++ b/Virustotal/manifest.json
@@ -20,5 +20,5 @@
     "name": "VirusTotal",
     "uuid": "d023af1d-25d8-465b-b85f-2ed48214d6a5",
     "slug": "virustotal",
-    "version": "1.27"
+    "version": "1.27.1"
 }

--- a/Virustotal/virustotal/action_virustotal_getcomments.py
+++ b/Virustotal/virustotal/action_virustotal_getcomments.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/Virustotal/virustotal/action_virustotal_postcomment.py
+++ b/Virustotal/virustotal/action_virustotal_postcomment.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/Virustotal/virustotal/action_virustotal_scandomain.py
+++ b/Virustotal/virustotal/action_virustotal_scandomain.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/Virustotal/virustotal/action_virustotal_scanfile.py
+++ b/Virustotal/virustotal/action_virustotal_scanfile.py
@@ -1,6 +1,6 @@
 import os
 import time
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/Virustotal/virustotal/action_virustotal_scanhash.py
+++ b/Virustotal/virustotal/action_virustotal_scanhash.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from sekoia_automation.action import Action

--- a/Virustotal/virustotal/action_virustotal_scanip.py
+++ b/Virustotal/virustotal/action_virustotal_scanip.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/Virustotal/virustotal/action_virustotal_scanurl.py
+++ b/Virustotal/virustotal/action_virustotal_scanurl.py
@@ -1,5 +1,5 @@
 import time
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests import Response

--- a/Virustotal/virustotal/api.py
+++ b/Virustotal/virustotal/api.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 
@@ -12,4 +12,4 @@ class VirusTotalV3API:
 
         headers["x-apikey"] = self.module.configuration["apikey"]
 
-        return requests.request(method, urljoin(self.VTAPI_BASE_URL, url), json=json, headers=headers)
+        return requests.request(method, urljoin(self.VTAPI_BASE_URL, url.lstrip("/")), json=json, headers=headers)

--- a/WithSecure/manifest.json
+++ b/WithSecure/manifest.json
@@ -25,5 +25,5 @@
     "name": "WithSecure",
     "uuid": "8aa9f86c-f360-4ae7-84f5-b61c6917cf01",
     "slug": "withsecure",
-    "version": "2.11"
+    "version": "2.11.1"
 }

--- a/WithSecure/withsecure/client/auth.py
+++ b/WithSecure/withsecure/client/auth.py
@@ -2,7 +2,7 @@ import time
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from threading import Event
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 import requests
 from requests.auth import AuthBase, HTTPBasicAuth
@@ -11,7 +11,7 @@ from withsecure.client.exceptions import AuthenticationError
 from withsecure.constants import API_AUTH_MAX_ATTEMPT, API_AUTH_SECONDS_BETWEEN_ATTEMPTS, API_BASE_URL, API_TIMEOUT
 from withsecure.helpers import human_readable_api_exception
 
-API_AUTHENTICATION_URL = urljoin(API_BASE_URL, "/as/token.oauth2")
+API_AUTHENTICATION_URL = urljoin(API_BASE_URL, "as/token.oauth2")
 
 
 class OAuthAuthentication(AuthBase):

--- a/WithSecure/withsecure/constants.py
+++ b/WithSecure/withsecure/constants.py
@@ -1,10 +1,10 @@
-from urllib.parse import urljoin
+from posixpath import join as urljoin
 
 API_BASE_URL = "https://api.connect.withsecure.com"
 API_TIMEOUT = 5
 API_AUTH_SECONDS_BETWEEN_ATTEMPTS = 5
 API_FETCH_EVENTS_PAGE_SIZE = 1000
 API_AUTH_MAX_ATTEMPT = 5
-API_SECURITY_EVENTS_URL = urljoin(API_BASE_URL, "/security-events/v1/security-events")
-API_DEVICES_OPERATION_URL = urljoin(API_BASE_URL, "/devices/v1/operations")
-API_LIST_DEVICES_URL = urljoin(API_BASE_URL, "/devices/v1/devices")
+API_SECURITY_EVENTS_URL = urljoin(API_BASE_URL, "security-events/v1/security-events")
+API_DEVICES_OPERATION_URL = urljoin(API_BASE_URL, "devices/v1/operations")
+API_LIST_DEVICES_URL = urljoin(API_BASE_URL, "devices/v1/devices")


### PR DESCRIPTION
Replaces `urllib.parse.urljoin` by `posixpath.join` so it work with sub folder.
```py
>>> from urllib.parse import urljoin
>>> urljoin("https://fra2.sekoia.io/api/", "v2/inthreat")
'https://fra2.sekoia.io/api/v2/inthreat'
>>> from posixpath import join as urljoin
>>> urljoin("https://fra2.sekoia.io/api/", "v2/inthreat") 
'https://fra2.sekoia.io/api/v2/inthreat'
```

@squioc do you think we may have places where `urllib.parse.urljoin` was used to remove the previous path ?