### PR TITLE
Mimecast: Fix Authentication issue

### DIFF
--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-01-15 - 1.1.1
+
+### Fixed
+
+- Initialize the API client in the run method
+
 ## 2024-11-26 - 1.1.0
 
 ### Added

--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "categories": [
     "Email"
   ]


### PR DESCRIPTION
Move the initialization of the authentication in the run method. The resolution of secrets is done just before this method.