### PR TITLE
Connectors: fix the way to compute lag

### DIFF
--- a/Bitsight/CHANGELOG.md
+++ b/Bitsight/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-08 - 1.0.2
+
+### Fixed
+
+- Fix the way to compute the lag in the collect of events
+
+### Changed
+
+- Change the way to compute the time to sleep between two batches
+
 ## 2024-07-05 - 1.0.1
 
 ### Added

--- a/Bitsight/connectors/pull_findings_trigger.py
+++ b/Bitsight/connectors/pull_findings_trigger.py
@@ -274,9 +274,15 @@ class PullFindingsConnector(AsyncConnector):
                         ]
                     )
 
-                    EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(
-                        processing_end - last_event_date.timestamp()
-                    )
+                    # compute the lag if we got events
+                    current_lag: int = 0
+                    if result_count > 0:
+                        current_lag = processing_end - last_event_date.timestamp()
+                    else:
+                        logger.info("No new events to forward")
+
+                    # report the lag
+                    EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(current_lag)
 
                     OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(result_count)
 

--- a/Bitsight/manifest.json
+++ b/Bitsight/manifest.json
@@ -28,5 +28,5 @@
   "name": "Bitsight",
   "uuid": "59b7f559-0a07-456f-b1c0-41d9fbe6ad4a",
   "slug": "bitsight",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/Darktrace/CHANGELOG.md
+++ b/Darktrace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-05 - 1.7.1
+
+### Fixed
+
+- Set the current lag to 0 when no events are fetched (because the connector is up-to-date)
+
 ## 2024-05-28 - 1.7.0
 
 ### Changed

--- a/Darktrace/manifest.json
+++ b/Darktrace/manifest.json
@@ -30,5 +30,5 @@
   "name": "Darktrace",
   "uuid": "0637f7c2-d68b-49cc-a1fc-ab7d0836e7ee",
   "slug": "darktrace",
-  "version": "1.7.0"
+  "version": "1.7.1"
 }

--- a/ExtraHop/CHANGELOG.md
+++ b/ExtraHop/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-08 - 1.1.1
+
+### Fixed
+
+- Fix the precision of timestamp (in milliseconds)
+
 ## 2024-05-28 - 1.1.0
 
 ### Changed

--- a/ExtraHop/manifest.json
+++ b/ExtraHop/manifest.json
@@ -29,5 +29,5 @@
   "name": "ExtraHop",
   "slug": "extrahop",
   "uuid": "7fbcf1fc-55d3-4fcd-9907-e491e234e9c0",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/Office365/tests/management_api/test_helpers.py
+++ b/Office365/tests/management_api/test_helpers.py
@@ -19,3 +19,13 @@ def test_split_date_range_should_return_two_ranges(connector):
     split = split_date_range(start_date, end_date, delta)
 
     assert list(split) == [(start_date, start_date + delta), (start_date + delta, end_date)]
+
+
+def test_split_date_range_should_return_ranges_lesser_or_equal_to_twentyfour_hours(connector):
+    end_date = datetime.utcnow()
+    start_date = end_date - timedelta(hours=26)
+    delta = timedelta(minutes=30)
+    split = split_date_range(start_date, end_date, delta)
+
+    for date_range in split:
+        assert date_range[0] - date_range[1] <= timedelta(hours=24)

--- a/PaloAltoCortexXDR/CHANGELOG.md
+++ b/PaloAltoCortexXDR/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-08 - 1.1.1
+
+### Fixed
+
+- Change the way to compute event lags
+
 ## 2024-05-28 - 1.1.0
 
 ### Changed

--- a/PaloAltoCortexXDR/CHANGELOG.md
+++ b/PaloAltoCortexXDR/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Change the way to compute event lags
+- Fix the precision of the timestamps used in the connector
 
 ## 2024-05-28 - 1.1.0
 

--- a/PaloAltoCortexXDR/cortex_module/cortex_edr_connector.py
+++ b/PaloAltoCortexXDR/cortex_module/cortex_edr_connector.py
@@ -130,14 +130,16 @@ class CortexQueryEDRTrigger(CortexConnector):
                 OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(combined_data))
                 self.push_events_to_intakes(events=combined_data)
 
+        current_lag: int = 0
         if len(events) > 0:
             most_recent_timestamp = orjson.loads(events[0]).get("detection_timestamp")
-            events_lag = int(time.time() - most_recent_timestamp)
-            EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(events_lag)
+            current_lag = int(time.time() - most_recent_timestamp)
             self.timestamp_cursor = most_recent_timestamp
 
         else:
             self.log(message=f"No alerts to forward at {self.timestamp_cursor}", level="info")
+
+        EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(current_lag)
 
     def run(self) -> None:
         """Run Cortex EDR Connector"""

--- a/PaloAltoCortexXDR/manifest.json
+++ b/PaloAltoCortexXDR/manifest.json
@@ -27,5 +27,5 @@
   "name": "Palo Alto Cortex XDR (EDR)",
   "uuid": "2bb1aaf9-a90c-411d-8e5f-c72b1b46b3d7",
   "slug": "paloalto_cortex_xdr",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }


### PR DESCRIPTION
- For Darktrace and BitSight, handle the case when no events are collected to compute the event lags.
- For ExtraHop and PaloAlto Cortex XDR, change the precision of the timestamps.