### PR TITLE
Azure: close correctly the client when stopping

### DIFF
--- a/Azure/CHANGELOG.md
+++ b/Azure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-09-25 - 2.5.5
+
+### Fix
+
+- Close correctly the EventHub client when stopping the connector
+
 ## 2024-09-20 - 2.5.4
 
 ### Changed

--- a/Azure/connectors/azure_eventhub.py
+++ b/Azure/connectors/azure_eventhub.py
@@ -185,7 +185,11 @@ class AzureEventsHubTrigger(AsyncConnector):
 
                     except Exception as ex:
                         self.log_exception(ex, message="Failed to consume messages")
+                        self.client.close()
                         raise ex
 
             except Exception as error:
                 self.log_exception(error, message="Failed to forward events")
+
+        self.log(message="Azure EventHub Trigger is stopping", level="info")
+        self.client.close()

--- a/Azure/manifest.json
+++ b/Azure/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Azure",
   "uuid": "525eecc0-9eee-484d-92bd-039117cf4dac",
   "slug": "azure",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "categories": [
     "Cloud Providers"
   ]


### PR DESCRIPTION
Close the Eventhub client when the connector is stopping (in order to finalize properly the connection).