### PR TITLE
AWS: 

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-10-24 - 1.31.7
+
+### Fixed
+
+- Fix the parameter `skip_first` for the AWS VPC Flowlogs trigger and connector to not collect the CSV header
+
 ## 2024-09-20 - 1.31.6
 
 ### Changed

--- a/AWS/connector_s3_flowlogs.json
+++ b/AWS/connector_s3_flowlogs.json
@@ -27,7 +27,7 @@
       "skip_first": {
         "type": "integer",
         "description": "The number of records to skip at the begining of each S3 object (default: 0)",
-        "default": 0
+        "default": 1
       },
       "ignore_comments": {
         "type": "boolean",

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,7 +29,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.31.6",
+  "version": "1.31.7",
   "categories": [
     "Cloud Providers"
   ]

--- a/AWS/trigger_s3_flowlogs.json
+++ b/AWS/trigger_s3_flowlogs.json
@@ -27,7 +27,7 @@
       "skip_first": {
         "type": "integer",
         "description": "The number of records to skip at the begining of each S3 object (default: 0)",
-        "default": 0
+        "default": 1
       },
       "ignore_comments": {
         "type": "boolean",


### PR DESCRIPTION
Fix the parameter `skip_first` for the AWS VPC Flowlogs trigger and connector to not collect the CSV header from the objects