### PR TITLE
SentinelOne: fix the way to compute the url of the tenant.

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-12-03 - 1.19.1
+
+### Fixed
+
+- Fix the way to compute the address of the tenant in the SentinelOne Singularity Identity connector
+
 ## 2024-11-30 - 1.19.0
 
 ### Added

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -22,7 +22,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/singularity/client.py
+++ b/SentinelOne/sentinelone_module/singularity/client.py
@@ -49,7 +49,7 @@ class SingularityClient(object):
     async def _session(self) -> AsyncGenerator[Client, None]:
         if self._client is None:
             transport = AIOHTTPTransport(
-                url=urljoin(self.hostname, "web/api/v2.1/unifiedalerts/graphql"),
+                url=urljoin(f"https://{self.hostname}", "web/api/v2.1/unifiedalerts/graphql"),
                 headers={"Authorization": f"Bearer {self.api_token}"},
             )
 

--- a/SentinelOne/tests/singularity/test_client.py
+++ b/SentinelOne/tests/singularity/test_client.py
@@ -14,7 +14,7 @@ def api_token():
 
 @pytest.fixture
 def hostname():
-    return "http://testhost"
+    return "testhost"
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ async def test_session(mock_limiter, mock_client, mock_transport, client):
         pass
 
     mock_transport.assert_called_once_with(
-        url=f"{client.hostname}/web/api/v2.1/unifiedalerts/graphql",
+        url=f"https://{client.hostname}/web/api/v2.1/unifiedalerts/graphql",
         headers={"Authorization": f"Bearer {client.api_token}"},
     )
     mock_client.assert_called_once_with(transport=mock_transport_instance)


### PR DESCRIPTION
The module configuration accepts the hostname of the tenant, not the base url. Fix it.