### PR TITLE
feat(AWS): allowing ec2 events with custom unsupported events

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-02-15 - 1.30.4
+
+### Changed
+
+- Removing ec2 events with the unsupported lists and allowing otherwise
+
 ## 2024-02-13 - 1.30.3
 
 ### Changed

--- a/AWS/connectors/s3/trigger_s3_records.py
+++ b/AWS/connectors/s3/trigger_s3_records.py
@@ -27,6 +27,10 @@ class AwsS3RecordsTrigger(AbstractAwsS3QueuedConnector):
             # If it is one of the unsupported events, we should skip it
             "unsupported": ["GetObjectTagging"],
         },
+        "ec2.amazonaws.com": {
+            # If it is one of the unsupported events, we should skip it
+            "unsupported": ["AssignPrivateIpAddresses", "CreateTags", "DeleteTags", "DescribeTags", "GetEbsDefaultKmsKeyId", "GetIpamPoolCidrs", "GetManagedPrefixListEntries"],
+        },
         "default": {"unsupported": ["List", "Describe", "GetRecords"]},
     }
 

--- a/AWS/connectors/s3/trigger_s3_records.py
+++ b/AWS/connectors/s3/trigger_s3_records.py
@@ -29,7 +29,15 @@ class AwsS3RecordsTrigger(AbstractAwsS3QueuedConnector):
         },
         "ec2.amazonaws.com": {
             # If it is one of the unsupported events, we should skip it
-            "unsupported": ["AssignPrivateIpAddresses", "CreateTags", "DeleteTags", "DescribeTags", "GetEbsDefaultKmsKeyId", "GetIpamPoolCidrs", "GetManagedPrefixListEntries"],
+            "unsupported": [
+                "AssignPrivateIpAddresses",
+                "CreateTags",
+                "DeleteTags",
+                "DescribeTags",
+                "GetEbsDefaultKmsKeyId",
+                "GetIpamPoolCidrs",
+                "GetManagedPrefixListEntries",
+            ],
         },
         "default": {"unsupported": ["List", "Describe", "GetRecords"]},
     }

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,5 +29,5 @@
     "name": "AWS",
     "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
     "slug": "aws",
-    "version": "1.30.3"
+    "version": "1.30.4"
 }

--- a/AWS/tests/connectors/s3/test_trigger_s3_records.py
+++ b/AWS/tests/connectors/s3/test_trigger_s3_records.py
@@ -107,6 +107,10 @@ def test_check_if_payload_is_valid_1(connector: AwsS3RecordsTrigger, session_fak
     assert connector.is_valid_payload({"eventSource": "random.amazonaws.com", "eventName": "Random"}) is True
     assert connector.is_valid_payload({"eventSource": "random.amazonaws.com", "eventName": "GetRecords"}) is False
 
+    assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "DescribeInstances"}) is True
+    assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "CreateImage"}) is True
+    assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "DescribeTags"}) is False
+    assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "CreateTags"}) is False
 
 def test_check_if_payload_is_valid_2(connector: AwsS3RecordsTrigger, session_faker: Faker):
     """

--- a/AWS/tests/connectors/s3/test_trigger_s3_records.py
+++ b/AWS/tests/connectors/s3/test_trigger_s3_records.py
@@ -112,6 +112,7 @@ def test_check_if_payload_is_valid_1(connector: AwsS3RecordsTrigger, session_fak
     assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "DescribeTags"}) is False
     assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "CreateTags"}) is False
 
+
 def test_check_if_payload_is_valid_2(connector: AwsS3RecordsTrigger, session_faker: Faker):
     """
     Test AwsS3RecordsTrigger `is_valid_payload`.


### PR DESCRIPTION
Proposal to add custom filtering for ec2 events instead of the default one.

For detection purpose we need most of the Describe* events from ec2.
We defined an unsupported list of events we do not need instead and are quite huge currently in terms of EPS.