### PR TITLE
SentinelOne: fix connector

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-08-26 - 1.17.4
+
+### Fixed
+
+- handle threats as a dictionary, instead of an object
+- declare batch_duration variable
+
 ## 2024-08-08 - 1.17.3
 
 ### Changed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -20,5 +20,5 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.17.3"
+  "version": "1.17.4"
 }

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -246,7 +246,7 @@ class SentinelOneThreatLogsConsumer(SentinelOneLogsConsumer):
             logger.debug("Collected nb_threats", nb=nb_threats)
 
             # discard already collected events
-            selected_events = filter_collected_events(threats.data, lambda threat: threat.id, self.events_cache)
+            selected_events = filter_collected_events(threats.data, lambda threat: threat["id"], self.events_cache)
 
             # Push events
             if len(selected_events) > 0:

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -123,6 +123,7 @@ class SentinelOneLogsConsumer(Thread):
     def next_batch(self):
         # save the starting time
         batch_start_time = time()
+        batch_duration: int = 0
 
         try:
             # get the batch

--- a/SentinelOne/tests/conftest.py
+++ b/SentinelOne/tests/conftest.py
@@ -107,17 +107,19 @@ def activity_2():
 
 @pytest.fixture
 def threat_1():
-    threat = Threat()
-    threat.createdAt = "2021-03-09T13:03:22.026416Z"
-    threat.id = (str(random.randint(0, 1000000)),)
+    threat = dict(
+        createdAt="2021-03-09T13:03:22.026416Z",
+        id=(str(random.randint(0, 1000000)),),
+    )
     yield threat
 
 
 @pytest.fixture
 def threat_2():
-    threat = Threat()
-    threat.createdAt = "2021-03-09T15:41:54.448862Z"
-    threat.id = (str(random.randint(0, 1000000)),)
+    threat = dict(
+        createdAt="2021-03-09T15:41:54.448862Z",
+        id=(str(random.randint(0, 1000000)),),
+    )
     yield threat
 
 

--- a/SentinelOne/tests/logs/test_connector.py
+++ b/SentinelOne/tests/logs/test_connector.py
@@ -91,8 +91,12 @@ def test_pull_threats(threat_consumer, threat_1, threat_2):
     assert EVENTS_LAG.labels(
         intake_key=threat_consumer.configuration.intake_key, type="threats"
     ).set.call_args_list == [
-        call(int((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(threat_1.createdAt)).total_seconds())),
-        call(int((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(threat_2.createdAt)).total_seconds())),
+        call(
+            int((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(threat_1["createdAt"])).total_seconds())
+        ),
+        call(
+            int((datetime.datetime.now(UTC) - datetime.datetime.fromisoformat(threat_2["createdAt"])).total_seconds())
+        ),
     ]
 
 


### PR DESCRIPTION
- Handle threats as a dict (and not an object with properties).
- declare `batch_duration` as we use it to compute the pause.