### PR TITLE
ExtraHop: change the way to compute the url of the endpoint

### DIFF
--- a/ExtraHop/CHANGELOG.md
+++ b/ExtraHop/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2024-03-01 - 1.0.1
+
+### Fixed
+
+- change the way to compute the detection endpoint

--- a/ExtraHop/extrahop/models.py
+++ b/ExtraHop/extrahop/models.py
@@ -5,3 +5,15 @@ class ExtraHopModuleConfiguration(BaseModel):
     base_url: str = Field(..., description="API base URL")
     client_id: str = Field(..., description="Client ID")
     client_secret: str = Field(secret=True, description="Client Secret")
+
+    @property
+    def tenant_url(self):
+        base_url = self.base_url.rstrip("/")
+
+        if base_url.startswith("http://"):
+            base_url = f"https://{base_url[7:]}"
+
+        if not base_url.startswith("https://"):
+            base_url = f"https://{base_url}"
+
+        return base_url

--- a/ExtraHop/extrahop/reveal_360_trigger.py
+++ b/ExtraHop/extrahop/reveal_360_trigger.py
@@ -69,7 +69,7 @@ class ExtraHopReveal360Connector(Connector):
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        url = urljoin(self.module.configuration.base_url.lstrip("/"), "api/v1/detections/search")
+        url = urljoin(self.module.configuration.base_url.rstrip("/"), "api/v1/detections/search")
         response = self.client.post(url, json=params, headers=headers, timeout=60)
 
         if not response.ok:

--- a/ExtraHop/extrahop/reveal_360_trigger.py
+++ b/ExtraHop/extrahop/reveal_360_trigger.py
@@ -31,7 +31,7 @@ class ExtraHopReveal360Connector(Connector):
     def client(self) -> ApiClient:
         return ApiClient(
             auth=ExtraHopApiAuthentication(
-                base_url=self.module.configuration.base_url,
+                base_url=self.module.configuration.tenant_url,
                 client_id=self.module.configuration.client_id,
                 client_secret=self.module.configuration.client_secret,
             )
@@ -69,7 +69,7 @@ class ExtraHopReveal360Connector(Connector):
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        url = urljoin(self.module.configuration.base_url.rstrip("/"), "api/v1/detections/search")
+        url = urljoin(self.module.configuration.tenant_url, "api/v1/detections/search")
         response = self.client.post(url, json=params, headers=headers, timeout=60)
 
         if not response.ok:

--- a/ExtraHop/extrahop/reveal_360_trigger.py
+++ b/ExtraHop/extrahop/reveal_360_trigger.py
@@ -1,6 +1,7 @@
 import time
 from functools import cached_property
 from typing import Generator
+from posixpath import join as urljoin
 
 import orjson
 from sekoia_automation.connector import Connector, DefaultConnectorConfiguration
@@ -68,7 +69,7 @@ class ExtraHopReveal360Connector(Connector):
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        url = f"{self.module.configuration.base_url}/api/v1/detections/search"
+        url = urljoin(self.module.configuration.base_url.lstrip("/"), "api/v1/detections/search")
         response = self.client.post(url, json=params, headers=headers, timeout=60)
 
         if not response.ok:

--- a/ExtraHop/manifest.json
+++ b/ExtraHop/manifest.json
@@ -29,5 +29,5 @@
     "name": "ExtraHop",
     "slug": "extrahop",
     "uuid": "7fbcf1fc-55d3-4fcd-9907-e491e234e9c0",
-    "version": "0.1.0"
+    "version": "1.0.1"
 }

--- a/ExtraHop/tests/test_connector.py
+++ b/ExtraHop/tests/test_connector.py
@@ -138,3 +138,38 @@ def test_next_batch(trigger, message_1, message_2):
         # events = trigger.fetch_events()
         trigger.next_batch()
         assert trigger.push_events_to_intakes.call_count == 1
+
+
+def test_clear_base_url_slash(data_storage, message_1, message_2):
+    module = ExtraHopModule()
+
+    trigger = ExtraHopReveal360Connector(module=module, data_path=data_storage)
+    trigger.log = MagicMock()
+    trigger.log_exception = MagicMock()
+    trigger.push_events_to_intakes = MagicMock()
+    trigger.module.configuration = {
+        "base_url": "https://some-test-cloud.extrahop.com/",
+        "client_id": "user123",
+        "client_secret": "some-secret",
+    }
+    trigger.configuration = {"intake_key": "intake_key", "frequency": 60}
+    trigger.get_last_timestamp = MagicMock()
+    trigger.from_date = 1645668000000
+
+    messages = [message_1, message_2]
+    with requests_mock.Mocker() as mock_requests, patch("extrahop.reveal_360_trigger.time") as mock_time:
+        mock_requests.post(
+            f"https://some-test-cloud.extrahop.com/oauth2/token",
+            json={
+                "access_token": "foo-token",
+                "token_type": "bearer",
+                "expires_in": 1799,
+            },
+        )
+        mock_requests.post(
+            "https://some-test-cloud.extrahop.com/api/v1/detections/search",
+            [{"json": messages}, {"json": []}],
+        )
+        # events = trigger.fetch_events()
+        trigger.next_batch()
+        assert trigger.push_events_to_intakes.call_count == 1


### PR DESCRIPTION
Use `posixpath.join` to compute the url of the endpoint, in order to avoid issue when the customer set the base_url with an ending slash.