### PR TITLE
AWS: Set MessageVisibilty to one minute

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-01-11 - 1.29.6
+
+### Fixed
+
+- Set MessageVisibilty to 1 minutes in the SQS wrapper
+
 ## 2024-01-05 - 1.29.5
 
 ### Changed

--- a/AWS/aws_helpers/sqs_wrapper.py
+++ b/AWS/aws_helpers/sqs_wrapper.py
@@ -106,7 +106,7 @@ class SqsWrapper(AwsClient[SqsConfiguration]):
                     WaitTimeSeconds=frequency,
                     MessageAttributeNames=["All"],
                     AttributeNames=["All"],
-                    VisibilityTimeout=0,
+                    VisibilityTimeout=60,
                 )
 
             except Exception as e:  # pragma: no cover

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,5 +29,5 @@
     "name": "AWS",
     "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
     "slug": "aws",
-    "version": "1.29.5"
+    "version": "1.29.6"
 }

--- a/AWS/tests/aws_helpers/test_sqs_wrapper.py
+++ b/AWS/tests/aws_helpers/test_sqs_wrapper.py
@@ -172,7 +172,7 @@ async def test_receive_messages(sqs_wrapper, sqs_wrapper_configuration, session_
             MaxNumberOfMessages=6,
             MessageAttributeNames=["All"],
             AttributeNames=["All"],
-            VisibilityTimeout=0,
+            VisibilityTimeout=60,
         )
 
         mock_sqs.delete_message.assert_any_call(QueueUrl=queue_url, ReceiptHandle=receipt_handle_1)


### PR DESCRIPTION
In the SQS wrapper, set the [MessageVisibility](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html) to one minute.