### PR TITLE
Lacework: Update the module configuration

### DIFF
--- a/Lacework/lacework_module/base.py
+++ b/Lacework/lacework_module/base.py
@@ -4,7 +4,7 @@ from sekoia_automation.module import Module
 
 
 class LaceworkConfiguration(BaseModel):
-    secret: str = Field(secret=True, description="The secret of your API Key")
+    secret: str = Field(..., description="The secret of your API Key", secret=True)
     key_id: str = Field(..., description="The KeyId of your API Key")
     account: str = Field(..., description="The account of your API Key (e.g: `YourLaceworkTenant.lacework.net`)")
 

--- a/Lacework/lacework_module/base.py
+++ b/Lacework/lacework_module/base.py
@@ -4,9 +4,9 @@ from sekoia_automation.module import Module
 
 
 class LaceworkConfiguration(BaseModel):
-    secret_key: str = Field(secret=True, description="Your unique identifier used as the Authorization header")
-    access_key: str = Field(..., description="Your unique key to create the token used to authenticate the API Key.")
-    lacework_url: str = Field(..., description="Your Lacework application name")
+    secret: str = Field(secret=True, description="The secret of your API Key")
+    key_id: str = Field(..., description="The KeyId of your API Key")
+    account: str = Field(..., description="The account of your API Key (e.g: `YourLaceworkTenant.lacework.net`)")
 
 
 class LaceworkModule(Module):

--- a/Lacework/lacework_module/client/__init__.py
+++ b/Lacework/lacework_module/client/__init__.py
@@ -30,16 +30,16 @@ class LaceworkApiClient(ApiClient):
 
     def list_alerts(self, parameters: dict[Any, Any] | None = None) -> requests.Response:
         return self.get(
-            url=(f"https://{self.base_url}.lacework.net/api/v2/Alerts"),
+            url=(f"https://{self.base_url}/api/v2/Alerts"),
             params=parameters,
         )
 
     def get_alerts_from_date(self, startTime: str) -> requests.Response:
         return self.get(
-            url=(f"https://{self.base_url}.lacework.net/api/v2/Alerts?startTime={startTime}"),
+            url=(f"https://{self.base_url}/api/v2/Alerts?startTime={startTime}"),
         )
 
     def get_alerts_details(self, alertId: str, scope: str) -> requests.Response:
         return self.get(
-            url=(f"https://{self.base_url}.lacework.net/api/v2/Alerts/{alertId}?scope={scope}"),
+            url=(f"https://{self.base_url}/api/v2/Alerts/{alertId}?scope={scope}"),
         )

--- a/Lacework/lacework_module/client/auth.py
+++ b/Lacework/lacework_module/client/auth.py
@@ -55,7 +55,7 @@ class LaceworkAuthentication(AuthBase):
             or current_dt + datetime.timedelta(seconds=3600) >= self.__api_credentials.expiresAt
         ):
             response = self.__http_session.post(
-                url=f"https://{self.__lacework_url}.lacework.net/api/v2/access/tokens",
+                url=f"https://{self.__lacework_url}/api/v2/access/tokens",
                 headers={"X-LW-UAKS": self.__secret_key, "Content-Type": "application/json"},
                 json={"keyId": self.__access_key, "expiryTime": 3600},
             )

--- a/Lacework/lacework_module/lacework_connector.py
+++ b/Lacework/lacework_module/lacework_connector.py
@@ -73,11 +73,11 @@ class LaceworkEventsTrigger(Connector):
     @cached_property
     def client(self) -> LaceworkApiClient:
         auth = LaceworkAuthentication(
-            lacework_url=self.module.configuration.lacework_url,
-            access_key=self.module.configuration.access_key,
-            secret_key=self.module.configuration.secret_key,
+            lacework_url=self.module.configuration.account,
+            access_key=self.module.configuration.key_id,
+            secret_key=self.module.configuration.secret,
         )
-        return LaceworkApiClient(base_url=self.module.configuration.lacework_url, auth=auth)
+        return LaceworkApiClient(base_url=self.module.configuration.account, auth=auth)
 
     def run(self) -> None:
         self.log(message="Lacework Events Trigger has started", level="info")

--- a/Lacework/lacework_module/lacework_connector.py
+++ b/Lacework/lacework_module/lacework_connector.py
@@ -13,7 +13,7 @@ from urllib3.exceptions import HTTPError as BaseHTTPError
 from lacework_module.base import LaceworkModule
 from lacework_module.client import LaceworkApiClient
 from lacework_module.client.auth import LaceworkAuthentication
