### PR TITLE
Netskope: fix the way to compute the event lag

### DIFF
--- a/Netskope/CHANGELOG.md
+++ b/Netskope/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-10 - 1.10.4
+
+### Fixed
+
+- Change the way to compute the event lag
+
 ## 2024-07-02 - 1.10.3
 
 ### Added

--- a/Netskope/manifest.json
+++ b/Netskope/manifest.json
@@ -20,5 +20,5 @@
   "name": "Netskope",
   "uuid": "1e3f2e33-fb9c-4387-bcf7-8d7ece37f913",
   "slug": "netskope",
-  "version": "1.10.3"
+  "version": "1.10.4"
 }

--- a/Netskope/netskope_modules/connector_pull_events_v2.py
+++ b/Netskope/netskope_modules/connector_pull_events_v2.py
@@ -107,10 +107,13 @@ class NetskopeEventConsumer(Thread):
         )
 
         # compute the lag
+        current_lag: int = 0
         if most_recent_timestamp > 0:
             now = time.time()
-            current_lag = now - most_recent_timestamp
-            EVENTS_LAG.labels(intake_key=self.connector.configuration.intake_key, type=self.name).set(int(current_lag))
+            current_lag = int(now - most_recent_timestamp)
+
+        # report the lag
+        EVENTS_LAG.labels(intake_key=self.connector.configuration.intake_key, type=self.name).set(current_lag)
 
         # get the sleeping time from the response. Otherwise, compute the remaining sleeping time.
         delta_sleep = content.get("wait_time", 30 - batch_duration)


### PR DESCRIPTION
The metric was only updated when new events were fetched. Fix the way to compute the lag to consider when no events were collected.