### PR TITLE
AWS/Azure: change the way to monitor the age of messages

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-09-20 - 1.31.6
+
+### Changed
+
+- Change the way to monitor the age of messages
+
 ## 2024-09-11 - 1.31.5
 
 ### Fixed

--- a/AWS/connectors/__init__.py
+++ b/AWS/connectors/__init__.py
@@ -11,7 +11,7 @@ from sekoia_automation.aio.helpers.aws.client import AwsClient, AwsConfiguration
 from sekoia_automation.connector import DefaultConnectorConfiguration
 from sekoia_automation.module import Module
 
-from .metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, OUTCOMING_EVENTS, AVERAGE_MESSAGES_AGE, OLDER_MESSAGE_AGE
+from .metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, OUTCOMING_EVENTS, MESSAGES_AGE
 
 
 class AwsModuleConfiguration(BaseModel):
@@ -78,8 +78,6 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
                 while self.running:
                     processing_start = time.time()
                     current_lag: int = 0
-                    avg_lag: int = 0
-                    max_lag: int = 0
 
                     batch_result: tuple[list[str], list[int]] = loop.run_until_complete(self.next_batch())
                     message_ids, messages_timestamp = batch_result
@@ -102,15 +100,15 @@ class AbstractAwsConnector(AsyncConnector, metaclass=ABCMeta):
                             int(processing_end - message_timestamp / 1000) for message_timestamp in messages_timestamp
                         ]
                         current_lag = min(messages_age)
-                        avg_lag = int(sum(messages_age) / len(messages_age))
-                        max_lag = max(messages_age)
+
+                        for age in messages_age:
+                            MESSAGES_AGE.labels(intake_key=self.configuration.intake_key).observe(age)
                     else:
                         self.log(message="No records to forward", level="info")
+                        MESSAGES_AGE.labels(intake_key=self.configuration.intake_key).observe(0)
 
                     # report the current lag
                     EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(current_lag)
-                    AVERAGE_MESSAGES_AGE.labels(intake_key=self.configuration.intake_key).set(avg_lag)
-                    OLDER_MESSAGE_AGE.labels(intake_key=self.configuration.intake_key).set(max_lag)
 
                     # compute the remaining sleeping time. If greater than 0 and no messages were fetched, sleep
                     delta_sleep = self.configuration.frequency - batch_duration

--- a/AWS/connectors/metrics.py
+++ b/AWS/connectors/metrics.py
@@ -37,7 +37,7 @@ EVENTS_LAG = Gauge(
 
 MESSAGES_AGE = Histogram(
     name="messages_age",
-    documentation="The average age of messages seen",
+    documentation="The age of messages seen",
     namespace=prom_aws_namespace,
     labelnames=["intake_key"],
 )

--- a/AWS/connectors/metrics.py
+++ b/AWS/connectors/metrics.py
@@ -3,13 +3,14 @@
 from prometheus_client import Counter, Gauge, Histogram
 
 # Declare common prometheus metrics
+prom_aws_namespace = "symphony_module_aws"
 prom_namespace = "symphony_module_common"
 
 
 INCOMING_EVENTS = Counter(
     name="collected_events",
     documentation="Number of collected events from AWS S3",
-    namespace=prom_namespace,
+    namespace=prom_aws_namespace,
     labelnames=["intake_key"],
 )
 
@@ -34,16 +35,9 @@ EVENTS_LAG = Gauge(
     labelnames=["intake_key"],
 )
 
-AVERAGE_MESSAGES_AGE = Gauge(
-    name="average_messages_age",
+MESSAGES_AGE = Histogram(
+    name="messages_age",
     documentation="The average age of messages seen",
-    namespace=prom_namespace,
-    labelnames=["intake_key"],
-)
-
-OLDER_MESSAGE_AGE = Gauge(
-    name="older_message_age",
-    documentation="The age of the older message seen",
-    namespace=prom_namespace,
+    namespace=prom_aws_namespace,
     labelnames=["intake_key"],
 )

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,5 +29,5 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.31.5"
+  "version": "1.31.6"
 }

--- a/Azure/CHANGELOG.md
+++ b/Azure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-09-20 - 2.5.4
+
+### Changed
+
+- Change the way to monitor the age of messages
+
 ## 2024-08-01 - 2.5.3
 
 ### Added

--- a/Azure/connectors/metrics.py
+++ b/Azure/connectors/metrics.py
@@ -3,12 +3,13 @@
 from prometheus_client import Counter, Gauge, Histogram
 
 # Declare common prometheus metrics
+prom_azure_namespace = "symphony_module_azure"
 prom_namespace = "symphony_module_common"
 
 INCOMING_MESSAGES = Counter(
     name="collected_messages",
     documentation="Number of messages consumed from the event_hub",
-    namespace=prom_namespace,
+    namespace=prom_azure_namespace,
     labelnames=["intake_key"],
 )
 
@@ -33,16 +34,9 @@ EVENTS_LAG = Gauge(
     labelnames=["intake_key"],
 )
 
-AVERAGE_MESSAGES_AGE = Gauge(
-    name="average_messages_age",
-    documentation="The average age of messages seen",
-    namespace=prom_namespace,
-    labelnames=["intake_key"],
-)
-
-OLDER_MESSAGE_AGE = Gauge(
-    name="older_message_age",
-    documentation="The age of the older message seen",
-    namespace=prom_namespace,
+MESSAGES_AGE = Gauge(
+    name="messages_age",
+    documentation="The age of messages seen",
+    namespace=prom_azure_namespace,
     labelnames=["intake_key"],
 )

--- a/Azure/manifest.json
+++ b/Azure/manifest.json
@@ -8,5 +8,5 @@
   "name": "Microsoft Azure",
   "uuid": "525eecc0-9eee-484d-92bd-039117cf4dac",
   "slug": "azure",
-  "version": "2.5.3"
+  "version": "2.5.4"
 }


### PR DESCRIPTION
Use a histogram to monitor the age of SQS notifications for AWS and the age of messages for Azure Event Hub