### PR TITLE
SentinelOne: filter collected events

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-08-08 - 1.17.3
+
+### Changed
+
+- filter events to discard already collected ones
+
 ## 2024-08-07 - 1.17.2
 
 ### Changed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -20,5 +20,5 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.17.2"
+  "version": "1.17.3"
 }

--- a/SentinelOne/poetry.lock
+++ b/SentinelOne/poetry.lock
@@ -160,6 +160,17 @@ filecache = ["filelock (>=3.8.0)"]
 redis = ["redis (>=2.10.5)"]
 
 [[package]]
+name = "cachetools"
+version = "5.4.0"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.4.0-py3-none-any.whl", hash = "sha256:3ae3b49a3d5e28a77a0be2b37dbcb89005058959cb2323858c2657c4a8cab474"},
+    {file = "cachetools-5.4.0.tar.gz", hash = "sha256:b8adc2e7c07f105ced7bc56dbb6dfbe7c4a00acce20e2227b3f355be89bc6827"},
+]
+
+[[package]]
 name = "certifi"
 version = "2023.11.17"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2248,4 +2259,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "71de2ecf9e9ba17ffe1a20c12a4776de7c5b4b50356d58536059af811b5ede51"
+content-hash = "6dcd5f2f119d889e433eeceefcb267ced85c9e9ce2200b41a74a0476429bef39"

--- a/SentinelOne/pyproject.toml
+++ b/SentinelOne/pyproject.toml
@@ -13,6 +13,7 @@ confluent-kafka = "^2.1.1"
 certifi = "^2023.7.22"
 protobuf = "^4.21.9"
 structlog = "^24.4.0"
+cachetools = "^5.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/SentinelOne/sentinelone_module/logs/helpers.py
+++ b/SentinelOne/sentinelone_module/logs/helpers.py
@@ -1,5 +1,7 @@
 from datetime import datetime
+from typing import Sequence, Callable
 
+from cachetools import Cache
 from management.mgmtsdk_v2.entities.activity import Activity
 from management.mgmtsdk_v2.entities.threat import Threat
 
@@ -25,3 +27,27 @@ def get_latest_event_timestamp(events: list[Activity | Threat | dict]) -> dateti
                     latest_event_datetime = event_created_at
 
     return latest_event_datetime
+
+
+def filter_collected_events(events: Sequence, getter: Callable, cache: Cache) -> list:
+    """
+    Filter events that have already been filter_collected_events
+
+    Args:
+        events: The list of events to filter
+        getter: The callable to get the criteria to filter the events
+        cache: The cache that hold the list of collected events
+    """
+
+    selected_events = []
+    for event in events:
+        key = getter(event)
+
+        # If the event was already collected, discard it
+        if key is None or key in cache:
+            continue
+
+        cache[key] = True
+        selected_events.append(event)
+
+    return selected_events

--- a/SentinelOne/tests/logs/test_helpers.py
+++ b/SentinelOne/tests/logs/test_helpers.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timezone
 
+from cachetools import LRUCache
 from management.mgmtsdk_v2.entities.activity import Activity
 from management.mgmtsdk_v2.entities.threat import Threat
 import pytest
 
-from sentinelone_module.logs.helpers import get_latest_event_timestamp
+from sentinelone_module.logs.helpers import get_latest_event_timestamp, filter_collected_events
 
 
 @pytest.mark.parametrize(
@@ -40,3 +41,33 @@ from sentinelone_module.logs.helpers import get_latest_event_timestamp
 )
 def test_get_lastest_event_timestamp(events, expected_datetime):
     assert get_latest_event_timestamp(events) == expected_datetime
+
+
+@pytest.mark.parametrize(
+    "events,getter,cache,expected_list",
+    [
+        (
+            ["key1", "key2", "key3", "key2", "key4"],
+            lambda x: x,
+            LRUCache(maxsize=256),
+            ["key1", "key2", "key3", "key4"],
+        ),
+        ([], lambda x: x, LRUCache(maxsize=256), []),
+        (["key1", "key2", "key3", "key4"], lambda x: x, LRUCache(maxsize=256), ["key1", "key2", "key3", "key4"]),
+        (
+            [
+                {"name": "key1"},
+                {"name": "key2"},
+                {"name": "key3"},
+                {"name": "key1"},
+                {"name": "key4"},
+                {"key": "key5"},
+            ],
+            lambda x: x.get("name"),
+            LRUCache(maxsize=256),
+            [{"name": "key1"}, {"name": "key2"}, {"name": "key3"}, {"name": "key4"}],
+        ),
+    ],
+)
+def test_filter_collected_events(events, getter, cache, expected_list):
+    assert filter_collected_events(events, getter, cache) == expected_list


### PR DESCRIPTION
Filter the events in order to discard already collected ones. We use a LRU cache to save temporary the identifier of the last colllected events.