### PR TITLE
SentinelOne: Fix the usage of the cursor in the connector

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-08-07 - 1.17.2
+
+### Changed
+
+- externalize the method to get the most recent date seen from the events
+
+### Fixed
+
+- fix the interactions with the context to be thread-safe
+- use the most recent date seen when query new events
+
 ## 2024-08-06 - 1.17.1
 
 ### Changed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -20,5 +20,5 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.17.1"
+  "version": "1.17.2"
 }

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -63,7 +63,7 @@ class SentinelOneLogsConsumer(Thread):
         return Management(hostname=self.module.configuration.hostname, api_token=self.module.configuration.api_token)
 
     @property
-    def _cache_last_event_date(self) -> datetime:
+    def most_recent_date_seen(self) -> datetime:
         """
         Get last event date.
 
@@ -74,7 +74,7 @@ class SentinelOneLogsConsumer(Thread):
         one_day_ago = (now - timedelta(days=1)).replace(microsecond=0)
 
         with self.context as cache:
-            last_event_date_str = cache.get("last_event_date")
+            last_event_date_str = cache.get("most_recent_date_seen")
 
         # If undefined, retrieve events from the last 1 hour
         if last_event_date_str is None:
@@ -191,7 +191,7 @@ class SentinelOneActivityLogsConsumer(SentinelOneLogsConsumer):
             latest_event_timestamp = get_latest_event_timestamp(activities.data)
             if latest_event_timestamp is not None:
                 with self.context as cache:
-                    cache["last_event_date"] = latest_event_timestamp.isoformat()
+                    cache["most_recent_date_seen"] = latest_event_timestamp.isoformat()
                 EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="activities").set(
                     (datetime.now(UTC) - latest_event_timestamp).total_seconds()
                 )
@@ -232,7 +232,7 @@ class SentinelOneThreatLogsConsumer(SentinelOneLogsConsumer):
             latest_event_timestamp = get_latest_event_timestamp(threats.data)
             if latest_event_timestamp is not None:
                 with self.context as cache:
-                    cache["last_event_date"] = latest_event_timestamp.isoformat()
+                    cache["most_recent_date_seen"] = latest_event_timestamp.isoformat()
 
                 EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="threats").set(
                     (datetime.now(UTC) - latest_event_timestamp).total_seconds()

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -206,7 +206,7 @@ class SentinelOneActivityLogsConsumer(SentinelOneLogsConsumer):
             latest_event_timestamp = get_latest_event_timestamp(activities.data)
             if latest_event_timestamp is not None:
                 self.most_recent_date_seen = latest_event_timestamp
-                current_lag = (datetime.now(UTC) - latest_event_timestamp).total_seconds()
+                current_lag = int((datetime.now(UTC) - latest_event_timestamp).total_seconds())
 
             EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="activities").set(current_lag)
 
@@ -250,7 +250,7 @@ class SentinelOneThreatLogsConsumer(SentinelOneLogsConsumer):
             latest_event_timestamp = get_latest_event_timestamp(threats.data)
             if latest_event_timestamp is not None:
                 self.most_recent_date_seen = latest_event_timestamp
-                current_lag = (datetime.now(UTC) - latest_event_timestamp).total_seconds()
+                current_lag = int((datetime.now(UTC) - latest_event_timestamp).total_seconds())
 
             EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="threats").set(current_lag)
 

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -202,16 +202,13 @@ class SentinelOneActivityLogsConsumer(SentinelOneLogsConsumer):
             )
 
             # Update context with latest event date
+            current_lag: int = 0
             latest_event_timestamp = get_latest_event_timestamp(activities.data)
             if latest_event_timestamp is not None:
                 self.most_recent_date_seen = latest_event_timestamp
+                current_lag = (datetime.now(UTC) - latest_event_timestamp).total_seconds()
 
-                EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="activities").set(
-                    (datetime.now(UTC) - latest_event_timestamp).total_seconds()
-                )
-
-            else:
-                EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="activities").set(0)
+            EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="activities").set(current_lag)
 
             if activities.pagination["nextCursor"] is None:
                 break
@@ -249,16 +246,13 @@ class SentinelOneThreatLogsConsumer(SentinelOneLogsConsumer):
             OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key, datasource="sentinelone").inc(nb_threats)
 
             # Update context with the latest event date
+            current_lag: int = 0
             latest_event_timestamp = get_latest_event_timestamp(threats.data)
             if latest_event_timestamp is not None:
                 self.most_recent_date_seen = latest_event_timestamp
+                current_lag = (datetime.now(UTC) - latest_event_timestamp).total_seconds()
 
-                EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="threats").set(
-                    (datetime.now(UTC) - latest_event_timestamp).total_seconds()
-                )
-
-            else:
-                EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="threats").set(0)
+            EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="threats").set(current_lag)
 
             if threats.pagination["nextCursor"] is None:
                 break

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -28,7 +28,7 @@ class SentinelOneLogsConsumer(Thread):
     Each endpoint of SentinelOne logs API is consumed in its own separate thread.
     """
 
