### PR TITLE
Office365: Reduce to 7 days the catch back in the past

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-11-04 - 2.18.1
+
+### Fixed
+
+- Reduce to 7 days the catch back in the past
+
 ## 2024-10-30 - 2.18.0
 
 ### Changed

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "categories": [
     "Applicative"
   ]

--- a/Office365/office365/management_api/checkpoint.py
+++ b/Office365/office365/management_api/checkpoint.py
@@ -19,10 +19,10 @@ class Checkpoint:
                 most_recent_date_seen_str = self._context.read_text()
                 most_recent_date_seen = isoparse(most_recent_date_seen_str)
 
-                # check if the date is older than the 30 days ago
-                thirty_days_ago = now - timedelta(days=30)
-                if most_recent_date_seen < thirty_days_ago:
-                    most_recent_date_seen = thirty_days_ago
+                # check if the date is older than the 7 days ago
+                one_week_ago = now - timedelta(days=7)
+                if most_recent_date_seen < one_week_ago:
+                    most_recent_date_seen = one_week_ago
             except Exception:
                 # if not defined, set the most recent date seen to now
                 most_recent_date_seen = now

--- a/Office365/tests/management_api/test_checkpoint.py
+++ b/Office365/tests/management_api/test_checkpoint.py
@@ -53,9 +53,9 @@ def test_checkpoint_greater_than_30_days(symphony_storage, checkpoint, intake_ke
         mock_datetime.now.return_value = now
         mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
 
-        # Timedelta is sligthly less than 30 days since a few microseconds elapsed between `now`
+        # Timedelta is sligthly less than 7 days since a few microseconds elapsed between `now`
         # and the moment `last_pull_date` is generated
-        assert (now - checkpoint.offset).days == 30
+        assert (now - checkpoint.offset).days == 7
 
 
 def test_checkpoint_save_last_date(symphony_storage, checkpoint, intake_key):


### PR DESCRIPTION
Reduce to 7 days the catch back in the past as the API only support 7 days.
```
{"error":{"code":"AF20055","message":"Start time and end time must both be specified (or both omitted) and must be less than or equal to 24 hours apart, with the start time prior to end time and start time no more than 7 days in the past. StartTime:2024-10-05T10:27:13.619091+00:00, EndTime:2024-10-05T10:57:13.619091+00:00"}}
```