### PR TITLE
Trellix: Fix the authentication url

### DIFF
--- a/Trellix/CHANGELOG.md
+++ b/Trellix/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-23 - 1.8.3
+
+### Fixed
+
+- Raise exception on authentication when facing 4xx status code
+- Fix the way to compute the authentication url
+
 ## 2024-07-22 - 1.8.2
 
 ### Changed

--- a/Trellix/client/token_refresher.py
+++ b/Trellix/client/token_refresher.py
@@ -137,13 +137,16 @@ class TrellixTokenRefresher(object):
             json={},
         ) as response:
             logger.info(response.url)
+
+            # raise an exception for any server error
             if response.status >= 500:
                 error_description = await response.text()
                 raise APIError(error_description)
 
             response_data = await response.json()
 
-            if response.status in (401, 403):
+            # raise an exception for any client error
+            if response.status >= 400:
                 raise AuthenticationFailed.from_http_response(response_data)
 
             self._token = TrellixToken(

--- a/Trellix/client/token_refresher.py
+++ b/Trellix/client/token_refresher.py
@@ -6,6 +6,7 @@ from asyncio import Lock, Task
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Optional, Set
 from urllib.parse import urlencode
+from posixpath import join as urljoin
 
 from aiohttp import BasicAuth, ClientSession
 from loguru import logger
@@ -118,9 +119,11 @@ class TrellixTokenRefresher(object):
             "scope": "+".join(self.scopes),
         }
 
-        return URL("{0}/iam/v1.1/token".format(self.base_url)).with_query(
-            urlencode(params, safe="+", encoding="utf-8")
-        )
+        auth_url = self.base_url
+        if not auth_url.endswith("/token"):
+            auth_url = urljoin(auth_url, "token")
+
+        return URL(auth_url).with_query(urlencode(params, safe="+", encoding="utf-8"))
 
     async def refresh_token(self) -> None:
         """

--- a/Trellix/manifest.json
+++ b/Trellix/manifest.json
@@ -56,5 +56,5 @@
   "name": "Trellix",
   "uuid": "888071f8-1456-11ee-be56-0242ac120002",
   "slug": "trellix",
-  "version": "1.8.2"
+  "version": "1.8.3"
 }

--- a/Trellix/tests/client/test_token_refresher.py
+++ b/Trellix/tests/client/test_token_refresher.py
@@ -203,3 +203,35 @@ async def test_trellix_refresher_instance(http_token, session_faker):
     await instance1.close()
     await instance2.close()
     await instance3.close()
+
+
+@pytest.mark.parametrize(
+    "auth_url,expected_auth_path",
+    [
+        ("https://iam.cloud.trellix.com/iam/v1.0", "/iam/v1.0/token"),
+        ("https://iam.cloud.trellix.com/iam/v1.0/token", "/iam/v1.0/token"),
+        ("https://iam.mcafee-cloud.com/iam/v1.1", "/iam/v1.1/token"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_trellix_refresher_auth_url(
+    http_token, session_faker, token_refresher_session, auth_url, expected_auth_path
+):
+    """
+    Test TrellixTokenRefresher.auth_url
+
+    Args:
+        http_token: HttpToken
+        session_faker: Faker
+        token_refresher_session: MagicMock
+    """
+
+    token_refresher = TrellixTokenRefresher(
+        session_faker.word(),
+        session_faker.word(),
+        session_faker.word(),
+        auth_url,
+        Scope.complete_set_of_scopes(),
+    )
+
+    assert token_refresher.auth_url.path == expected_auth_path


### PR DESCRIPTION
- Raise exceptions on authentication when facing 4xx status code
- Fix the way to compute the authentication url