-    def __init__(self, connector: "SentinelOneLogsConnector"):
+    def __init__(self, connector: "SentinelOneLogsConnector",  consumer_type: str):
         super().__init__()
 
         self.context = PersistentJSON("context.json", connector._data_path)
@@ -37,6 +37,7 @@ class SentinelOneLogsConsumer(Thread):
         self.configuration = connector.configuration
         self.connector = connector
         self.module = connector.module
+        self.consumer_type = consumer_type
 
         self._stop_event = Event()
 
@@ -165,6 +166,9 @@ class SentinelOneLogsConsumer(Thread):
 
 
 class SentinelOneActivityLogsConsumer(SentinelOneLogsConsumer):
+    def __init__(self, connector: "SentinelOneLogsConnector"):
+        super().__init__(connector, "activity")
+
     def pull_events(self) -> list:
         """Fetches activities from SentinelOne"""
         # Set  filters
@@ -213,6 +217,9 @@ class SentinelOneActivityLogsConsumer(SentinelOneLogsConsumer):
 
 
 class SentinelOneThreatLogsConsumer(SentinelOneLogsConsumer):
+    def __init__(self, connector: "SentinelOneLogsConnector"):
+        super().__init__(connector, "threat")
+
     def pull_events(self):
         """Fetches threats from SentinelOne"""
         query_filter = ThreatQueryFilter()

--- a/SentinelOne/sentinelone_module/logs/helpers.py
+++ b/SentinelOne/sentinelone_module/logs/helpers.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from management.mgmtsdk_v2.entities.activity import Activity
+from management.mgmtsdk_v2.entities.threat import Threat
+
+
+def get_latest_event_timestamp(events: list[Activity | Threat | dict]) -> datetime | None:
+    """Searches for the most recent timestamp from a list of events
+
+    Args:
+        events (list[Activity | Threat | dict]): List of events to
+
+    Returns:
+        datetime: Timestamp of the most recent event of the list
+    """
+    latest_event_datetime: datetime | None = None
+    for event in events:
+        event_dict = event if isinstance(event, dict) else event.__dict__
+        if event_dict.get("createdAt") is not None:
+            if latest_event_datetime is None:
+                latest_event_datetime = datetime.fromisoformat(event_dict["createdAt"])
+            else:
+                event_created_at = datetime.fromisoformat(event_dict["createdAt"])
+                if event_created_at > latest_event_datetime:
+                    latest_event_datetime = event_created_at
+
+    return latest_event_datetime

--- a/SentinelOne/tests/logs/test_connector.py
+++ b/SentinelOne/tests/logs/test_connector.py
@@ -22,6 +22,7 @@ class MockResponse:
 def test_pull_activities(activity_consumer, activity_1, activity_2):
     OUTCOMING_EVENTS.labels = MagicMock()
     EVENTS_LAG.labels = MagicMock()
+    most_recent_datetime_seen = datetime.datetime(2024, 1, 23, 11, 6, 34)
 
     # Test timestamp caching
     activity_1.createdAt = None
@@ -29,7 +30,7 @@ def test_pull_activities(activity_consumer, activity_1, activity_2):
     response_1 = MockResponse(pagination={"nextCursor": "foo"}, data=[activity_1])
     response_2 = MockResponse(pagination={"nextCursor": None}, data=[activity_2])
     activity_consumer.management_client.activities.get.side_effect = [response_1, response_2]
