### PR TITLE
AWS: fix the way to compute the lag

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-02-08 - 1.20.2
+
+### Fixed
+
+- Fix the way to compute the delay
+
 ## 2024-01-11 - 1.29.6
 
 ### Fixed

--- a/AWS/connectors/__init__.py
+++ b/AWS/connectors/__init__.py
@@ -89,7 +89,7 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
                     processing_end = time.time()
                     for message_timestamp in messages_timestamp:
                         EVENTS_LAG.labels(intake_key=self.configuration.intake_key).observe(
-                            processing_end - message_timestamp
+                            processing_end - (message_timestamp / 1000)
                         )
 
                     OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(message_ids))

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,5 +29,5 @@
     "name": "AWS",
     "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
     "slug": "aws",
-    "version": "1.30.1"
+    "version": "1.30.2"
 }


### PR DESCRIPTION
AWS timestamps are in milliseconds. Convert them into seconds to compute the delay.