### PR TITLE
VadeSecure: Stop the trigger when failing to authenticate

### DIFF
--- a/VadeSecure/CHANGELOG.md
+++ b/VadeSecure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-10-29 - 1.51.1
+
+### Fixed
+
+- Stop the trigger if it fail to authenticate
+
 ## 2024-05-28 - 1.51.0
 
 ### Changed

--- a/VadeSecure/manifest.json
+++ b/VadeSecure/manifest.json
@@ -36,7 +36,7 @@
   "name": "Vade Secure",
   "uuid": "1411df5b-5de1-40bd-a988-725cfe692aff",
   "slug": "vadesecure",
-  "version": "1.51.0",
+  "version": "1.51.1",
   "categories": [
     "Email"
   ]

--- a/VadeSecure/vadesecure_modules/trigger_m365_events.py
+++ b/VadeSecure/vadesecure_modules/trigger_m365_events.py
@@ -60,9 +60,10 @@ class M365EventsTrigger(Trigger):
 
         except requests.exceptions.HTTPError as error:
             response = error.response
+            level = "critical" if response.status_code in [401, 403] else "error"
             self.log(
                 f"OAuth2 server responded {response.status_code} - {response.reason}",
-                level="error",
+                level=level,
             )
             raise error
 


### PR DESCRIPTION
When the trigger fails to authenticate against the Vade API, log the message as critical in order to stop the trigger after 5 fails