### PR TITLE
fix(Sekoia.io): Do not push empty bundles to the IC

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-01-18 - 2.58.3
+
+### Fixed
+
+- Do not push empty bundles to the IC
+
 ## 2024-01-15 - 2.58.2
 
 ### Changed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
     "name": "Sekoia.io",
     "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
     "slug": "sekoia.io",
-    "version": "2.58.2"
+    "version": "2.58.3"
 }

--- a/Sekoia.io/sekoiaio/intelligence_center/actions.py
+++ b/Sekoia.io/sekoiaio/intelligence_center/actions.py
@@ -8,17 +8,27 @@ from sekoia_automation.action import GenericAPIAction
 from sekoiaio.intelligence_center import base_url
 
 
+class EmptyBundleError(Exception):
+    pass
+
+
 class PostBundleAction(GenericAPIAction):
     verb = "post"
     endpoint = base_url + "bundles"
     query_parameters = ["auto_merge", "name", "enrich", "assigned_to"]
 
     def get_body(self, arguments):
+        data = self.json_argument("bundle", arguments)
+        if not data.get("objects"):
+            raise EmptyBundleError("No objects in bundle")
         return {"data": self.json_argument("bundle", arguments)}
 
     def run(self, arguments) -> dict | None:
-        if results := super().run(arguments):
-            return results.get("data")
+        try:
+            if results := super().run(arguments):
+                return results.get("data")
+        except EmptyBundleError:
+            pass
 
         return None
 

--- a/Sekoia.io/tests/test_post_bundle.py
+++ b/Sekoia.io/tests/test_post_bundle.py
@@ -128,3 +128,15 @@ def test_post_bundle_results(stix_bundle):
         )
 
         assert action.run(arguments) == {"content_proposal_id": "some_id"}
+
+
+def test_post_empty_bundle(stix_bundle):
+    stix_bundle["objects"] = []
+    arguments = {"bundle": stix_bundle}
+    action = PostBundleAction()
+
+    action.module.configuration = {
+        "base_url": "http://fake.url/",
+        "api_key": "fake_api_key",
+    }
+    assert action.run(arguments) is None


### PR DESCRIPTION
Empty bundles are rejected by the Intelligence Center. This PR avoids to send them.