### PR TITLE
feat(Sekoia.io): Enforce default and limit from manifests

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-08-12 - 2.64.0
+
+### Changed
+
+- Enforce default and limit specified in action manifests
+
 ## 2024-08-02 - 2.63.0
 
 ### Changed

--- a/Sekoia.io/action_get_event_field_common_values.json
+++ b/Sekoia.io/action_get_event_field_common_values.json
@@ -28,7 +28,7 @@
         "type": "number",
         "description": "Maximum number of events to retrieve",
 	"minimum": 1,
-	"default": 20,
+	"default": 100,
 	"maximum": 100
       }
     },

--- a/Sekoia.io/action_get_events.json
+++ b/Sekoia.io/action_get_events.json
@@ -24,7 +24,7 @@
         "type": "number",
         "description": "Maximum number of events to retrieve",
 	"minimum": 1,
-	"default": 20,
+	"default": 100,
 	"maximum": 100
       }
     },

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,5 +12,5 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.63.0"
+  "version": "2.64.0"
 }

--- a/Sekoia.io/sekoiaio/operation_center/base_get_event.py
+++ b/Sekoia.io/sekoiaio/operation_center/base_get_event.py
@@ -15,6 +15,9 @@ class BaseGetEvents(Action):
     http_session: Session
     events_api_path: str
 
+    DEFAULT_LIMIT = 100
+    MAX_LIMIT = 100
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/Sekoia.io/sekoiaio/operation_center/get_event_field_common_values.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_event_field_common_values.py
@@ -9,7 +9,7 @@ class GetEventFieldCommonValues(BaseGetEvents):
             query=arguments["query"],
             earliest_time=arguments["earliest_time"],
             latest_time=arguments["latest_time"],
-            limit=arguments.get("limit"),
+            limit=min(self.MAX_LIMIT, arguments.get("limit") or self.DEFAULT_LIMIT),
         )
 
         self.wait_for_search_job_execution(event_search_job_uuid=event_search_job_uuid)

--- a/Sekoia.io/tests/operation_center_action/test_get_events.py
+++ b/Sekoia.io/tests/operation_center_action/test_get_events.py
@@ -132,7 +132,7 @@ def test_not_events_found(requests_mock):
     requests_mock.get(
         (
             "https://fake.url/api/v1/sic/conf/events/search/jobs/"
-            "483d36a5-8538-49c4-be19-49b669f90bf8/events?limit=1000&offset=0"
+            "483d36a5-8538-49c4-be19-49b669f90bf8/events?limit=100&offset=0"
         ),
         json={
             "items": [],
@@ -168,7 +168,7 @@ def test_not_events_found_but_total(requests_mock):
     requests_mock.get(
         (
             "https://fake.url/api/v1/sic/conf/events/search/jobs/"
-            "483d36a5-8538-49c4-be19-49b669f90bf8/events?limit=1000&offset=0"
+            "483d36a5-8538-49c4-be19-49b669f90bf8/events?limit=100&offset=0"
         ),
         json={
             "items": [],


### PR DESCRIPTION
A default limit was not applied on the first query when it was not provided in the arguments. 
Also the max in the code was set to `1 000` and in the manifest it was `100`. I updated the code to reflect the manifest, but we can pass it to `1 000` if you feel `100` is too low

This PR also raise the default limit to `100`. 