### PR TITLE
Salesforce: pause the connector when no records were returned

### DIFF
--- a/Salesforce/CHANGELOG.md
+++ b/Salesforce/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 2024-02-02 - 1.5.1
+
+#### Added
+
+- Configuration option for frequency
+
 ### 2024-01-24 - 1.4.12
 
 #### Added

--- a/Salesforce/manifest.json
+++ b/Salesforce/manifest.json
@@ -39,5 +39,5 @@
     "name": "Salesforce",
     "uuid": "f811e134-2548-11ee-be56-0242ac120002",
     "slug": "salesforce",
-    "version": "1.5.0"
+    "version": "1.5.1"
 }

--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -173,7 +173,7 @@ class SalesforceConnector(AsyncConnector):
                     FORWARD_EVENTS_DURATION.labels(intake_key=self.configuration.intake_key).observe(batch_duration)
 
                     # If no records were fetched
-                    if len(mesage_id) == 0:
+                    if len(message_ids) == 0:
                         # compute the remaining sleeping time. If greater than 0, sleep
                         delta_sleep = self.configuration.frequency - batch_duration
                         if delta_sleep > 0:

--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -169,9 +169,19 @@ class SalesforceConnector(AsyncConnector):
                     logger.info(log_message)
                     self.log(message=log_message, level="info")
 
-                    FORWARD_EVENTS_DURATION.labels(intake_key=self.configuration.intake_key).observe(
-                        processing_end - processing_start
-                    )
+                    batch_duration = processing_end - processing_start
+                    FORWARD_EVENTS_DURATION.labels(intake_key=self.configuration.intake_key).observe(batch_duration)
+
+                    # If no records were fetched
+                    if len(mesage_id) == 0:
+                        # compute the remaining sleeping time. If greater than 0, sleep
+                        delta_sleep = self.configuration.frequency - batch_duration
+                        if delta_sleep > 0:
+                            self.log(
+                                message=f"Next batch of events in the future. " f"Waiting {delta_sleep} seconds",
+                                level="info",
+                            )
+                            time.sleep(delta_sleep)
 
                     previous_processing_end = processing_end
 

--- a/Salesforce/trigger_salesforce_events.json
+++ b/Salesforce/trigger_salesforce_events.json
@@ -17,7 +17,12 @@
                 "type": "integer",
                 "description": "The max size of chunks for the batch processing",
                 "default": 1000
-            }
+            },
+	    "frequency": {
+	        "type": "integer",
+		"description": "Batch frequency in seconds",
+		"default": 600
+	    }
         },
         "required": [
             "intake_key"


### PR DESCRIPTION
Pause the connector (by default, during 10 minutes, as the Salesforce API generate hourly log files) when no records were returned from the previous batch.