### PR TITLE
Sophos: fix expected status code

### DIFF
--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-10 - 1.16.3
+
+### Fixed
+
+- Change the expected status code from responses
+
 ## 2024-07-09 - 1.16.2
 
 ### Fixed

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,5 +38,5 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.16.2"
+  "version": "1.16.3"
 }

--- a/Sophos/sophos_module/trigger_sophos_xdr_query.py
+++ b/Sophos/sophos_module/trigger_sophos_xdr_query.py
@@ -110,7 +110,7 @@ class SophosXDRQueryTrigger(SophosConnector):
         )
 
         response = self.client.run_query(json_query=query)
-        if response.status_code != 200:
+        if response.status_code >= 400:
             self.log(
                 message=f"Failed to post the query. Status code: {response.status_code}, response: {response.text}",
                 level="error",
@@ -133,7 +133,7 @@ class SophosXDRQueryTrigger(SophosConnector):
             # It's the Second step of our query treatment.
             # Checking the status of our query.
             response_query_status = self.client.get_query_status(query_id)
-            if response_query_status.status_code != 200:
+            if response_query_status.status_code >= 400:
                 self.log(
                     message=f"Failed to get the query status. Status code: {response_query_status.status_code}, "
                     f"response: {response_query_status.text}",


### PR DESCRIPTION
The API return a 201 when creating a new query. Change the expected status code to only logs on errors.