### PR TITLE
CatoNetwork: extends the length of the accountID to 5 digits

### DIFF
--- a/CatoNetwork/CHANGELOG.md
+++ b/CatoNetwork/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-08 - 1.5.1
+
+### Fixed
+
+- Update the length of the accountID to 5 digits
+
 ## 2024-05-28 - 1.5.0
 
 ### Changed

--- a/CatoNetwork/manifest.json
+++ b/CatoNetwork/manifest.json
@@ -7,8 +7,8 @@
         "type": "string"
       },
       "account_id": {
-        "description": "Account Id (4 digits) to work with Cato API",
-        "pattern": "^[0-9]{4}$",
+        "description": "Account Id (4 or 5 digits) to work with Cato API",
+        "pattern": "^[0-9]{4,5}$",
         "type": "string"
       }
     },

--- a/CatoNetwork/manifest.json
+++ b/CatoNetwork/manifest.json
@@ -26,5 +26,5 @@
   "name": "Cato Networks",
   "uuid": "d7aa9364-3182-11ee-be56-0242ac120002",
   "slug": "cato",
-  "version": "1.5.0"
+  "version": "1.5.1"
 }


### PR DESCRIPTION
- allows 4 or 5 digits for the accountID