### PR TITLE
AWS: change the way to compute the events lag

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-08 - 1.31.1
+
+### Changed
+
+- Change the way to report the lag, when no events were collected
+- Refactor the way to pause the connector
+
 ## 2024-05-28 - 1.31.0
 
 ### Changed

--- a/AWS/connectors/__init__.py
+++ b/AWS/connectors/__init__.py
@@ -96,8 +96,8 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
 
                         # Identify delay between message timestamp ( when it was pushed to sqs )
                         # and current timestamp ( when it was processed )
-                        max_message_timestamp = int(max(messages_timestamp) / 1000)
-                        current_lag = processing_end - max_message_timestamp
+                        max_message_timestamp = max(messages_timestamp)
+                        current_lag = int(processing_end - max_message_timestamp / 1000)
                     else:
                         self.log(message="No records to forward", level="info")
 

--- a/AWS/connectors/__init__.py
+++ b/AWS/connectors/__init__.py
@@ -77,18 +77,14 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
 
                 while self.running:
                     processing_start = time.time()
+                    current_lag: int = 0
 
                     batch_result: tuple[list[str], list[int]] = loop.run_until_complete(self.next_batch())
                     message_ids, messages_timestamp = batch_result
 
-                    # Identify delay between message timestamp ( when it was pushed to sqs )
-                    # and current timestamp ( when it was processed )
+                    # compute the duration of the batch
                     processing_end = time.time()
                     batch_duration = processing_end - processing_start
-                    for message_timestamp in messages_timestamp:
-                        EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(
-                            processing_end - (message_timestamp / 1000)
-                        )
 
                     OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(message_ids))
                     FORWARD_EVENTS_DURATION.labels(intake_key=self.configuration.intake_key).observe(
@@ -97,8 +93,16 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
 
                     if len(message_ids) > 0:
                         self.log(message="Pushed {0} records".format(len(message_ids)), level="info")
+
+                        # Identify delay between message timestamp ( when it was pushed to sqs )
+                        # and current timestamp ( when it was processed )
+                        max_message_timestamp = int(max(messages_timestamp) / 1000)
+                        current_lag = processing_end - max_message_timestamp
                     else:
                         self.log(message="No records to forward", level="info")
+
+                    # report the current lag
+                    EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(current_lag)
 
                     # compute the remaining sleeping time. If greater than 0, sleep
                     delta_sleep = self.configuration.frequency - batch_duration

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,5 +29,5 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.31.0"
+  "version": "1.31.1"
 }


### PR DESCRIPTION
- Change the way to report the lag, when no events were collected
- Refactor the way to pause the connector