### PR TITLE
Remove need for a configuration for Sekoia modules

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-08-02 - 2.63.0
+
+### Changed
+
+- No need for a configuration for all Sekoia.io modules
+
 ## 2024-07-23 - 2.62.1
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -1,21 +1,7 @@
 {
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-      "api_key": {
-        "description": "Sekoia.io API key",
-        "type": "string"
-      },
-      "base_url": {
-        "description": "Sekoia.io base URL (ex. https://api.sekoia.io)",
-        "type": "string",
-        "format": "uri"
-      }
-    },
-    "required": [
-      "api_key",
-      "base_url"
-    ],
+    "properties": {},
     "title": "Sekoia.io Configuration",
     "type": "object",
     "secrets": [
@@ -26,5 +12,5 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.62.1"
+  "version": "2.63.0"
 }


### PR DESCRIPTION
To achieve internal/automatic configuration of the Sekoia.io modules, they have to *not* require a configuration from the user.
Their configuration elements have been removed.
This configuration will be created and linked to the module in Symphony API but won't be accessible to the user.
Only the `secrets` field has been kept in order to encrypt the relevant field when it will be automatically created.

Parent task: [#58166](https://github.com/SekoiaLab/platform/issues/58166)