### PR TITLE
SentinelOne: fix the pagination

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-12-13 - 1.19.8
+
+### Fixed
+
+- Fix the pagination system in the SentinelOne Singularity connector
+
 ## 2024-12-10 - 1.19.7
 
 ### Changed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.19.7",
+  "version": "1.19.8",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/singularity/client.py
+++ b/SentinelOne/sentinelone_module/singularity/client.py
@@ -14,7 +14,7 @@ from graphql import ExecutionResult
 from pydantic import BaseModel
 
 
-requests_logger.setLevel(int(os.getenv("GQL_LOG_LEVEL", logging.WARNING))) # Warning level by default
+requests_logger.setLevel(int(os.getenv("GQL_LOG_LEVEL", logging.WARNING)))  # Warning level by default
 
 
 class ListAlertsResult(BaseModel):

--- a/SentinelOne/sentinelone_module/singularity/client.py
+++ b/SentinelOne/sentinelone_module/singularity/client.py
@@ -1,3 +1,5 @@
+import logging
+import os
 from contextlib import asynccontextmanager
 from posixpath import join as urljoin
 from typing import Any, AsyncGenerator
@@ -7,8 +9,12 @@ from aiolimiter import AsyncLimiter
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from gql.transport.exceptions import TransportServerError
+from gql.transport.requests import log as requests_logger
 from graphql import ExecutionResult
 from pydantic import BaseModel
+
+
+requests_logger.setLevel(int(os.getenv("GQL_LOG_LEVEL", logging.WARNING))) # Warning level by default
 
 
 class ListAlertsResult(BaseModel):

--- a/SentinelOne/tests/singularity/test_connectors.py
+++ b/SentinelOne/tests/singularity/test_connectors.py
@@ -46,7 +46,7 @@ def patch_connector(
         return {
             "alerts": {
                 "totalCount": 0,
-                "pageInfo": {"endCursor": "cursor-1", "hasNextPage": False},
+                "pageInfo": {"endCursor": None, "hasNextPage": False},
                 "edges": [{"node": alert}, {"node": alert}],
             }
         }


### PR DESCRIPTION
- Reduce the verbosity of the GQL client in the logs
- Fix the pagination in the Singularity connector.