### PR TITLE
SentinelOne: handle Timeout exception

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-12-10 - 1.19.7
+
+### Changed
+
+- Handle the timeout exception
+
 ## 2024-12-10 - 1.19.6
 
 ### Fixed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.19.6",
+  "version": "1.19.7",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/singularity/connectors.py
+++ b/SentinelOne/sentinelone_module/singularity/connectors.py
@@ -125,7 +125,7 @@ class AbstractSingularityConnector(AsyncConnector, ABC):
                 self.log(message=error.message, level="critical")
                 await asyncio.sleep(self.configuration.frequency)
 
-            except Timeout as error:
+            except TimeoutError as error:
                 self.log(message="A timeout was raised by the client", level="warning")
                 await asyncio.sleep(self.configuration.frequency)
 

--- a/SentinelOne/sentinelone_module/singularity/connectors.py
+++ b/SentinelOne/sentinelone_module/singularity/connectors.py
@@ -125,6 +125,10 @@ class AbstractSingularityConnector(AsyncConnector, ABC):
                 self.log(message=error.message, level="critical")
                 await asyncio.sleep(self.configuration.frequency)
 
+            except Timeout as error:
+                self.log(message="A timeout was raised by the client", level="warning")
+                await asyncio.sleep(self.configuration.frequency)
+
             except Exception as error:
                 self.log_exception(error)
                 await asyncio.sleep(self.configuration.frequency)


### PR DESCRIPTION
Intercept the Timeout exception that can be raised time to time.
Handle it as a normal event.