### PR TITLE
Tehtris: change the fitler for duplicated events

### DIFF
--- a/Tehtris/CHANGELOG.md
+++ b/Tehtris/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2024-05-30 - 1.15.2
+## 2024-10-22 - 1.15.2
 
 ### Fixed
 

--- a/Tehtris/CHANGELOG.md
+++ b/Tehtris/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-10-30 - 1.15.3
+
+### Fixed
+
+- Fix the filter that removes duplicated events.
+
 ## 2024-10-22 - 1.15.2
 
 ### Fixed

--- a/Tehtris/manifest.json
+++ b/Tehtris/manifest.json
@@ -29,7 +29,7 @@
   "name": "TEHTRIS",
   "uuid": "1528d749-d353-4e38-ab1b-6e01d7595569",
   "slug": "tehtris",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "categories": [
     "Endpoint"
   ]

--- a/Tehtris/tehtris_modules/trigger_tehtris_events.py
+++ b/Tehtris/tehtris_modules/trigger_tehtris_events.py
@@ -90,8 +90,8 @@ class TehtrisEventConnector(Connector):
         Returns:
             list[dict[str, Any]]:
         """
-        result = [event for event in events if event["uid"] not in self.events_cache]
-        self.events_cache.update({event["uid"]: None for event in result})
+        result = [event for event in events if event["id"] not in self.events_cache]
+        self.events_cache.update({event["id"]: None for event in result})
 
         return result
 

--- a/Tehtris/tests/test_tehtris_event_trigger.py
+++ b/Tehtris/tests/test_tehtris_event_trigger.py
@@ -64,7 +64,7 @@ def message(event_id: int) -> dict[str, Any]:
         "uuid__": "3be682e9-5568-4dbf-8e2d-5b36159945da",
         "path": "C:\\Windows\\System32\\cmd.exe",
         "tag": "YBE_PDT_WIN",
-        "uid": f"{event_id};windows;HOST01;example.org",
+        "uid": "65470575-d8d5-4c54-80ca-a5e33c7e3dbe;windows;HOST01;example.org",
         "os__": "windows",
         "os_architecture__": "x86_64",
         "hostname__": "HOST01",
@@ -178,16 +178,11 @@ def test_fetch_events_without_duplicates(trigger, message1, message2):
 
         result_first = next(trigger.fetch_events())
         assert [event["id"] for event in result_first] == [1, 2, 3]
-        assert [event["uid"] for event in result_first] == [
-            "1;windows;HOST01;example.org",
-            "2;windows;HOST01;example.org",
-            "3;windows;HOST01;example.org",
-        ]
 
         assert trigger.events_cache == {
-            "1;windows;HOST01;example.org": None,
-            "2;windows;HOST01;example.org": None,
-            "3;windows;HOST01;example.org": None,
+            1: None,
+            2: None,
+            3: None,
         }
 
         mock.get(
@@ -199,10 +194,6 @@ def test_fetch_events_without_duplicates(trigger, message1, message2):
         result_second = next(trigger.fetch_events())
 
         assert [event["id"] for event in result_second] == [4, 5]
-        assert [event["uid"] for event in result_second] == [
-            "4;windows;HOST01;example.org",
-            "5;windows;HOST01;example.org",
-        ]
         assert len(result_second) == 2
 
 


### PR DESCRIPTION
The `uid` is not unique and discard too many events. Use `id` instead.