### PR TITLE
VadeSecure: fix connector declaration

### DIFF
--- a/VadeSecure/CHANGELOG.md
+++ b/VadeSecure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-11-15 - 1.52.1
+
+### Fixed
+
+- Fix the declaration of the connector
+
 ## 2024-11-04 - 1.52.0
 
 ### Added

--- a/VadeSecure/connector_m365_events.json
+++ b/VadeSecure/connector_m365_events.json
@@ -41,7 +41,6 @@
     "required": [
       "frequency",
       "tenant_id",
-      "intake_server",
       "intake_key"
     ],
     "title": "M365 Events",

--- a/VadeSecure/manifest.json
+++ b/VadeSecure/manifest.json
@@ -36,7 +36,7 @@
   "name": "Vade Secure",
   "uuid": "1411df5b-5de1-40bd-a988-725cfe692aff",
   "slug": "vadesecure",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "categories": [
     "Email"
   ]


### PR DESCRIPTION
Remove intake_server from the required properties. This requirement blocks the creation of the intake :shrug: 