### PR TITLE
Office365: change how to close Office365 client

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-03 - 2.17.8
+
+### Fixed
+
+- Change the way to close the Office365 client
+
 ## 2024-07-03 - 2.17.7
 
 ### Fixed

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,5 +8,5 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.17.7"
+  "version": "2.17.8"
 }

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -129,6 +129,8 @@ class Office365Connector(AsyncConnector):
             except Exception as error:
                 self.log_exception(error, message="Failed to forward events")
 
+        await self.client.close()
+
     def run(self):
         """Main execution thread
 
@@ -142,4 +144,3 @@ class Office365Connector(AsyncConnector):
         loop.run_until_complete(self.collect_events())
 
         loop.close()
-        self.client.close()


### PR DESCRIPTION
The close method, from the Office365 Client, is async. So, we have to await it inside an async method.