### PR TITLE
Trellix: add retries on HTTP errors

### DIFF
--- a/Trellix/CHANGELOG.md
+++ b/Trellix/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-07-29 - 1.8.4
+
+### Changed
+
+- add a safety margin for the refresh token
+
+### Fixed
+
+- add retries on failed http requests
+- handle 429 HTTP responses
+
 ## 2024-07-23 - 1.8.3
 
 ### Fixed

--- a/Trellix/client/http_client.py
+++ b/Trellix/client/http_client.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncGenerator, Optional, Set
 
 from aiohttp import ClientSession
 from aiolimiter import AsyncLimiter
+from aiohttp_retry import RetryClient
 from yarl import URL
 
 from .schemas.attributes.edr_affectedhosts import EdrAffectedhostAttributes
@@ -100,7 +101,7 @@ class TrellixHttpClient(object):
             AsyncGenerator[ClientSession, None]:
         """
         if cls._session is None:
-            cls._session = ClientSession()
+            cls._session = RetryClient()
 
         if cls._rate_limiter:
             async with cls._rate_limiter:

--- a/Trellix/client/retry.py
+++ b/Trellix/client/retry.py
@@ -1,0 +1,32 @@
+from aiohttp_retry import RetryOptionsBase
+from aiohttp import ClientResponse
+
+
+class RetryWithRateLimiter(RetryOptionsBase):
+    """
+    This retry option will pause the retry according to the Retry-After, if defined, when the limit was exhausted (status code: 429).
+    Otherwise, it will call the underlying retry options
+    """
+
+    RETRY_AFTER_HEADER = "Retry-After"
+
+    def __init__(self, retry_options: RetryOptionsBase):
+        self._wrapped_retry_options = retry_options
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped_retry_options, name)
+
+    def get_timeout(self, attempt: int, response: ClientResponse | None = None) -> float:
+        """
+        Return the time to wait before the next attempt
+
+        Args:
+            attempt: The number of attempts for the request
+            response: The response of the previous attempt
+        """
+        # Call the underlying retry options if the response is not defined or if the response is not a too many requests response (status code: 429)
+        if response is None or response.status != 429 or self.RETRY_AFTER_HEADER not in response.headers:
+            return self._wrapped_retry_options.get_timeout(attempt, response)
+
+        # Return the pause specified in the Retry-After header
+        return int(response.headers["Retry-After"])

--- a/Trellix/client/retry.py
+++ b/Trellix/client/retry.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from aiohttp_retry import RetryOptionsBase
 from aiohttp import ClientResponse
 
@@ -13,7 +15,7 @@ class RetryWithRateLimiter(RetryOptionsBase):
     def __init__(self, retry_options: RetryOptionsBase):
         self._wrapped_retry_options = retry_options
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return getattr(self._wrapped_retry_options, name)
 
     def get_timeout(self, attempt: int, response: ClientResponse | None = None) -> float:

--- a/Trellix/client/token_refresher.py
+++ b/Trellix/client/token_refresher.py
@@ -160,6 +160,15 @@ class TrellixTokenRefresher(object):
 
             await self._schedule_token_refresh(self._token.token.expires_in)
 
+    def _compute_refresh_time(self, expires_in: int) -> int:
+        """
+        Compute a refresh intervale with a safety margin
+        This margin is depends on the refresh interval and a maximum of five minutes.
+        The refresh interval is a minimum of 30 seconds
+        """
+        delta = min(300, int(expires_in / 6))
+        return max(30, expires_in - delta)
+
     async def _schedule_token_refresh(self, expires_in: int) -> None:
         """
         Schedule token refresh.
@@ -170,7 +179,7 @@ class TrellixTokenRefresher(object):
         await self.close()
 
         async def _refresh() -> None:
-            await asyncio.sleep(expires_in)
+            await asyncio.sleep(self._compute_refresh_time(expires_in))
             await self.refresh_token()
 
         self._token_refresh_task = asyncio.create_task(_refresh())

--- a/Trellix/manifest.json
+++ b/Trellix/manifest.json
@@ -56,5 +56,5 @@
   "name": "Trellix",
   "uuid": "888071f8-1456-11ee-be56-0242ac120002",
   "slug": "trellix",
-  "version": "1.8.3"
+  "version": "1.8.4"
 }

--- a/Trellix/poetry.lock
+++ b/Trellix/poetry.lock
@@ -162,6 +162,20 @@ yarl = ">=1.0,<2.0"
 speedups = ["Brotli", "aiodns", "brotlicffi"]
 
 [[package]]
+name = "aiohttp-retry"
+version = "2.8.3"
+description = "Simple retry client for aiohttp"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "aiohttp_retry-2.8.3-py3-none-any.whl", hash = "sha256:3aeeead8f6afe48272db93ced9440cf4eda8b6fd7ee2abb25357b7eb28525b45"},
+    {file = "aiohttp_retry-2.8.3.tar.gz", hash = "sha256:9a8e637e31682ad36e1ff9f8bcba912fcfc7d7041722bc901a4b948da4d71ea9"},
+]
+
+[package.dependencies]
+aiohttp = "*"
+
+[[package]]
 name = "aioitertools"
 version = "0.11.0"
 description = "itertools and builtins for AsyncIO and mixed iterables"
