### PR TITLE
Sekoia.io: Explictly log all Alert API exceptions

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-01-04 - 2.57.1
+
 ### Fixed
 
 - Log an error when Alert API is not available after 10 retries.

--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Log an error when Alert API is not available after 10 retries.
+
 ## 2024-01-04 - 2.57.0
 
 ### Changed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.57.0"
+    "version": "2.57.1"
 }

--- a/Sekoia.io/sekoiaio/triggers/alerts.py
+++ b/Sekoia.io/sekoiaio/triggers/alerts.py
@@ -45,7 +45,11 @@ class SecurityAlertsTrigger(_SEKOIANotificationBaseTrigger):
         if not self._filter_notifications(message):
             return
 
-        alert = self._retrieve_alert_from_alertapi(alert_uuid)
+        try:
+            alert = self._retrieve_alert_from_alertapi(alert_uuid)
+        except Exception as exp:
+            self.log_exception(exp, message="Failed to fetch alert from Alert API")
+            return
 
         if rule_filter := self.configuration.get("rule_filter"):
             if alert["rule"]["name"] != rule_filter and alert["rule"]["uuid"] != rule_filter:

--- a/Sekoia.io/tests/triggers/test_alerts.py
+++ b/Sekoia.io/tests/triggers/test_alerts.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests_mock
@@ -69,6 +69,17 @@ def test_securityalertstrigger_retrieve_alert_from_api(alert_trigger, sample_not
 
         alert = alert_trigger._retrieve_alert_from_alertapi(alert_uuid)
         assert sorted(alert) == sorted(sample_sicalertapi)
+
+
+def test_securityalertstrigger_retrieve_alert_from_api_exp_raised(
+    alert_trigger, samplenotif_alert_created, requests_mock
+):
+    alert_uuid = samplenotif_alert_created["attributes"]["uuid"]
+    requests_mock.get(f"http://fake.url/api/v1/sic/alerts/{alert_uuid}", status_code=500)
+
+    with patch("tenacity.nap.time"):
+        alert_trigger.handle_event(samplenotif_alert_created)
+        alert_trigger.log.assert_called()
 
 
 def test_securityalertstrigger_handle_alert_send_message(


### PR DESCRIPTION
If an error is raised when trying to fetch an alert from the Alert API (after 10 retries), then, log explicitly the error that was raised.