### PR TITLE
GA: add the name of the module in the name of the uploaded artifact

### DIFF
--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Upload Event
         uses: actions/upload-artifact@v4
         with:
-          name: Event File
+          name: Event File ${{ matrix.module }}
           path: ${{ github.event_path }}
 
       - name: Upload Test Results


### PR DESCRIPTION
add the name of the module in the name of the uploaded artifact to avoid conflict when several modules are updated in a PR (see [GA job](https://github.com/SEKOIA-IO/automation-library/actions/runs/9109729684/?pr=943))