### PR TITLE
Fix the way to compute the lag

### DIFF
--- a/Cybereason/CHANGELOG.md
+++ b/Cybereason/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-06-06 - 1.13.2
+
+### Fixed
+
+- Fix the way to compute the lag on events, when no events were fetched from the API
+
 ## 2024-05-30 - 1.13.1
 
 ### Fixed

--- a/Cybereason/cybereason_modules/client/auth.py
+++ b/Cybereason/cybereason_modules/client/auth.py
@@ -11,7 +11,7 @@ from cybereason_modules.helpers import validate_response_not_login_failure
 
 
 class CybereasonApiCredentials:
-    session_id: str
+    session_id: str | None
     expires_at: datetime
 
 

--- a/Cybereason/cybereason_modules/connector_pull_events.py
+++ b/Cybereason/cybereason_modules/connector_pull_events.py
@@ -313,14 +313,11 @@ class CybereasonEventConnector(Connector):
             else:
                 yield from self.enrich_generic_malop(malop)
 
-        current_lag: int = 0
-
         # save the most recent date and compute the lag
         if most_recent_date_seen > self.from_date:
             self.from_date = most_recent_date_seen
             current_lag = int(time.time() - (most_recent_date_seen / 1000))
-
-        EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(current_lag)
+            EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(current_lag)
 
     def next_batch(self):
         """
@@ -335,6 +332,8 @@ class CybereasonEventConnector(Connector):
         if len(batch_of_events) > 0:
             OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(batch_of_events))
             self.push_events_to_intakes(events=batch_of_events)
+        else:
+            EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(0)
 
         # get the ending time and compute the duration to fetch the events
         batch_end_time = time.time()

--- a/Cybereason/manifest.json
+++ b/Cybereason/manifest.json
@@ -32,5 +32,5 @@
   "name": "Cybereason",
   "uuid": "b96361fb-a01b-4ae7-8927-9622b9ea0acf",
   "slug": "cybereason",
-  "version": "1.13.1"
+  "version": "1.13.2"
 }

--- a/Fastly/CHANGELOG.md
+++ b/Fastly/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-06-06 - 1.0.2
+
+### Fixed
+
+- Fix the way to compute the lag on events, when no events were fetched from the API
+
 ## 2024-05-30 - 1.0.1
 
 ### Fixed

--- a/Fastly/manifest.json
+++ b/Fastly/manifest.json
@@ -10,5 +10,5 @@
   "name": "Fastly",
   "uuid": "d8d68a10-622d-4ed9-97e4-d1a34ff3d6f8",
   "slug": "fastly",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/Lacework/CHANGELOG.md
+++ b/Lacework/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-06-06 - 1.2.2
+
+### Fixed
+
+- Fix the way to compute the lag on events, when no events were fetched from the API
+
 ## 2024-05-31 - 1.2.1
 
 ### Fixed

--- a/Lacework/manifest.json
+++ b/Lacework/manifest.json
@@ -30,5 +30,5 @@
   "name": "Lacework",
   "uuid": "5803f97d-b324-4452-b861-0253b15de650",
   "slug": "lacework",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-06-06 - 1.16.1
+
+### Fixed
+
+- Fix the way to compute the lag on events, when no events were fetched from the API
+
 ## 2024-05-28 - 1.16.0
 
 ### Changed

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,5 +38,5 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.16.0"
+  "version": "1.16.1"
 }

--- a/Sophos/sophos_module/trigger_sophos_edr_events.py
+++ b/Sophos/sophos_module/trigger_sophos_edr_events.py
@@ -180,3 +180,4 @@ class SophosEDREventsTrigger(SophosConnector):
             self.push_events_to_intakes(events=messages)
         else:
             self.log(message="No messages to forward", level="info")
+            EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(0)


### PR DESCRIPTION
Handle the computation of the events lag when no events were fetched from the API