### PR TITLE
Filters for Crowdstrike falcon telemetry

### DIFF
--- a/CrowdStrike/CHANGELOG.md
+++ b/CrowdStrike/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2024-07-09
+
+### Changed
+
+- Filter on specific event_simpleName values
+
 ## [1.10.0] - 2024-05-28
 
 ### Changed

--- a/CrowdStrike/crowdstrike_telemetry/metrics.py
+++ b/CrowdStrike/crowdstrike_telemetry/metrics.py
@@ -17,6 +17,13 @@ FORWARD_EVENTS_DURATION = Histogram(
     labelnames=["intake_key"],
 )
 
+DISCARDED_EVENTS = Counter(
+    name="discarded_events",
+    documentation="Number of events discarded from the collect",
+    namespace=prom_namespace,
+    labelnames=["intake_key"],
+)
+
 EVENTS_LAG = Gauge(
     name="events_lags",
     documentation="The delay, in seconds, from the date of the last event",

--- a/CrowdStrike/crowdstrike_telemetry/pull_telemetry_events.py
+++ b/CrowdStrike/crowdstrike_telemetry/pull_telemetry_events.py
@@ -1,4 +1,5 @@
 """Contains connector, configuration and module."""
+
 import json
 import asyncio
 import time
@@ -37,6 +38,7 @@ EXCLUDED_EVENT_ACTIONS = [
     "AgentOnline",
     "ResourceUtilization",
 ]
+
 
 class CrowdStrikeTelemetryConfig(DefaultConnectorConfiguration):
     queue_name: str
@@ -149,7 +151,10 @@ class CrowdStrikeTelemetryConnector(AsyncConnector):
             if len(line.strip()) > 0:
                 try:
                     event = json.loads(line)
-                    if event.get("event_simpleName") is None or event.get("event_simpleName") in EXCLUDED_EVENT_ACTIONS:
+                    if (
+                        event.get("event_simpleName") is None
+                        or event.get("event_simpleName") in EXCLUDED_EVENT_ACTIONS
+                    ):
                         DISCARDED_EVENTS.labels(intake_key=self.configuration.intake_key).inc()
                         continue
                     result.append(line)

--- a/CrowdStrike/crowdstrike_telemetry/pull_telemetry_events.py
+++ b/CrowdStrike/crowdstrike_telemetry/pull_telemetry_events.py
@@ -160,7 +160,6 @@ class CrowdStrikeTelemetryConnector(AsyncConnector):
                         stream_root_url=self.stream_root_url,
                     )
                     self.log_exception(any_exception)
-                    raise any_exception
         return result
 
     def run(self) -> None:  # pragma: no cover

--- a/CrowdStrike/manifest.json
+++ b/CrowdStrike/manifest.json
@@ -29,5 +29,5 @@
   "name": "CrowdStrike",
   "uuid": "4ffe6bd9-6693-414d-ade0-5ec9fb1b8b2c",
   "slug": "crowdstrike",
-  "version": "1.10.0"
+  "version": "1.10.1"
 }

--- a/CrowdStrike/tests/crowdstrike_telemetry/test_crowdstrike.py
+++ b/CrowdStrike/tests/crowdstrike_telemetry/test_crowdstrike.py
@@ -77,12 +77,11 @@ async def test_process_s3_file(crowdstrike_connector, session_faker):
     """
     key = session_faker.file_path(depth=2, extension="json")
     content = b"""
-{"data": "aaaaa"}
-{"data": "bbbbb"}
+{"data": "aaaaa", "event_simpleName": "EndOfProcess"}
+{"data": "bbbbb", "event_simpleName": "FalconServiceStatus"}
 """
     expected = [
-        '{"data": "aaaaa"}',
-        '{"data": "bbbbb"}',
+        '{"data": "aaaaa", "event_simpleName": "EndOfProcess"}',
     ]
 
     with patch.object(crowdstrike_connector.s3_wrapper, "read_key") as mock_read_key:
@@ -105,8 +104,8 @@ async def test_process_gzipped_s3_file(crowdstrike_connector, session_faker):
     """
     key = session_faker.file_path(depth=2, extension="json")
     data = [
-        {"data": session_faker.sentence()},
-        {"data": session_faker.sentence()},
+        {"data": session_faker.sentence(), "event_simpleName": "EndOfProcess"},
+        {"data": session_faker.sentence(), "event_simpleName": "EndOfProcess"},
     ]
     expected = [json.dumps(item) for item in data]
 
@@ -131,7 +130,7 @@ async def test_process_s3_file_one_line(crowdstrike_connector, session_faker):
         session_faker: Faker
     """
     key = session_faker.file_path(depth=2, extension="json")
-    data = {"data": session_faker.sentence()}
+    data = {"data": session_faker.sentence(), "event_simpleName": "EndOfProcess"}
     expected = [json.dumps(data)]
 
     with patch.object(crowdstrike_connector.s3_wrapper, "read_key") as mock_read_key:


### PR DESCRIPTION
Add a filter on specific Crowdstrike Falcon logs:

- event_simpleName not defined
- event_simpleName in :
  "SensorHeartbeat",
  "ConfigStateUpdate",
  "ErrorEvent",
  "FalconServiceStatus",
  "CurrentSystemTags",
  "BillingInfo",
  "ChannelActive",
  "IdpDcPerfReport",
  "ProvisioningChannelVersionRequired",
  "ChannelVersionRequired",
  "SensorSelfDiagnosticTelemetry",
  "SystemCapacity",
  "MobilePowerStats",
  "DeliverRulesEngineResultsToCloud",
  "NeighborListIP4",
  "NeighborListIP6",
  "AgentConnect",
  "AgentOnline",
  "ResourceUtilization",