### PR TITLE
CrowdStrikeFalcon: Fix stop of the collect when facing ratelimit

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-01-19 - 1.16.1
+
+### Fixed
+
+- Change the way to handle graceful shutdown
+- Change the way to consume events in the queue
+
 ## 2024-01-05 - 1.15.3
 
 ### Fixed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/retry.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/retry.py
@@ -28,11 +28,11 @@ class Retry(BaseRetry):
         """
 
         # parse Retry-After header if defined
-        retry_after = response.getheader("Retry-After")
+        retry_after = response.headers.get("Retry-After")
         if retry_after:
             return self.parse_retry_after(retry_after)
 
-        ratelimit_retry_after = response.getheader("X-RateLimit-RetryAfter")
+        ratelimit_retry_after = response.headers.get("X-RateLimit-RetryAfter")
         if ratelimit_retry_after:
             return self.parse_ratelimit_retry_after(ratelimit_retry_after)
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -558,5 +558,11 @@ class EventStreamTrigger(Connector):
                 self.stop_streams(streams, stream_threads)
                 read_queue_thread.stop()
 
+        except HTTPError as error:
+            if error.response is not None and error.response.status_code == 429:
+                self.log(message="The connector was rate-limited, waiting 1 minute before retrying.", level="warning")
+                time.sleep(60)  # The authentication faces a ratelimit, sleep 1 minutes
+            else:
+                self.log_exception(error, message="Failed to fetch and forward events")
         except Exception as error:
             self.log_exception(error, message="Failed to fetch and forward events")

--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -211,7 +211,7 @@ class EventStreamReader(threading.Thread):
 
         next_refresh_at = datetime.utcnow() + timedelta(seconds=self.refresh_interval)
         self.log(
-            message=f"Readin event stream {self.data_feed_url} starting at offset {self.offset}",
+            message=f"Reading event stream {self.data_feed_url} starting at offset {self.offset}",
             level="info",
         )
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -528,9 +528,8 @@ class EventStreamTrigger(Connector):
                     )
                     stream_threads[stream_root_url].start()
 
-    def stop_streams(self, streams: dict, stream_threads: dict):
-        for stream_root_url in streams.keys():
-            stream_thread = stream_threads[stream_root_url]
+    def stop_streams(self, stream_threads: dict):
+        for stream_thread in stream_threads.values():
             if stream_thread.is_alive():
                 stream_thread.stop()
 
@@ -555,7 +554,7 @@ class EventStreamTrigger(Connector):
                     self.supervise_streams(streams, stream_threads)
                     time.sleep(5)
             finally:
-                self.stop_streams(streams, stream_threads)
+                self.stop_streams(stream_threads)
                 read_queue_thread.stop()
 
         except HTTPError as error:

--- a/CrowdStrikeFalcon/crowdstrike_falcon/logging.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/logging.py
@@ -1,0 +1,21 @@
+import os
+
+import structlog
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper("iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.LogfmtRenderer(),
+    ],
+    context_class=dict,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.make_filtering_bound_logger(int(os.environ.get("LOG_LEVEL", 20))),
+)
+
+
+def get_logger(*args):
+    return structlog.get_logger(*args)

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
     "name": "CrowdStrike Falcon",
     "slug": "crowdstrike-falcon",
     "description": "Integrates with CrowdStrike Falcon EDR",
-    "version": "1.16",
+    "version": "1.16.1",
     "configuration": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {

--- a/CrowdStrikeFalcon/poetry.lock
+++ b/CrowdStrikeFalcon/poetry.lock
@@ -1922,6 +1922,24 @@ docs = ["sphinx", "sphinx-prompt"]
 test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
+name = "structlog"
+version = "24.1.0"
+description = "Structured Logging for Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "structlog-24.1.0-py3-none-any.whl", hash = "sha256:3f6efe7d25fab6e86f277713c218044669906537bb717c1807a09d46bca0714d"},
+    {file = "structlog-24.1.0.tar.gz", hash = "sha256:41a09886e4d55df25bdcb9b5c9674bccfab723ff43e0a86a1b7b236be8e57b16"},
+]
+
+[package.extras]
+dev = ["structlog[tests,typing]"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "sphinxext-opengraph", "twisted"]
+tests = ["freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
+typing = ["mypy (>=1.4)", "rich", "twisted"]
+
+[[package]]
 name = "tenacity"
 version = "8.2.3"
 description = "Retry code until it succeeds"
@@ -2175,4 +2193,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "e23b096d38cd30fa7f4c410407aee4f7549687c375fa98b22eda8debc090664c"
+content-hash = "60b54a82a58284e9bd8352f2987fb5f2bedd390747afa5bca1ab212b3ae00f8a"

--- a/CrowdStrikeFalcon/pyproject.toml
+++ b/CrowdStrikeFalcon/pyproject.toml
@@ -10,6 +10,7 @@ sekoia-automation-sdk = "^1.8.1"
 crowdstrike-falconpy = "^1.1.4"
 requests-ratelimiter = "^0.4.0"
 stix2-patterns = "^2.0.0"
+structlog = "^24.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/CrowdStrikeFalcon/tests/test_event_stream_trigger.py
+++ b/CrowdStrikeFalcon/tests/test_event_stream_trigger.py
@@ -11,7 +11,12 @@ import requests_mock
 
 from crowdstrike_falcon import CrowdStrikeFalconModule
 from crowdstrike_falcon.client import CrowdstrikeFalconClient, CrowdstrikeThreatGraphClient
-from crowdstrike_falcon.event_stream_trigger import EventStreamReader, EventStreamTrigger, VerticlesCollector
+from crowdstrike_falcon.event_stream_trigger import (
+    EventStreamReader,
+    EventStreamTrigger,
+    VerticlesCollector,
+    EventForwarder,
+)
 
 
 @pytest.fixture
@@ -39,12 +44,12 @@ def test_read_queue(trigger):
     trigger.events_queue.put(("fake-stream-url", '{"metadata": {"offset": 10}, "foo": "bar"}'))
 
     trigger.push_events_to_intakes = MagicMock()
-    t = threading.Thread(target=trigger.read_queue)
+    t = EventForwarder(trigger)
     t.start()
 
     time.sleep(2)
 
-    trigger.stop()
+    t.stop()
     t.join()
 
     assert len(trigger.push_events_to_intakes.call_args.kwargs["events"]) == 1

--- a/CrowdStrikeFalcon/tests/test_event_stream_trigger.py
+++ b/CrowdStrikeFalcon/tests/test_event_stream_trigger.py
@@ -84,6 +84,15 @@ def test_get_streams(trigger):
         assert streams == {"stream": {"dataFeedURL": "stream?q=1"}}
 
 
+def test_authentication_exceed_ratelimit(trigger):
+    with requests_mock.Mocker() as mock, patch("crowdstrike_falcon.event_stream_trigger.time.sleep") as mock_time:
+        mock.register_uri("POST", "https://my.fake.sekoia/oauth2/token", status_code=429)
+
+        trigger.stop()
+        trigger.run()
+        mock_time.assert_called_once_with(60)
+
+
 def test_refresh_stream(trigger):
     reader = EventStreamReader(trigger, "", {}, "sio-00000")
 

--- a/CrowdStrikeFalcon/tests/test_event_stream_trigger.py
+++ b/CrowdStrikeFalcon/tests/test_event_stream_trigger.py
@@ -44,7 +44,7 @@ def test_read_queue(trigger):
 
     time.sleep(2)
 
-    trigger.f_stop.set()
+    trigger.stop()
     t.join()
 
     assert len(trigger.push_events_to_intakes.call_args.kwargs["events"]) == 1
@@ -155,7 +155,7 @@ def test_read_stream(trigger):
     reader.start()
 
     time.sleep(1)
-    trigger.f_stop.set()
+    reader.stop()
     reader.join()
 
     assert trigger.events_queue.qsize() > 1
@@ -212,7 +212,7 @@ def test_read_stream_call_verticles_collector(trigger):
     reader.start()
 
     time.sleep(1)
-    trigger.f_stop.set()
+    reader.stop()
     reader.join()
 
     assert trigger.events_queue.qsize() > 1
@@ -270,7 +270,7 @@ def test_run(trigger, symphony_storage):
             }
         }
     )
-    trigger.f_stop.set()
+    trigger.stop()
 
     with patch("crowdstrike_falcon.event_stream_trigger.EventStreamReader"), requests_mock.Mocker() as mock:
         mock.register_uri(
@@ -300,12 +300,12 @@ def test_read_stream_consider_offset(trigger):
     }
 
     trigger.auth_token_refreshed_at = datetime.utcnow()
-    trigger.f_stop.set()
     client_mock = MagicMock()
     client_mock.get.return_value.__enter__.return_value.status_code = 200
     reader = EventStreamReader(
         trigger, fake_stream["dataFeedURL"].split("?")[0], fake_stream, "sio-00000", 100, client_mock
     )
+    reader.stop()
     reader.run()
 
     assert client_mock.get.call_args.kwargs.get("url") == (
@@ -353,7 +353,7 @@ def test_read_stream_integration(symphony_storage):
 
     # wait few seconds
     time.sleep(5)
-    trigger.f_stop.set()
+    read_stream_thread.stop()
 
     assert trigger.events_queue.qsize() > 0
 
@@ -741,7 +741,7 @@ def test_read_stream_with_verticles(trigger):
         reader.start()
 
         time.sleep(1)
-        trigger.f_stop.set()
+        reader.stop()
         reader.join()
 
         expected_verticles = [


### PR DESCRIPTION
After a ratelimit on the authentication, the connector stopped collecting the events because `f_stop` was set at the end of the `run` method.

Changes applied:
- change the way to manage thread:
   - change the way to handle graceful shutdown
   - outsource the reading of the events queue in a dedicated and stoppable thread
- remove the expression that set `f_stop` at the end of the `run` method
- Add a timer to sleep 1 minute if the connector faces a ratelimit.