### PR TITLE
VadeCloud: Stop connector on authentication errors

### DIFF
--- a/VadeCloud/CHANGELOG.md
+++ b/VadeCloud/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-10-29 - 1.5.1
+
+### Fixed
+
+- Stop the trigger if it fail to authenticate 
+
 ## 2024-05-28 - 1.5.0
 
 ### Changed

--- a/VadeCloud/manifest.json
+++ b/VadeCloud/manifest.json
@@ -31,7 +31,7 @@
   "name": "Vade Cloud",
   "slug": "vade-cloud",
   "uuid": "203d043e-a1ea-4b5c-81ef-6fc0f8a6a9d3",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "categories": [
     "Network"
   ]


### PR DESCRIPTION
Log as critical, any authentication error. This will stop the connector after 5 failures