### PR TITLE
CrowdStrike: Improve the way to delete indicators

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-03-18 - 1.18.1
+
+### Fixed
+
+- Change the way to paginate CrowdStrike responses
+- Add intermediate steps when deleting indicators
+
 ## 2024-03-17 - 1.18.0
 
 ### Added

--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 2024-02-21 - 1.18.0
+## 2024-03-17 - 1.18.0
 
-### Add
+### Added
 
 - Add method to remove expired indicators
 - Add method to remove old indicators
 
 ## 2024-02-21 - 1.17.4
 
-### Add
+### Added
 
 - Add some logs for http response
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -78,7 +78,9 @@ class ApiClient(requests.Session):
             yield from content.get("resources") or []
 
             pagination = content.get("meta", {}).get("pagination")
-            still_fetching_items = pagination is not None and (bool(pagination.get("offset")) or bool(pagination.get("after")))
+            still_fetching_items = pagination is not None and (
+                bool(pagination.get("offset")) or bool(pagination.get("after"))
+            )
 
 
 class CrowdstrikeFalconClient(ApiClient):

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -78,7 +78,7 @@ class ApiClient(requests.Session):
             yield from content.get("resources") or []
 
             pagination = content.get("meta", {}).get("pagination")
-            still_fetching_items = pagination is not None and pagination.get("offset") > 0
+            still_fetching_items = pagination is not None and pagination.get("offset", 0) > 0
 
 
 class CrowdstrikeFalconClient(ApiClient):

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -78,7 +78,7 @@ class ApiClient(requests.Session):
             yield from content.get("resources") or []
 
             pagination = content.get("meta", {}).get("pagination")
-            still_fetching_items = pagination is not None and pagination.get("offset", 0) > 0
+            still_fetching_items = pagination is not None and (bool(pagination.get("offset")) or bool(pagination.get("after")))
 
 
 class CrowdstrikeFalconClient(ApiClient):

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -54,8 +54,13 @@ class ApiClient(requests.Session):
         while still_fetching_items:
             new_params = dict(params)
 
-            if pagination and "offset" in pagination:
-                new_params["offset"] = pagination["offset"]
+            if pagination:
+                # If after parameter is defined in the response, use it for the pagination
+                if "after" in pagination:
+                    new_params["after"] = pagination["after"]
+                # Otherwise, fallback on the offset parameter if defined
+                elif "offset" in pagination:
+                    new_params["offset"] = pagination["offset"]
 
             response = self.request(method=method, url=url, params=new_params, **kwargs)
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -78,7 +78,7 @@ class ApiClient(requests.Session):
             yield from content.get("resources") or []
 
             pagination = content.get("meta", {}).get("pagination")
-            still_fetching_items = pagination is not None
+            still_fetching_items = pagination is not None and pagination.get("offset") > 0
 
 
 class CrowdstrikeFalconClient(ApiClient):

--- a/CrowdStrikeFalcon/crowdstrike_falcon/custom_iocs.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/custom_iocs.py
@@ -48,6 +48,12 @@ class CrowdstrikeActionIOC(CrowdstrikeAction):
         for result in self.client.find_indicators(fql_filter=f"source:'{self.DEFAULT_SOURCE}'+expired:true"):
             ids_to_remove.append(result)
 
+            # Delete the IOCs in Crowdstrike
+            if len(ids_to_remove) > 1000:
+                self.log(f"Removing {len(ids_to_remove)} existing indicators from Crowdstrike Falcon")
+                next(self.client.delete_indicators(ids_to_remove))
+                ids_to_remove = []
+
         # Delete the IOCs in Crowdstrike
         if len(ids_to_remove) > 0:
             self.log(f"Removing {len(ids_to_remove)} existing indicators from Crowdstrike Falcon")
@@ -60,6 +66,12 @@ class CrowdstrikeActionIOC(CrowdstrikeAction):
             fql_filter=f"source:'{self.DEFAULT_SOURCE}'+modified_on:<='{date.today() - timedelta(days=valid_for)}'"
         ):
             ids_to_remove.append(result)
