### PR TITLE
CrowdStrike: change the way to log errors when refreshing datafeed

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-22 - 1.19.2
+
+### Changed
+
+- Log on refresh url errors
+
 ## 2024-05-28 - 1.19.0
 
 ### Changed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -204,25 +204,20 @@ class EventStreamReader(threading.Thread):
         """
         logger.debug("refresh the event stream", refresh_url={refresh_url})
 
-        try:
-            response = self.client.post(
-                url=refresh_url,
-                json={"action_name": "refresh_active_stream_session", "appId": self.app_id},
+        response = self.client.post(
+            url=refresh_url,
+            json={"action_name": "refresh_active_stream_session", "appId": self.app_id},
+        )
+        if not response.ok:
+            logger.error(
+                "Failed to refresh the event stream",
+                refresh_url=refresh_url,
+                status_code=response.status_code,
+                content=response.text,
             )
-            response.raise_for_status()
-
+            self.log(level="error", message="failed to refresh the event stream")
+        else:
             logger.info("successfully refreshed event stream", refresh_url=refresh_url)
-
-        except requests.exceptions.RequestException as e:
-            if e.response:
-                self.log_exception(
-                    e,
-                    message=f"failed to refresh the event stream with "
-                    f"http status {e.response.status_code} and content: `{e.response.text}`",
-                )
-
-            else:
-                self.log_exception(e, message="failed to refresh the event stream")
 
     def refresh_stream_timer(self):
         return self.refresh_stream(refresh_url=self.stream_info["refreshActiveSessionURL"])

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "Integrates with CrowdStrike Falcon EDR",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {


### PR DESCRIPTION
try to have the content of the response when the url failed