### PR TITLE
feat(Sekoia.io): Update rule filter description

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-01-04 - 2.58.1
+
+### Changed
+
+- Change description of rule filter to avoid confusion for users
+
 ## 2024-01-04 - 2.57.1
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.58.0"
+    "version": "2.58.1"
 }

--- a/Sekoia.io/trigger_sekoiaio_alert_comment_created.json
+++ b/Sekoia.io/trigger_sekoiaio_alert_comment_created.json
@@ -4,7 +4,7 @@
         "properties": {
             "rule_filter": {
                 "type": "string",
-                "description": "Create a run only for alerts matching a rule name or UUID"
+                "description": "Create a run only for alerts matching a rule name"
             }
         },
         "type": "object",

--- a/Sekoia.io/trigger_sekoiaio_alert_created.json
+++ b/Sekoia.io/trigger_sekoiaio_alert_created.json
@@ -4,7 +4,7 @@
         "properties": {
             "rule_filter": {
                 "type": "string",
-                "description": "Create a run only for alerts matching a rule name or UUID"
+                "description": "Create a run only for alerts matching a rule name"
             }
         },
         "type": "object",

--- a/Sekoia.io/trigger_sekoiaio_alert_status_changed.json
+++ b/Sekoia.io/trigger_sekoiaio_alert_status_changed.json
@@ -4,7 +4,7 @@
         "properties": {
             "rule_filter": {
                 "type": "string",
-                "description": "Create a run only for alerts matching a rule name or UUID"
+                "description": "Create a run only for alerts matching a rule name"
             }
         },
         "type": "object",

--- a/Sekoia.io/trigger_sekoiaio_alert_updated.json
+++ b/Sekoia.io/trigger_sekoiaio_alert_updated.json
@@ -4,7 +4,7 @@
         "properties": {
             "rule_filter": {
                 "type": "string",
-                "description": "Create a run only for alerts matching a rule name or UUID"
+                "description": "Create a run only for alerts matching a rule name"
             }
         },
         "type": "object",

--- a/Sekoia.io/trigger_sekoiaio_securityalert.json
+++ b/Sekoia.io/trigger_sekoiaio_securityalert.json
@@ -4,7 +4,7 @@
         "properties": {
             "rule_filter": {
                 "type": "string",
-                "description": "Create a run only for alerts matching a rule name or UUID"
+                "description": "Create a run only for alerts matching a rule name"
             }
         },
         "type": "object",


### PR DESCRIPTION
Update the description so the user rely on the rule name instead of the uuid.

Usually the user provides the rule definition uuid instead of the rule instance uuid, making the trigger not handle any alerts.
By using the name there will be no possible confusion.