### PR TITLE
ThinkstCanary: Set version number to 1.0.0

### DIFF
--- a/ThinkstCanary/CHANGELOG.md
+++ b/ThinkstCanary/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2024-07-30 - 1.0.0
+
+### Added
+
+- Initial version of the connector

--- a/ThinkstCanary/manifest.json
+++ b/ThinkstCanary/manifest.json
@@ -20,5 +20,5 @@
   "name": "Thinkst Canary",
   "slug": "thinkst-canary",
   "uuid": "cf24fdfe-d132-4b83-9fad-d1658818e0c3",
-  "version": "0.1.0"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
and fix the way to compute the events lag (specially when no events were forwarded)