### PR TITLE
Netskope: set base_url property as nullable

### DIFF
--- a/Netskope/CHANGELOG.md
+++ b/Netskope/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.3] - 2024-01-02
+
+### Changed
+
+- Set `base_url` property as nullable and update the Netskope Events connector to check this property
+
 ## [1.9.0] - 2023-12-22
 
 ### Added

--- a/Netskope/manifest.json
+++ b/Netskope/manifest.json
@@ -7,10 +7,12 @@
       "base_url": {
         "description": "API base URL",
         "type": "string",
-        "format": "uri"
+        "format": "uri",
+	"nullable": true,
+	"default": null
       }
     },
-    "required": []
+    "required": ["base_url"]
   },
   "description": "[Netskope](https://www.netskope.com/) is a cybersecurity company, providing solutions to protect data in cloud apps and network security applying zero trust principles.",
   "name": "Netskope",

--- a/Netskope/manifest.json
+++ b/Netskope/manifest.json
@@ -18,5 +18,5 @@
   "name": "Netskope",
   "uuid": "1e3f2e33-fb9c-4387-bcf7-8d7ece37f913",
   "slug": "netskope",
-  "version": "1.9.2"
+  "version": "1.9.3"
 }

--- a/Netskope/netskope_modules/connector_pull_events_v2.py
+++ b/Netskope/netskope_modules/connector_pull_events_v2.py
@@ -9,6 +9,7 @@ from netskope_api.iterator.const import Const
 from netskope_api.iterator.netskope_iterator import NetskopeIterator
 from pydantic import Field
 from sekoia_automation.connector import Connector, DefaultConnectorConfiguration
+from sekoia_automation.exceptions import ModuleConfigurationError
 
 from netskope_modules import NetskopeModule
 from netskope_modules.constants import MESSAGE_CANNOT_CONSUME_SERVICE
@@ -279,6 +280,11 @@ class NetskopeEventConnector(Connector):
                 consumers[name].stop()
 
     def run(self):
+
+        # raise a configuration error if the base_url is not defined
+        if self.module.configuration.base_url is None:
+            raise ModuleConfigurationError("The base url is undefined. Please set the url of the netskope api")
+
         try:
             # create iterators from data exports
             iterators = self.create_iterators(self.dataexports)

--- a/Netskope/netskope_modules/connector_pull_events_v2.py
+++ b/Netskope/netskope_modules/connector_pull_events_v2.py
@@ -1,4 +1,3 @@
-import os
 import time
 from functools import cached_property
 from json.decoder import JSONDecodeError
@@ -280,7 +279,6 @@ class NetskopeEventConnector(Connector):
                 consumers[name].stop()
 
     def run(self):
-
         # raise a configuration error if the base_url is not defined
         if self.module.configuration.base_url is None:
             raise ModuleConfigurationError("The base url is undefined. Please set the url of the netskope api")

--- a/Netskope/netskope_modules/models.py
+++ b/Netskope/netskope_modules/models.py
@@ -2,4 +2,4 @@ from pydantic import BaseModel, Field
 
 
 class NetskopeModuleConfiguration(BaseModel):
-    base_url: str = Field(description="API base URL")
+    base_url: str | None = Field(None, description="API base URL")


### PR DESCRIPTION
Set the module configuration property `base_url` as nullable (but required) and update the Netskope Events connector to check if this property is defined or not.