### PR TITLE
Office365: fix dates to use for pulling

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-06-26 - 2.17.4
+
+### Fixed
+
+- Fix the dates used to pull the contents
+
 ## 2024-06-26 - 2.17.3
 
 ### Fixed

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,5 +8,5 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.17.3"
+  "version": "2.17.4"
 }

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -98,7 +98,7 @@ class Office365Connector(AsyncConnector):
         end_pull_date = datetime.now(UTC)
 
         for start_date, end_date in split_date_range(start_pull_date, end_pull_date, timedelta(minutes=30)):
-            async for list_of_events in self.pull_content(start_pull_date, end_pull_date):
+            async for list_of_events in self.pull_content(start_date, end_date):
                 await self.send_events(list_of_events)
 
         # get the ending time and compute the duration to forward the events


### PR DESCRIPTION
Fix the dates to use when pulling new contents.
We have to use the dates from the date ranges, not the ones from the whole period of times to fetch.