### PR TITLE
Google: Change the end of the period to call when restarting the connector

### DIFF
--- a/Google/CHANGELOG.md
+++ b/Google/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-22 - 1.20.6
+
+### Fixed
+
+- Change the way to catch back the delay with the timestepper
+
 ## 2024-07-02 - 1.20.5
 
 ### Changed

--- a/Google/google_module/google_reports.py
+++ b/Google/google_module/google_reports.py
@@ -101,11 +101,13 @@ class GoogleReports(GoogleTrigger):
             if most_recent_date_seen < six_months_ago:
                 most_recent_date_seen = six_months_ago
 
-            return TimeStepper.create_from_time(
+            timeshift = timedelta(minutes=self.configuration.timedelta)
+            return TimeStepper(
                 self,
                 most_recent_date_seen,
-                self.configuration.frequency,
-                self.configuration.timedelta,
+                now - timeshift,  # Set the end of the period to the now minus the temporal shift
+                timedelta(seconds=self.configuration.frequency),
+                timeshift,
             )
 
     @stepper.setter

--- a/Google/google_module/google_reports.py
+++ b/Google/google_module/google_reports.py
@@ -168,12 +168,6 @@ class GoogleReports(GoogleTrigger):
                 duration = int(time.time() - duration_start)
                 FORWARD_EVENTS_DURATION.labels(intake_key=self.configuration.intake_key).observe(duration)
 
-                # Compute the remaining sleeping time
-                delta_sleep = self.configuration.frequency - duration
-                # if greater than 0, sleep
-                if delta_sleep > 0:
-                    time.sleep(delta_sleep)
-
         finally:
             self.log(
                 message="Failed to forward events from Google Reports API",

--- a/Google/manifest.json
+++ b/Google/manifest.json
@@ -63,5 +63,5 @@
   "name": "Google",
   "uuid": "4f682a9e-9a25-43a5-8a48-cd9bd7fade7e",
   "slug": "google",
-  "version": "1.20.5"
+  "version": "1.20.6"
 }


### PR DESCRIPTION
When restarting, the connector starts to collect events from the `most recent date seen` to the `most resent date seen` + the interval (the `frequency`) to request. This behavior drives having a slow catch back of events if the `most recent date seen` is days ago.

To speed up the catch back, we set the end of the period to call to the upper bound (i.e, now - the temporal shift to collect the logs). In that way, the first call will retrieve all events from the `most recent date seen` to the moment the connector restarted.

PS: I also remove the pause in the connector as the TimeStepper class already compute one.