### PR TITLE
fix(Sekoia.io): Fixes potential errors in URLs

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-23 - 2.62.1
+
+### Fixed
+
+- Fixes potential errors in URLs
+
 ## 2024-07-23 - 2.62.0
 
 ### Changed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -26,5 +26,5 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.62.0"
+  "version": "2.62.1"
 }

--- a/Sekoia.io/sekoiaio/triggers/alerts.py
+++ b/Sekoia.io/sekoiaio/triggers/alerts.py
@@ -101,6 +101,7 @@ class SecurityAlertsTrigger(_SEKOIANotificationBaseTrigger):
     )
     def _retrieve_alert_from_alertapi(self, alert_uuid):
         api_url = urljoin(self.module.configuration["base_url"], f"api/v1/sic/alerts/{alert_uuid}")
+        api_url = api_url.replace("/api/api", "/api")  # In case base_url ends with /api
 
         api_key = self.module.configuration["api_key"]
         headers = {"Authorization": f"Bearer {api_key}", "User-Agent": user_agent()}

--- a/Sekoia.io/sekoiaio/triggers/intelligence.py
+++ b/Sekoia.io/sekoiaio/triggers/intelligence.py
@@ -40,11 +40,12 @@ class FeedConsumptionTrigger(Trigger):
         url = (
             urljoin(
                 self.module.configuration["base_url"],
-                f"v2/inthreat/collections/{self.feed_id}/objects",
+                f"api/v2/inthreat/collections/{self.feed_id}/objects",
             )
             + f"?limit={self.batch_size_limit}"
             + f"&include_revoked={not self.first_run}"
         )
+        url = url.replace("/api/api", "/api")  # In case base_url ends with /api
         if len(self.API_URL_ADDITIONAL_PARAMETERS) > 0:
             url += "&" + "&".join(self.API_URL_ADDITIONAL_PARAMETERS)
 

--- a/Sekoia.io/tests/ic_oc_triggers/test_base.py
+++ b/Sekoia.io/tests/ic_oc_triggers/test_base.py
@@ -84,14 +84,14 @@ def test_pong(base_trigger):
 
 
 def test_run_forbidden(base_trigger, requests_mock):
-    requests_mock.get("http://fake.url//v1/me", status_code=403)
+    requests_mock.get("http://fake.url/api/v1/me", status_code=403)
     with pytest.raises(HTTPError):
         base_trigger.run()
         assert base_trigger._error_count == 5
 
 
 def test_run(base_trigger, requests_mock):
-    requests_mock.get("http://fake.url//v1/me", status_code=200)
+    requests_mock.get("http://fake.url/api/v1/me", status_code=200)
     base_trigger.stop()
     try:
         base_trigger.run()

--- a/Sekoia.io/tests/ic_oc_triggers/test_intelligence.py
+++ b/Sekoia.io/tests/ic_oc_triggers/test_intelligence.py
@@ -37,7 +37,7 @@ def trigger(data_storage):
 
 def test_url_generation(trigger):
     expected_url = (
-        "https://api.sekoia.io/v2/inthreat/collections/"
+        "https://api.sekoia.io/api/v2/inthreat/collections/"
         "d6092c37-d8d7-45c3-8aff-c4dc26030608/objects"
         "?limit=200&include_revoked=False&skip_expired=true"
     )
@@ -47,7 +47,7 @@ def test_url_generation(trigger):
 def test_url_generation_modified_after(trigger):
     trigger.configuration["modified_after"] = "2021-09-01T00:00:00Z"
     expected_url = (
-        "https://api.sekoia.io/v2/inthreat/collections/"
+        "https://api.sekoia.io/api/v2/inthreat/collections/"
         "d6092c37-d8d7-45c3-8aff-c4dc26030608/objects"
         "?limit=200&include_revoked=False&skip_expired=true&modified_after=2021-09-01T00:00:00Z"
     )


### PR DESCRIPTION
* Handle cases where the base URL from the config has the `/api` or not.
* Harmonize all the triggers
  * `/me` and `/v2/inthreat` were expecting `/api` to be in the base url (or that the base url is `https://api.sekoia.io`)
  *  `/v1/sic/alerts` was not expecting `/api` to be in the URL


The fix should also work with `https://api.sekoia.io` because `https://api.sekoia.io/api` also works.