### PR TITLE
Sekoia.io: Read v2 notifications from `liveapi`

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-01-04 - 2.57.0
+
 ### Changed
 
 - Read v2 notifications from Sekoia.io’s `liveapi`.

--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Read v2 notifications from Sekoia.io’s `liveapi`.
 
 ## 2024-01-04 - 2.56.3
 
 ### Changed
 
 - Change log level from error to info when receiving a non v1 event
-
 
 ## 2023-12-12 - 2.56.1
 
@@ -26,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Action to add an IOC to an IOC Collection
-
 
 ## 2023-12-07 - 2.55.0
 

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.56.3"
+    "version": "2.57.0"
 }

--- a/Sekoia.io/pyproject.toml
+++ b/Sekoia.io/pyproject.toml
@@ -39,3 +39,8 @@ omit = [
     "tests/*",
     "main.py",
 ]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 119
+fix = true

--- a/Sekoia.io/sekoiaio/intelligence_center/actions.py
+++ b/Sekoia.io/sekoiaio/intelligence_center/actions.py
@@ -6,8 +6,6 @@ Module for actions that are not fully generic
 from sekoia_automation.action import GenericAPIAction
 
 from sekoiaio.intelligence_center import base_url
-import re
-from posixpath import join as urljoin
 
 
 class PostBundleAction(GenericAPIAction):

--- a/Sekoia.io/sekoiaio/triggers/intelligence.py
+++ b/Sekoia.io/sekoiaio/triggers/intelligence.py
@@ -1,6 +1,4 @@
-import signal
 import time
-from threading import Event
 from posixpath import join as urljoin
 
 import requests

--- a/Sekoia.io/tests/triggers/conftest.py
+++ b/Sekoia.io/tests/triggers/conftest.py
@@ -4,7 +4,14 @@ from tempfile import mkdtemp
 import pytest
 from sekoia_automation import constants
 
-from .samples import sample_notifications, sample_sicalertapi  # noqa
+from .samples import (
+    sample_notifications,  # noqa: F401
+    sample_sicalertapi,  # noqa: F401
+    samplenotif_alert_created,  # noqa: F401
+    samplenotif_alert_updated,  # noqa: F401
+    samplenotif_alert_status_changed,  # noqa: F401
+    samplenotif_alert_comment_created,  # noqa: F401
+)
 
 
 @pytest.fixture

--- a/Sekoia.io/tests/triggers/samples.py
+++ b/Sekoia.io/tests/triggers/samples.py
@@ -4,60 +4,95 @@ import pytest
 
 
 @pytest.fixture
