### PR TITLE
CrowdStrikeFalcon: change the way to compute the refresh interval

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-23 - 1.19.3
+
+### Fixed
+
+- Change the way the refresh interval is calculated to keep the datafeed active
+
 ## 2024-07-22 - 1.19.2
 
 ### Changed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -16,7 +16,7 @@ from sekoia_automation.timer import RepeatedTimer
 from crowdstrike_falcon import CrowdStrikeFalconModule
 from crowdstrike_falcon.client import CrowdstrikeFalconClient, CrowdstrikeThreatGraphClient
 from crowdstrike_falcon.exceptions import StreamNotAvailable
-from crowdstrike_falcon.helpers import get_detection_id, group_edges_by_verticle_type
+from crowdstrike_falcon.helpers import get_detection_id, group_edges_by_verticle_type, compute_refresh_interval
 from crowdstrike_falcon.metrics import EVENTS_LAG, INCOMING_DETECTIONS, INCOMING_VERTICLES, OUTCOMING_EVENTS
 from crowdstrike_falcon.models import CrowdStrikeFalconEventStreamConfiguration
 from crowdstrike_falcon.logging import get_logger
@@ -190,7 +190,7 @@ class EventStreamReader(threading.Thread):
 
     @property
     def refresh_interval(self) -> int:
-        return int(self.stream_info["refreshActiveSessionInterval"])
+        return compute_refresh_interval(int(self.stream_info["refreshActiveSessionInterval"]))
 
     def log(self, *args, **kwargs):
         self.connector.log(*args, **kwargs)

--- a/CrowdStrikeFalcon/crowdstrike_falcon/helpers.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/helpers.py
@@ -144,3 +144,14 @@ def stix_to_indicators(stix_object, supported_types_map):
             results.append({"type": ioc_type, "value": ioc_value})
 
     return results
+
+
+def compute_refresh_interval(interval: int) -> int:
+    """
+    Compute a refresh interval with a safety margin
+
+    This margin is depends on the refresh interval and a maximum of five minutes.
+    The refresh interval is a minimum of 30 seconds
+    """
+    delta = min(300, int(interval / 6))
+    return max(30, interval - delta)

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "Integrates with CrowdStrike Falcon EDR",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/CrowdStrikeFalcon/tests/test_helpers.py
+++ b/CrowdStrikeFalcon/tests/test_helpers.py
@@ -5,6 +5,7 @@ from crowdstrike_falcon.helpers import (
     get_detection_id,
     get_extended_verticle_type,
     group_edges_by_verticle_type,
+    compute_refresh_interval,
 )
 
 
@@ -106,3 +107,8 @@ def test_get_detection_id():
         },
     }
     assert get_detection_id(detection) == detection_id
+
+
+@pytest.mark.parametrize("interval,expected_result", [(1800, 1500), (60, 50), (30, 30), (3600, 3300)])
+def test_compute_refresh_interval(interval, expected_result):
+    assert compute_refresh_interval(interval) == expected_result


### PR DESCRIPTION
The connector read a long pulling request to get the events. To keep this connection alive, we have to call a URL on a regular interval.

Until now, the connector uses the interval provided by the API. Now, we add a safety margin to this interval to avoid calling the URL outside the time range.