### PR TITLE
WithSecure: change the way to compute the event lag

### DIFF
--- a/WithSecure/CHANGELOG.md
+++ b/WithSecure/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## 2024-05-28 - 2.14.5
+
+### Changed
+
+- Change the way to compute the lag
+
 ## 2024-05-23 - 2.14.4
 
 ### Fixed

--- a/WithSecure/manifest.json
+++ b/WithSecure/manifest.json
@@ -25,5 +25,5 @@
   "name": "WithSecure",
   "uuid": "8aa9f86c-f360-4ae7-84f5-b61c6917cf01",
   "slug": "withsecure",
-  "version": "2.14.4"
+  "version": "2.14.5"
 }


### PR DESCRIPTION
When no new events are collected, the metrics always increases.
Change the way to compute the event lags to get closer to the reality