-def sample_notifications():
-    yield [
-        {
-            "created_at": "2019-09-06T07:32:03.256679+00:00",
-            "event_version": 1,
-            "created_by": "59899459-d385-48da-9c0e-1d91ebe42c4a",
-            "created_by_type": "application",
-            "event_type": "alert",
-            "community_uuid": "cc93fe3f-c26b-4eb1-82f7-082209cf1892",
-            "attributes": {
-                "event": "alert-created",
-                "alert_uuid": "af0a370f-2e44-433c-99b2-2d0e4b348d0c",
-            },
+def samplenotif_alert_created():
+    yield {
+        "metadata": {
+            "version": 2,
             "uuid": "a8fb31cb-7310-4f59-afc2-d52033b5cf78",
+            "created_at": "2019-09-06T07:32:03.256679+00:00",
+            "community_uuid": "cc93fe3f-c26b-4eb1-82f7-082209cf1892",
         },
-        {
+        "type": "alert",
+        "action": "created",
+        "attributes": {
+            "uuid": "af0a370f-2e44-433c-99b2-2d0e4b348d0c",
+            "short_id": "ALakbd8NXp9W",
+        },
+    }
+
+
+@pytest.fixture
+def samplenotif_alert_status_changed():
+    yield {
+        "metadata": {
+            "version": 2,
             "community_uuid": "6ffbe55b-d30a-4dc4-bc52-a213dce0af29",
-            "event_type": "alert",
-            "created_by": "59899459-d385-48da-9c0e-1d91ebe42c4a",
+            "created_at": "2019-09-06T07:07:54.830677+00:00",
             "uuid": "02e10dca-e86e-462e-85cf-cd4c56b7d7e8",
-            "event_version": 1,
-            "attributes": {
-                "event": "alert-status-changed",
-                "alert_uuid": "90767578-2597-4d9d-ac1f-854fe2a41432",
-            },
-            "created_by_type": "application",
-            "created_at": "2019-09-06T07:07:54.830677+00:00",
         },
-        {
+        "type": "alert",
+        "action": "updated",
+        "attributes": {
+            "updated": {"status": "8f206505-af6d-433e-93f4-775d46dc7d0f", "status_name": "Acknowledged"},
+            "uuid": "af0a370f-2e44-433c-99b2-2d0e4b348d0c",
+            "short_id": "ALakbd8NXp9W",
+        },
+    }
+
+
+@pytest.fixture
+def samplenotif_alert_updated():
+    yield {
+        "metadata": {
+            "version": 2,
             "community_uuid": "6ffbe55b-d30a-4dc4-bc52-a213dce0af29",
-            "event_type": "alert",
-            "created_by": "59899459-d385-48da-9c0e-1d91ebe42c4a",
+            "created_at": "2019-09-06T07:07:54.830677+00:00",
             "uuid": "b47e4dad-e1de-4f9d-b77c-1c0bb61b20fe",
-            "event_version": 1,
-            "attributes": {
-                "event": "alert-updated",
-                "alert_uuid": "90767578-2597-4d9d-ac1f-854fe2a41432",
-            },
-            "created_by_type": "application",
-            "created_at": "2019-09-06T07:07:54.830677+00:00",
         },
-        {
+        "type": "alert",
+        "action": "updated",
+        "attributes": {
+            "updated": {"dynamic_urgency_value": 20},
+            "uuid": "af0a370f-2e44-433c-99b2-2d0e4b348d0c",
+            "short_id": "ALakbd8NXp9W",
+        },
+    }
+
+
+@pytest.fixture
+def samplenotif_alert_comment_created():
+    yield {
+        "metadata": {
+            "version": 2,
             "community_uuid": "6ffbe55b-d30a-4dc4-bc52-a213dce0af29",
-            "event_type": "alert",
-            "created_by": "59899459-d385-48da-9c0e-1d91ebe42c4a",
             "uuid": "94ef1f9d-ebad-42ba-98d7-2be3447c6bd0",
-            "event_version": 1,
-            "attributes": {
-                "event": "alert-comment-created",
-                "alert_uuid": "90767578-2597-4d9d-ac1f-854fe2a41432",
-            },
-            "created_by_type": "application",
             "created_at": "2019-09-06T07:07:54.830677+00:00",
         },
+        "type": "alert-comment",
+        "action": "created",
+        "attributes": {
+            "content": "comment",
+            "created_by": "c110d686-0b45-4ae7-b917-f15486d0f8c7",
+            "created_by_type": "user",
+            "alert_uuid": "af0a370f-2e44-433c-99b2-2d0e4b348d0c",
+            "alert_short_id": "ALakbd8NXp9W",
+            "uuid": "5869b4d8-e3bb-4465-baad-95daf28267c7",
+        },
+    }
+
+
+@pytest.fixture
+def sample_notifications(
+    samplenotif_alert_created,
+    samplenotif_alert_updated,
+    samplenotif_alert_status_changed,
+    samplenotif_alert_comment_created,
+):
+    yield [
+        samplenotif_alert_created,
+        samplenotif_alert_updated,
+        samplenotif_alert_status_changed,
+        samplenotif_alert_comment_created,
     ]
 
 

--- a/Sekoia.io/tests/triggers/test_base.py
+++ b/Sekoia.io/tests/triggers/test_base.py
@@ -1,10 +1,8 @@
 import json
-from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
 from requests import HTTPError
-from websocket import WebSocketBadStatusException
 
 from sekoiaio.triggers.alerts import _SEKOIANotificationBaseTrigger
 

--- a/Sekoia.io/tests/triggers/test_base.py
+++ b/Sekoia.io/tests/triggers/test_base.py
@@ -67,6 +67,12 @@ def test_on_error(base_trigger):
     base_trigger.log_exception.assert_not_called()
 
 
+def test_on_open(base_trigger):
+    ws = Mock()
+    base_trigger.on_open(ws)
+    ws.send.assert_called_with('{"action": "upgrade"}')
+
+
 def test_ping(base_trigger):
     base_trigger.on_ping(None, None)
     base_trigger.log.assert_called_once()


### PR DESCRIPTION
Update the Sekoia.io module to handle “v2 notifications”. This required to change a few things in the existing codebase.

Changes:
- In `_SEKOIANotificationBaseTrigger`, move away from the `handle_${event_type}` and only rely on a `handle_event` function that should be in charge of filtering the collected event. This way, the `SecurityAlertsTrigger` can handle alert notifications (`alert:created`, `alert:updated`, and `alert-comment:created` kind of events).
- Update `AlertCommentCreatedTrigger` to only handle changes about alert status changed (status changes are now in `alert:updated` events).
- Add a new `on_open()` callback to ask `liveapi` to send v2 notifications.
- Update test samples to be v2 notifications.