### PR TITLE
Trellix: use connector's logger

### DIFF
--- a/Trellix/CHANGELOG.md
+++ b/Trellix/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-22 - 1.8.2
+
+### Changed
+
+- Update the loggers
+
 ## 2024-07-15 - 1.8.1
 
 ### Fixed

--- a/Trellix/connectors/trellix_edr_connector.py
+++ b/Trellix/connectors/trellix_edr_connector.py
@@ -270,7 +270,6 @@ class TrellixEdrConnector(AsyncConnector):
                     if len(message_ids) > 0:
                         log_message = "Pushed {0} records".format(len(message_ids))
 
-                    logger.info(log_message)
                     self.log(message=log_message, level="info")
 
                     logger.info(
@@ -283,4 +282,4 @@ class TrellixEdrConnector(AsyncConnector):
                     )
 
             except Exception as e:
-                logger.error("Error while running Trellix EDR: {error}", error=e)
+                self.log_exception(e, message="Error while running Trellix EDR")

--- a/Trellix/connectors/trellix_epo_connector.py
+++ b/Trellix/connectors/trellix_epo_connector.py
@@ -130,9 +130,7 @@ class TrellixEpoConnector(AsyncConnector):
                     if len(message_ids) > 0:
                         log_message = "Pushed {0} records".format(len(message_ids))
 
-                    logger.info(log_message)
                     self.log(message=log_message, level="info")
-                    logger.info(log_message)
                     logger.info(
                         "Processing took {processing_time} seconds",
                         processing_time=(processing_end - processing_start),
@@ -145,4 +143,4 @@ class TrellixEpoConnector(AsyncConnector):
                     previous_processing_end = processing_end
 
             except Exception as e:
-                logger.error("Error while running Trellix EPO: {error}", error=e)
+                self.log_exception(e, message="Error while running Trellix EPO")

--- a/Trellix/manifest.json
+++ b/Trellix/manifest.json
@@ -56,5 +56,5 @@
   "name": "Trellix",
   "uuid": "888071f8-1456-11ee-be56-0242ac120002",
   "slug": "trellix",
-  "version": "1.8.1"
+  "version": "1.8.2"
 }


### PR DESCRIPTION
Use the logger of the connector to push messages to the interface.