### PR TITLE
SentinelOne: Fix the start_time

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-12-16 - 1.19.9
+
+### Changed
+
+- discard already collected alerts in the singularity connector
+
+### Fixed
+
+- Fix the start_time parameter into milliseconds in the singularity connector
+
 ## 2024-12-13 - 1.19.8
 
 ### Fixed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.19.8",
+  "version": "1.19.9",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/helpers.py
+++ b/SentinelOne/sentinelone_module/helpers.py
@@ -2,8 +2,10 @@ import re
 import secrets
 import string
 from datetime import UTC, datetime
+from typing import Callable, Sequence
 
 import six
+from cachetools import Cache
 from stix2patterns.pattern import Pattern
 
 
@@ -79,3 +81,27 @@ def stix_to_indicators(stix_object, supported_types_map):
             results.append({"type": ioc_type, "value": ioc_value})
 
     return results
+
+
+def filter_collected_events(events: Sequence, getter: Callable, cache: Cache) -> list:
+    """
+    Filter events that have already been filter_collected_events
+
+    Args:
+        events: The list of events to filter
+        getter: The callable to get the criteria to filter the events
+        cache: The cache that hold the list of collected events
+    """
+
+    selected_events = []
+    for event in events:
+        key = getter(event)
+
+        # If the event was already collected, discard it
+        if key is None or key in cache:
+            continue
+
+        cache[key] = True
+        selected_events.append(event)
+
+    return selected_events

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -18,8 +18,9 @@ from sekoia_automation.storage import PersistentJSON
 from sentinelone_module.base import SentinelOneModule
 from sentinelone_module.logging import get_logger
 from sentinelone_module.logs.configuration import SentinelOneLogsConnectorConfiguration
-from sentinelone_module.logs.helpers import filter_collected_events, get_latest_event_timestamp
+from sentinelone_module.logs.helpers import get_latest_event_timestamp
 from sentinelone_module.logs.metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, INCOMING_MESSAGES, OUTCOMING_EVENTS
+from sentinelone_module.helpers import filter_collected_events
 
 logger = get_logger()
 

--- a/SentinelOne/sentinelone_module/logs/helpers.py
+++ b/SentinelOne/sentinelone_module/logs/helpers.py
@@ -1,7 +1,5 @@
 from datetime import datetime
-from typing import Callable, Sequence
 
-from cachetools import Cache
 from management.mgmtsdk_v2.entities.activity import Activity
 from management.mgmtsdk_v2.entities.threat import Threat
 
@@ -27,27 +25,3 @@ def get_latest_event_timestamp(events: list[Activity | Threat | dict]) -> dateti
                     latest_event_datetime = event_created_at
 
     return latest_event_datetime
-
-
-def filter_collected_events(events: Sequence, getter: Callable, cache: Cache) -> list:
-    """
-    Filter events that have already been filter_collected_events
-
-    Args:
-        events: The list of events to filter
-        getter: The callable to get the criteria to filter the events
-        cache: The cache that hold the list of collected events
-    """
-
-    selected_events = []
-    for event in events:
-        key = getter(event)
-
-        # If the event was already collected, discard it
-        if key is None or key in cache:
-            continue
-
-        cache[key] = True
-        selected_events.append(event)
-
-    return selected_events

--- a/SentinelOne/sentinelone_module/singularity/connectors.py
+++ b/SentinelOne/sentinelone_module/singularity/connectors.py
@@ -60,7 +60,7 @@ class AbstractSingularityConnector(AsyncConnector, ABC):
 
         # Set up parameters
         last_event_date = self.last_event_date.offset
-        start_time = int(last_event_date.timestamp())
+        start_time = int(last_event_date.timestamp() * 1000)  # convert the event date into a timestamp in millisecond
         cursor: str | None = None
         has_more_items: bool = True
 

--- a/SentinelOne/tests/logs/test_helpers.py
+++ b/SentinelOne/tests/logs/test_helpers.py
@@ -1,11 +1,10 @@
 from datetime import datetime, timezone
 
 import pytest
-from cachetools import LRUCache
 from management.mgmtsdk_v2.entities.activity import Activity
 from management.mgmtsdk_v2.entities.threat import Threat
 
-from sentinelone_module.logs.helpers import filter_collected_events, get_latest_event_timestamp
+from sentinelone_module.logs.helpers import get_latest_event_timestamp
 
 
 @pytest.mark.parametrize(
@@ -41,33 +40,3 @@ from sentinelone_module.logs.helpers import filter_collected_events, get_latest_
 )
 def test_get_lastest_event_timestamp(events, expected_datetime):
     assert get_latest_event_timestamp(events) == expected_datetime
-
-
-@pytest.mark.parametrize(
-    "events,getter,cache,expected_list",
-    [
-        (
-            ["key1", "key2", "key3", "key2", "key4"],
-            lambda x: x,
-            LRUCache(maxsize=256),
-            ["key1", "key2", "key3", "key4"],
-        ),
-        ([], lambda x: x, LRUCache(maxsize=256), []),
-        (["key1", "key2", "key3", "key4"], lambda x: x, LRUCache(maxsize=256), ["key1", "key2", "key3", "key4"]),
-        (
-            [
-                {"name": "key1"},
-                {"name": "key2"},
-                {"name": "key3"},
-                {"name": "key1"},
-                {"name": "key4"},
-                {"key": "key5"},
-            ],
-            lambda x: x.get("name"),
-            LRUCache(maxsize=256),
-            [{"name": "key1"}, {"name": "key2"}, {"name": "key3"}, {"name": "key4"}],
-        ),
-    ],
-)
-def test_filter_collected_events(events, getter, cache, expected_list):
-    assert filter_collected_events(events, getter, cache) == expected_list

--- a/SentinelOne/tests/singularity/conftest.py
+++ b/SentinelOne/tests/singularity/conftest.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -24,7 +23,7 @@ def mock_push_data_to_intakes() -> AsyncMock:
 
 
 @pytest.fixture
-def sentinel_module(symphony_storage: Path) -> SentinelOneModule:
+def sentinel_module() -> SentinelOneModule:
     """
     Create a SentinelOne module.
 

--- a/SentinelOne/tests/singularity/test_connectors.py
+++ b/SentinelOne/tests/singularity/test_connectors.py
@@ -1,5 +1,6 @@
 import itertools
 import time
+from pathlib import Path
 from multiprocessing import Process
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -16,9 +17,9 @@ class CustomTestConnector(AbstractSingularityConnector):
 
 @pytest.fixture
 def custom_test_connector(
-    sentinel_module: SentinelOneModule, mock_push_data_to_intakes: AsyncMock
+    sentinel_module: SentinelOneModule, symphony_storage: Path, mock_push_data_to_intakes: AsyncMock
 ) -> CustomTestConnector:
-    connector = CustomTestConnector(sentinel_module)
+    connector = CustomTestConnector(module=sentinel_module, data_path=symphony_storage)
     connector.configuration = {
         "intake_key": "test_key",
         "intake_server": "http://test_server.test",


### PR DESCRIPTION
- Convert the start_time into milliseconds (because it's the precision expected by the API)
- Add a cache to discard already collected alerts.