### PR TITLE
Microsoft 365 Defender: fix determination

### DIFF
--- a/MicrosoftDefender/action_update_alert.json
+++ b/MicrosoftDefender/action_update_alert.json
@@ -32,22 +32,22 @@
         ]
       },
       "determination": {
-        "description": "Determination of the alert",
+        "description": "Determination of the alert.\nThe determination must match the classification (see https://learn.microsoft.com/en-us/defender-endpoint/api/update-alert)",
         "type": "string",
         "enum": [
-          "Multistage attack",
-          "Malicious user activity",
-          "Compromised account",
+          "MultiStagedAttack",
+          "MaliciousUserActivity",
+          "CompromisedUser",
           "Malware",
           "Phishing",
-          "Unwanted software",
+          "UnwantedSoftware",
 
-          "Security test",
-          "Line-of-business application",
-          "Confirmed activity",
+          "SecurityTesting",
+          "LineOfBusinessApplication",
+          "ConfirmedActivity",
 
-          "Not malicious",
-          "Not enough data to validate",
+          "NotMalicious",
+          "InsufficientData",
 
           "Other"
         ]

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -41,5 +41,5 @@
   "name": "MicrosoftDefender",
   "slug": "microsoft-defender",
   "uuid": "ce491d8d-87a8-45af-a7c5-ede98c4a4ba3",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
- Fix the values for the determination.
- Add a comment about the mapping between the classification and the determination.