### PR TITLE
Office365: fix the checkpoint

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-06-25 - 2.17.2
+
+### Fixed
+
+- Update the internal cursor when saving a new date in the checkpoint
+
 ## 2024-06-24 - 2.17.1
 
 ### Fixed
 
-- Fixe the way to use the event loop
+- Fix the way to use the event loop
 
 ## 2024-06-17 - 2.17.0
 

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,5 +8,5 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.17.1"
+  "version": "2.17.2"
 }

--- a/Office365/office365/management_api/checkpoint.py
+++ b/Office365/office365/management_api/checkpoint.py
@@ -35,4 +35,5 @@ class Checkpoint:
     def offset(self, last_message_date: datetime | None):
         if last_message_date is not None:
             if self.offset is None or last_message_date > self.offset:
+                self._most_recent_date_seen = last_message_date
                 self._context.write_text(last_message_date.isoformat())

--- a/Office365/tests/management_api/test_checkpoint.py
+++ b/Office365/tests/management_api/test_checkpoint.py
@@ -56,3 +56,21 @@ def test_checkpoint_greater_than_30_days(symphony_storage, checkpoint, intake_ke
         # Timedelta is sligthly less than 30 days since a few microseconds elapsed between `now`
         # and the moment `last_pull_date` is generated
         assert (now - checkpoint.offset).days == 30
+
+
+def test_checkpoint_save_last_date(symphony_storage, checkpoint, intake_key):
+    # arrange
+    now = datetime.now(timezone.utc)
+    previous_observed_date = now - timedelta(days=5)
+    context = symphony_storage / f"o365_{intake_key}_last_pull"
+    context.write_text(previous_observed_date.isoformat())
+
+    # assert that the checkpoint is at the last observed date
+    assert checkpoint.offset == previous_observed_date
+
+    # save a more recent date in the checkpoint
+    new_observed_date = now - timedelta(days=1)
+    checkpoint.offset = new_observed_date
+
+    # assert that the checkpoint was updated to the new observed date
+    assert checkpoint.offset == new_observed_date


### PR DESCRIPTION
The checkpoint track internally (cursor) the date of the last message seen. However, this cursor was not updated when saving a new date. 
This PR fixes this behavior.