### PR TITLE
Azure: reset event lag when no message was received

### DIFF
--- a/Azure/CHANGELOG.md
+++ b/Azure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-24 - 2.5.2
+
+### Fixed
+
+- Reset event lag when no message was received
+
 ## 2024-07-04 - 2.5.1
 
 ### Added

--- a/Azure/connectors/azure_eventhub.py
+++ b/Azure/connectors/azure_eventhub.py
@@ -93,6 +93,7 @@ class AzureEventsHubTrigger(AsyncConnector):
                 ),
                 level="info",
             )
+            EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(0)
             await self.client.close()
 
         # acknowledge the messages

--- a/Azure/manifest.json
+++ b/Azure/manifest.json
@@ -8,5 +8,5 @@
   "name": "Microsoft Azure",
   "uuid": "525eecc0-9eee-484d-92bd-039117cf4dac",
   "slug": "azure",
-  "version": "2.5.1"
+  "version": "2.5.2"
 }


### PR DESCRIPTION
Reset the event lag when no message was received after several seconds.