### PR TITLE
Add filter on specific event action values

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-09 - 1.19.1
+
+### Changed
+
+- Filter on specific event_simpleName values
+
 ## 2024-05-28 - 1.19.0
 
 ### Changed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/metrics.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/metrics.py
@@ -27,6 +27,13 @@ OUTCOMING_EVENTS = Counter(
     labelnames=["intake_key"],
 )
 
+DISCARDED_EVENTS = Counter(
+    name="discarded_events",
+    documentation="Number of events discarded from the collect",
+    namespace=prom_namespace,
+    labelnames=["intake_key"],
+)
+
 EVENTS_LAG = Gauge(
     name="events_lags",
     documentation="The delay, in seconds, from the date of the last event",

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "Integrates with CrowdStrike Falcon EDR",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {


### PR DESCRIPTION
Add a filter on specific Crowdstrike Falcon logs: 
- event_simpleName not defined 
- event_simpleName in : 
 "SensorHeartbeat",
    "ConfigStateUpdate",
    "ErrorEvent",
    "FalconServiceStatus",
    "CurrentSystemTags",
    "BillingInfo",
    "ChannelActive",
    "IdpDcPerfReport",
    "ProvisioningChannelVersionRequired",
    "ChannelVersionRequired",
    "SensorSelfDiagnosticTelemetry",
    "SystemCapacity",
    "MobilePowerStats",
    "DeliverRulesEngineResultsToCloud",
    "NeighborListIP4",
    "NeighborListIP6",
    "AgentConnect",
    "AgentOnline",
    "ResourceUtilization",