-from lacework_module.metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, INCOMING_EVENTS, OUTCOMING_EVENTS
+from lacework_module.metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, OUTCOMING_EVENTS
 
 
 class LaceworkConfiguration(DefaultConnectorConfiguration):
@@ -47,7 +47,7 @@ class LaceworkEventsTrigger(Connector):
         with self.context as cache:
             most_recent_date_seen_str = cache.get("most_recent_date_seen")
 
-            if most_recent_date_seen_str == None:
+            if most_recent_date_seen_str is None:
                 return now - timedelta(days=1)
 
             most_recent_date_seen = isoparse(most_recent_date_seen_str)
@@ -120,7 +120,7 @@ class LaceworkEventsTrigger(Connector):
             return None
         try:
             return response.json()
-        except ValueError as ex:
+        except ValueError:
             self.log(
                 message=("No more messages to forward"),
                 level="info",
@@ -141,7 +141,7 @@ class LaceworkEventsTrigger(Connector):
             return None
         try:
             return response.json()
-        except ValueError as ex:
+        except ValueError:
             self.log(
                 message=("No more messages to forward"),
                 level="info",

--- a/Lacework/manifest.json
+++ b/Lacework/manifest.json
@@ -3,26 +3,26 @@
            "title": "Lacework",
            "type": "object",
            "properties": {
-               "access_key": {
-                   "description": "Client Identifier",
+               "key_id": {
+                   "description": "The KeyId of your API Key",
                    "type": "string"
                },
-               "secret_key": {
-                   "description": "Client Secret",
+               "secret": {
+                   "description": "The secret of your API Key",
                    "type": "string"
                },
-               "lacework_url": {
-                   "description": "Client Lacework application name",
+               "account": {
+                   "description": "The account of your API Key",
                    "type": "string"
                }
            },
            "required": [
-               "access_key",
-               "secret_key",
-               "lacework_url"
+               "key_id",
+               "secret",
+               "account"
            ],
            "secrets": [
-               "secret_key"
+               "secret"
            ]
        },
     "description": "[Lacework](https://www.lacework.com/) is a cybersecurity company specializing in cloud security and compliance, offering automated threat detection and response solutions for modern cloud environments.",

--- a/Lacework/manifest.json
+++ b/Lacework/manifest.json
@@ -12,7 +12,7 @@
                    "type": "string"
                },
                "account": {
-                   "description": "The account of your API Key",
+                   "description": "The account of your API Key (e.g: `YourLaceworkTenant.lacework.net`)",
                    "type": "string"
                }
            },

--- a/Lacework/manifest.json
+++ b/Lacework/manifest.json
@@ -29,6 +29,6 @@
     "name": "Lacework",
     "uuid": "5803f97d-b324-4452-b861-0253b15de650",
     "slug": "lacework",
-    "version": "0.1.4"
+    "version": "0.1.5"
     
 }

--- a/Lacework/tests/client/test_auth.py
+++ b/Lacework/tests/client/test_auth.py
@@ -8,16 +8,16 @@ from lacework_module.client.auth import LaceworkAuthentication
 
 
 def test_get_credentials():
-    lacework_url = "api"
-    access_key = "foo"
-    secret_key = "bar"
-    auth = LaceworkAuthentication(lacework_url, access_key, secret_key)
+    account = "example.lacework.net"
+    key_id = "foo"
+    secret = "bar"
+    auth = LaceworkAuthentication(account, key_id, secret)
 
     with requests_mock.Mocker() as mock:
         mock.register_uri(
             "POST",
-            url=f"https://{lacework_url}.lacework.net/api/v2/access/tokens",
-            headers={"X-LW-UAKS": secret_key, "Content-Type": "application/json"},
+            url=f"https://{account}/api/v2/access/tokens",
+            headers={"X-LW-UAKS": secret, "Content-Type": "application/json"},
             json={
                 "token": "foo-token",
                 "expiresAt": (datetime.now(timezone.utc) + timedelta(seconds=3600)).isoformat(),
@@ -33,15 +33,15 @@ def test_get_credentials():
 
 
 def test_get_credentials_request_new_token_only_when_needed():
-    lacework_url = "api"
-    access_key = "foo"
-    secret_key = "bar"
-    auth = LaceworkAuthentication(lacework_url, access_key, secret_key)
+    account = "example.lacework.net"
+    key_id = "foo"
+    secret = "bar"
+    auth = LaceworkAuthentication(account, key_id, secret)
 
     with requests_mock.Mocker() as mock:
         p1 = mock.post(
-            url=f"https://{lacework_url}.lacework.net/api/v2/access/tokens",
-            headers={"X-LW-UAKS": secret_key, "Content-Type": "application/json"},
+            url=f"https://{account}/api/v2/access/tokens",
+            headers={"X-LW-UAKS": secret, "Content-Type": "application/json"},
             json={"token": "123456", "expiresAt": (datetime.now(timezone.utc) + timedelta(seconds=3600)).isoformat()},
         )
 
@@ -49,16 +49,16 @@ def test_get_credentials_request_new_token_only_when_needed():
         assert credentials.authorization == "Bearer 123456"
 
         p2 = mock.post(
-            url=f"https://{lacework_url}.lacework.net/api/v2/access/tokens",
-            headers={"X-LW-UAKS": secret_key, "Content-Type": "application/json"},
+            url=f"https://{account}/api/v2/access/tokens",
+            headers={"X-LW-UAKS": secret, "Content-Type": "application/json"},
             json={"token": "78910", "expiresAt": (datetime.now(timezone.utc) + timedelta(seconds=10000)).isoformat()},
         )
         credentials = auth.get_credentials()
         assert credentials.authorization == "Bearer 78910"
 
         p3 = mock.post(
-            url=f"https://{lacework_url}.lacework.net/api/v2/access/tokens",
-            headers={"X-LW-UAKS": secret_key, "Content-Type": "application/json"},
+            url=f"https://{account}/api/v2/access/tokens",
+            headers={"X-LW-UAKS": secret, "Content-Type": "application/json"},
             json={"token": "78910", "expiresAt": (datetime.now(timezone.utc) + timedelta(seconds=10000)).isoformat()},
         )
 
@@ -72,10 +72,10 @@ def test_get_credentials_request_new_token_only_when_needed():
 
 @pytest.mark.skipif("{'LACEWORK_ID', 'LACEWORK_SECRET'}.issubset(os.environ.keys()) == False")
 def test_authentication_integration(symphony_storage):
-    lacework_url = os.environ["LACEWORK_URL"]
-    access_key = os.environ["LACEWORK_ACCESS_KEY"]
-    secret_key = os.environ["LACEWORK_SECRET_KEY"]
-    auth = LaceworkAuthentication(lacework_url, access_key, secret_key)
+    account = os.environ["LACEWORK_URL"]
+    key_id = os.environ["LACEWORK_ACCESS_KEY"]
+    secret = os.environ["LACEWORK_SECRET_KEY"]
+    auth = LaceworkAuthentication(account, key_id, secret)
 
     credentials = auth.get_credentials()
     assert credentials.token is not None

--- a/Lacework/tests/client/test_client.py
+++ b/Lacework/tests/client/test_client.py
@@ -10,17 +10,17 @@ from lacework_module.client.auth import LaceworkAuthentication
 
 
 def test_list_alerts():
-    lacework_url = "api"
-    access_key = "foo"
-    secret_key = "bar"
-    auth = LaceworkAuthentication(lacework_url, access_key, secret_key)
-    client = LaceworkApiClient(lacework_url, auth=auth)
+    account = "example.lacework.net"
+    key_id = "foo"
+    secret = "bar"
+    auth = LaceworkAuthentication(account, key_id, secret)
+    client = LaceworkApiClient(account, auth=auth)
 
     with requests_mock.Mocker() as mock:
         mock.register_uri(
             "POST",
-            url=f"https://{lacework_url}.lacework.net/api/v2/access/tokens",
-            headers={"X-LW-UAKS": secret_key, "Content-Type": "application/json"},
+            url=f"https://{account}/api/v2/access/tokens",
+            headers={"X-LW-UAKS": secret, "Content-Type": "application/json"},
             json={"token": "foo-token", "expiresAt": str(datetime.utcnow() + timedelta(seconds=3600))},
         )
 
@@ -29,7 +29,7 @@ def test_list_alerts():
             "paging": {
                 "rows": 1000,
                 "totalRows": 3120,
-                "urls": {"nextPage": "https://{lacework_url}.lacework.net/api/v2/Alerts/AbcdEfgh123..."},
+                "urls": {"nextPage": "https://{account}/api/v2/Alerts/AbcdEfgh123..."},
             },
             "data": [
                 {
@@ -70,18 +70,18 @@ def test_list_alerts():
             ],
         }
         # flake8: qa
-        mock.get(f"https://{lacework_url}.lacework.net/api/v2/Alerts", json=response)
+        mock.get(f"https://{account}/api/v2/Alerts", json=response)
         list_events_response = client.list_alerts()
         assert list_events_response is not None
 
 
 @pytest.mark.skipif("{'LACEWORK_ID', 'LACEWORK_SECRET'}.issubset(os.environ.keys()) == False")
 def test_authentication_integration(symphony_storage):
-    lacework_url = os.environ["LACEWORK_URL"]
-    access_key = os.environ["LACEWORK_ACCESS_KEY"]
-    secret_key = os.environ["LACEWORK_SECRET_KEY"]
-    auth = LaceworkAuthentication(lacework_url, access_key, secret_key)
-    client = LaceworkApiClient(lacework_url, auth=auth)
+    account = os.environ["LACEWORK_URL"]
+    key_id = os.environ["LACEWORK_ACCESS_KEY"]
+    secret = os.environ["LACEWORK_SECRET_KEY"]
+    auth = LaceworkAuthentication(account, key_id, secret)
+    client = LaceworkApiClient(account, auth=auth)
 
     response = client.list_alerts()
     assert response.status_code < 300

--- a/Lacework/tests/test_lacework_connector.py
+++ b/Lacework/tests/test_lacework_connector.py
@@ -15,9 +15,9 @@ def trigger(symphony_storage: Path):
     module = LaceworkModule()
     trigger = LaceworkEventsTrigger(module=module, data_path=symphony_storage)
     trigger.module.configuration = {
-        "secret_key": "my-secret",
-        "access_key": "my-id",
-        "lacework_url": "api",
+        "secret": "my-secret",
+        "key_id": "my-id",
+        "account": "example.lacework.net",
     }
     trigger.configuration = {"intake_key": "0123456789"}
     trigger.push_events_to_intakes = Mock()
@@ -27,7 +27,7 @@ def trigger(symphony_storage: Path):
 
 
 def test_get_next_events(trigger: LaceworkEventsTrigger):
-    host = f"https://{trigger.module.configuration.lacework_url}.lacework.net"
+    host = f"https://{trigger.module.configuration.account}"
     params = {"token": "foo-token", "expiresAt": str(datetime.utcnow() + timedelta(seconds=3600))}
     with requests_mock.Mocker() as mock:
         mock.post(
@@ -42,7 +42,7 @@ def test_get_next_events(trigger: LaceworkEventsTrigger):
             "paging": {
                 "rows": 1000,
                 "totalRows": 3120,
-                "urls": {"nextPage": "https://api-test.lacework.net/api/v2/Alerts/AbcdEfgh123..."},
+                "urls": {"nextPage": "https://example.lacework.net/api/v2/Alerts/AbcdEfgh123..."},
             },
             "data": [
                 {
@@ -94,9 +94,9 @@ def test_get_next_events(trigger: LaceworkEventsTrigger):
 def test_forward_next_batches_integration(symphony_storage: Path):
     module = LaceworkModule()
     trigger = LaceworkEventsTrigger(module=module, data_path=symphony_storage)
-    trigger.configuration.lacework_url = (os.environ["LACEWORK_URL"],)
-    trigger.configuration.access_key = (os.environ["LACEWORK_ACCESS_KEY"],)
-    trigger.configuration.secret_key = (os.environ["LACEWORK_SECRET_KEY"],)
+    trigger.configuration.account = (os.environ["LACEWORK_URL"],)
+    trigger.configuration.key_id = (os.environ["LACEWORK_ACCESS_KEY"],)
+    trigger.configuration.secret = (os.environ["LACEWORK_SECRET_KEY"],)
     trigger.configuration.frequency = 0
     trigger.configuration.intake_key = "0123456789"
     trigger.push_events_to_intakes = Mock()


### PR DESCRIPTION
Update the module configuration to match the lacework terminology.

For an APIKey, we get the KeyId, the secret and the account (i.e, the base url of the Lacework tenant). In order to avoid misconfiguration from users, we replace the old parameters names, in the module configuration with these terms.