-    activity_consumer.pull_events()
+    activity_consumer.pull_events(most_recent_datetime_seen)
 
     assert activity_consumer.management_client.activities.get.call_count == 2
     assert activity_consumer.connector.push_events_to_intakes.call_args_list == [
@@ -52,11 +53,12 @@ def test_pull_activities(activity_consumer, activity_1, activity_2):
 def test_pull_threats(threat_consumer, threat_1, threat_2):
     OUTCOMING_EVENTS.labels = MagicMock()
     EVENTS_LAG.labels = MagicMock()
+    most_recent_datetime_seen = datetime.datetime(2024, 1, 23, 11, 6, 34)
 
     response_1 = MockResponse(pagination={"nextCursor": "foo"}, data=[threat_1])
     response_2 = MockResponse(pagination={"nextCursor": None}, data=[threat_2])
     threat_consumer.management_client.client.get.side_effect = [response_1, response_2]
-    threat_consumer.pull_events()
+    threat_consumer.pull_events(most_recent_datetime_seen)
 
     assert threat_consumer.management_client.client.get.call_count == 2
     assert threat_consumer.connector.push_events_to_intakes.call_args_list == [

--- a/SentinelOne/tests/logs/test_connector.py
+++ b/SentinelOne/tests/logs/test_connector.py
@@ -45,7 +45,9 @@ def test_pull_activities(activity_consumer, activity_1, activity_2):
         intake_key=activity_consumer.configuration.intake_key, type="activities"
     ).set.call_args_list == [
         call(0),
-        call((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(activity_2.createdAt)).total_seconds()),
+        call(
+            int((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(activity_2.createdAt)).total_seconds())
+        ),
     ]
 
 
@@ -72,8 +74,8 @@ def test_pull_threats(threat_consumer, threat_1, threat_2):
     assert EVENTS_LAG.labels(
         intake_key=threat_consumer.configuration.intake_key, type="threats"
     ).set.call_args_list == [
-        call((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(threat_1.createdAt)).total_seconds()),
-        call((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(threat_2.createdAt)).total_seconds()),
+        call(int((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(threat_1.createdAt)).total_seconds())),
+        call(int((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(threat_2.createdAt)).total_seconds())),
     ]
 
 

--- a/SentinelOne/tests/logs/test_connector.py
+++ b/SentinelOne/tests/logs/test_connector.py
@@ -43,7 +43,7 @@ def test_pull_activities(activity_consumer, activity_1, activity_2):
     assert EVENTS_LAG.labels(
         intake_key=activity_consumer.configuration.intake_key, type="activities"
     ).set.call_args_list == [
-        call(86400),  # nb of seconds in a day
+        call(0),
         call((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(activity_2.createdAt)).total_seconds()),
     ]
 

--- a/SentinelOne/tests/logs/test_helpers.py
+++ b/SentinelOne/tests/logs/test_helpers.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+
+from management.mgmtsdk_v2.entities.activity import Activity
+from management.mgmtsdk_v2.entities.threat import Threat
+import pytest
+
+from sentinelone_module.logs.helpers import get_latest_event_timestamp
+
+
+@pytest.mark.parametrize(
+    "events,expected_datetime",
+    [
+        (
+            [
+                Activity(createdAt="2024-07-21T11:23:48Z"),
+                Activity(createdAt="2024-07-25T02:30:11Z"),
+                Activity(createdAt="2024-07-22T14:56:11Z"),
+            ],
+            datetime(2024, 7, 25, 2, 30, 11, tzinfo=timezone.utc),
+        ),
+        (
+            [
+                Threat(createdAt="2024-07-21T11:23:48Z"),
+                Threat(createdAt="2024-07-25T02:30:11Z"),
+                Threat(createdAt="2024-07-22T14:56:11Z"),
+            ],
+            datetime(2024, 7, 25, 2, 30, 11, tzinfo=timezone.utc),
+        ),
+        (
+            [
+                dict(createdAt="2024-07-21T11:23:48Z"),
+                dict(createdAt="2024-07-25T02:30:11Z"),
+                dict(createdAt="2024-07-22T14:56:11Z"),
+            ],
+            datetime(2024, 7, 25, 2, 30, 11, tzinfo=timezone.utc),
+        ),
+        ([{}, {}, {}], None),
+        ([], None),
+    ],
+)
+def test_get_lastest_event_timestamp(events, expected_datetime):
+    assert get_latest_event_timestamp(events) == expected_datetime


### PR DESCRIPTION
## 1. Use the most recent date seen when query new events 

Currently, the connector doesn't use the most recent date seen to query new events.
So we always collect the same events

## 2. Fix the interactions with the context to be thread-safe

The context is used by two threads for the collect of events. However, it wasn't thread-safe and each thread could erase the progression of the other thread

## 3. externalize the method to get the most recent date seen from the events

Externalize the method to add test and simplify its maintenance