+
+            # Delete the IOCs in Crowdstrike
+            if len(ids_to_remove) > 1000:
+                self.log(f"Removing {len(ids_to_remove)} existing indicators from Crowdstrike Falcon")
+                next(self.client.delete_indicators(ids_to_remove))
+                ids_to_remove = []
 
         # Delete the IOCs in Crowdstrike
         if len(ids_to_remove) > 0:

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
     "name": "CrowdStrike Falcon",
     "slug": "crowdstrike-falcon",
     "description": "Integrates with CrowdStrike Falcon EDR",
-    "version": "1.18.0",
+    "version": "1.18.1",
     "configuration": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {

--- a/CrowdStrikeFalcon/tests/test_actions_iocs.py
+++ b/CrowdStrikeFalcon/tests/test_actions_iocs.py
@@ -500,6 +500,42 @@ def test_remove_expired_indicators():
         )
 
 
+def test_remove_expired_indicators_by_steps():
+    action = configured_action(CrowdstrikeActionPushIOCsBlock)
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            "https://my.fake.sekoia/oauth2/token",
+            json={
+                "access_token": "foo-token",
+                "token_type": "bearer",
+                "expires_in": 1799,
+            },
+        )
+        mock.register_uri(
+            "GET",
+            "https://my.fake.sekoia/iocs/queries/indicators/v1",
+            json={
+                "resources": [
+                    "0451b9c358b1404717f5060aea5711327cf169cd4c5648f5ac23f1a1fb740716",
+                ]
+                * 1002
+            },
+        )
+        deletion_mock = mock.register_uri(
+            "DELETE",
+            "https://my.fake.sekoia/iocs/entities/indicators/v1",
+            json={
+                "resources": [
+                    "0451b9c358b1404717f5060aea5711327cf169cd4c5648f5ac23f1a1fb740716",
+                ]
+            },
+        )
+        result = action.remove_expired_indicators()
+        assert result is None
+        assert deletion_mock.call_count == 2  # One call for the 1000 first indicators, the second for the last one
+
+
 def test_remove_old_indicators():
     action = configured_action(CrowdstrikeActionPushIOCsBlock)
     with requests_mock.Mocker() as mock:
@@ -540,6 +576,42 @@ def test_remove_old_indicators():
             "ids=0451b9c358b1404717f5060aea5711327cf169cd4c5648f5ac23f1a1fb740716&ids=4999492aa2ebcc763adb04d6333187e4481da18027726d99e9d227a99715381b"
             in history[2].url
         )
+
+
+def test_remove_old_indicators_by_steps():
+    action = configured_action(CrowdstrikeActionPushIOCsBlock)
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            "https://my.fake.sekoia/oauth2/token",
+            json={
+                "access_token": "foo-token",
+                "token_type": "bearer",
+                "expires_in": 1799,
+            },
+        )
+        mock.register_uri(
+            "GET",
+            "https://my.fake.sekoia/iocs/queries/indicators/v1",
+            json={
+                "resources": [
+                    "0451b9c358b1404717f5060aea5711327cf169cd4c5648f5ac23f1a1fb740716",
+                ]
+                * 1002
+            },
+        )
+        deletion_mock = mock.register_uri(
+            "DELETE",
+            "https://my.fake.sekoia/iocs/entities/indicators/v1",
+            json={
+                "resources": [
+                    "0451b9c358b1404717f5060aea5711327cf169cd4c5648f5ac23f1a1fb740716",
+                ]
+            },
+        )
+        result = action.remove_old_indicators(7)
+        assert result is None
+        assert deletion_mock.call_count == 2  # One call for the 1000 first indicators, the second for the last one
 
 
 def test_create_indicators():


### PR DESCRIPTION
- Add intermediate steps when deleting indicators to avoid one big calls at the end that may exceed some HTTP limitations
- Change the way to paginate the responses from CrowdStrike. The endpoints don't accept that the `offset` parameter exceed 10000. Instead, CrowdStrike recommends using the `after` parameters.
- Fix the condition that finalize the pagination (to avoid infinite loops).