@@ -2908,4 +2922,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "0dd321521e64575f30bb02f531a1dc5ea365618f74d8085050375631f99ba05b"
+content-hash = "176937bc458df6ff12915d30ad4e04003cd302519cb8d5e55f146b418d801f00"

--- a/Trellix/pyproject.toml
+++ b/Trellix/pyproject.toml
@@ -12,6 +12,7 @@ sekoia-automation-sdk = { version = "^1.13.0", extras = ["all"] }
 async-lru = "^2.0.2"
 aiohttp = "^3.8.5"
 aiolimiter = "^1.1.0"
+aiohttp-retry = "^2.8.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/Trellix/tests/client/test_http_client.py
+++ b/Trellix/tests/client/test_http_client.py
@@ -1,5 +1,7 @@
 """Tests for http client."""
 
+from unittest.mock import patch
+
 import orjson
 import pytest
 from aioresponses import aioresponses
@@ -359,3 +361,55 @@ async def test_trellix_http_client_retry(
         result = await http_client.get_edr_alerts(results_start_date, results_limit)
 
         assert result == expected_result
+
+
+@pytest.mark.asyncio
+async def test_trellix_http_client_api_limit_exhausted(
+    session_faker: Faker, http_token: HttpToken, edr_alert_event_response: TrellixResponse[EdrAlertAttributes]
+):
+    """
+    Test get edr alert events.
+
+    Args:
+        session_faker: Faker
+        http_token: HttpToken
+        edr_alert_event_response: TrellixResponse[EdrAlertAttributes]
+    """
+    with aioresponses() as mocked_responses:
+        base_url = session_faker.uri()
+        base_auth_url = session_faker.uri()
+        client_id = session_faker.word()
+        client_secret = session_faker.word()
+        api_key = session_faker.word()
+
+        results_limit = session_faker.pyint()
+        results_start_date = session_faker.date_time()
+
+        http_client = await TrellixHttpClient.instance(
+            client_id,
+            client_secret,
+            api_key,
+            base_auth_url,
+            base_url,
+        )
+
+        token_refresher = await http_client._get_token_refresher(Scope.threats_set_of_scopes())
+
+        mocked_responses.post(token_refresher.auth_url, status=200, payload=http_token.dict())
+
+        expected_result = [edr_alert_event_response.dict() for _ in range(0, session_faker.pyint(max_value=100))]
+
+        url = http_client.edr_alerts_url(results_start_date, limit=results_limit)
+        mocked_responses.get(url, status=429, headers={"Retry-After": "300"})
+        mocked_responses.get(
+            http_client.edr_alerts_url(results_start_date, limit=results_limit),
+            status=200,
+            payload={
+                "data": orjson.loads(orjson.dumps(expected_result).decode("utf-8")),
+            },
+        )
+        with patch("asyncio.sleep") as mock_sleep:
+            result = await http_client.get_edr_alerts(results_start_date, results_limit)
+
+            assert result == expected_result
+            mock_sleep.assert_called_once_with(300)

--- a/Trellix/tests/client/test_retry.py
+++ b/Trellix/tests/client/test_retry.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock
+
+from client.retry import RetryWithRateLimiter
+
+
+def test_retry_with_success_request_should_call_underlying_retry_options():
+    retry_options = MagicMock()
+    attempt = 1
+    response = MagicMock()
+    response.status = 200
+    retry = RetryWithRateLimiter(retry_options=retry_options)
+
+    retry.get_timeout(1, response)
+    assert retry_options.get_timeout.called
+
+
+def test_retry_none_response_should_call_underlying_retry_options():
+    retry_options = MagicMock()
+    attempt = 1
+    response = None
+    retry = RetryWithRateLimiter(retry_options=retry_options)
+
+    retry.get_timeout(1, response)
+    assert retry_options.get_timeout.called
+
+
+def test_retry_without_retry_after_should_call_underlying_retry_options():
+    retry_options = MagicMock()
+    attempt = 1
+    response = MagicMock()
+    response.status = 429
+    response.headers = {}
+    retry = RetryWithRateLimiter(retry_options=retry_options)
+
+    retry.get_timeout(1, response)
+    assert retry_options.get_timeout.called
+
+
+def test_retry_with_exhausted_limit_should_wait_retry_after():
+    retry_options = MagicMock()
+    attempt = 1
+    response = MagicMock()
+    response.status = 429
+    response.headers = {"Retry-After": 250}
+    retry = RetryWithRateLimiter(retry_options=retry_options)
+
+    time_to_sleep = retry.get_timeout(1, response)
+    assert not retry_options.get_timeout.called
+    assert time_to_sleep == 250


### PR DESCRIPTION
- add a safety margin when refreshing the token
- Add retries on HTTP errors
- Handle 429 HTTP responses