### PR TITLE
fix(triage): fix action module to prevent from adding domain port with incorrect pattern

### DIFF
--- a/Triage/CHANGELOG.md
+++ b/Triage/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-02-05 - 1.39.0
+
+### Changed
+
+- Fix a minor bug related to incorrect domain_port format
+
 ## 2025-01-06 - 1.38.0
 
 ### Changed

--- a/Triage/manifest.json
+++ b/Triage/manifest.json
@@ -25,7 +25,7 @@
   "name": "Triage",
   "uuid": "919705ab-7a64-493e-a92b-4049fafea325",
   "slug": "triage",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "categories": [
     "Threat Intelligence"
   ]

--- a/Triage/tests/test_triage_to_observables.py
+++ b/Triage/tests/test_triage_to_observables.py
@@ -331,3 +331,46 @@ def test_get_observables_from_url_without_http(action):
         if item["type"] == "url":
             assert item["value"] == "http://193.233.20.15/dF30Hn4m/index.php"
     assert count["file"] == 1
+
+
+def test_exclude_wrong_domain_port_pattern(action):
+    """ "
+    Make sure the domain:port pattern includes only one port 
+    """
+    arguments = {
+        "triage_raw_results": [
+            {
+                "malware": "xworm",
+                "samples": {
+                    "250205-ep1g8synhz": {
+                        "sample_c2s": ["dvd-crossword.gl.at.ply.gg:43216:43216","dvd-crossword.gl.at.ply.gg:43216"],
+                        "sample_urls": [],
+                        "sample_hashes": [
+                            "0de45ff4c9d8c08551619009eb07265a",
+                            "b16530d8c5d9358e63ec1113e3e22aa80c51102f",
+                            "c68385c8744b3558b7357eccaca2ad45f3089578454fe2fd31e17aff3ff456c3",
+                            "70716ae8d4c0b2d77ab4685b017aa2ed92c56206f8d5cc42793cc83ffed0f2ba"
+                            "d34fc8220ed82d4e0eee641c6b71820b6f4c4f82beba00591b4af6927bf67649",
+                        ],
+                    }
+                },
+            },
+        ]
+    }
+    res = action.run(arguments)
+    print(res)
+    assert "observables" in res
+    assert res["observables"]["type"] == "bundle"
+
+    count = defaultdict(lambda: 0)
+    for item in res["observables"]["objects"]:
+        count[item["type"]] += 1
+
+    assert count["file"] == 1
+    assert count["domain-name"] == 1
+
+    for item in res["observables"]["objects"]:
+        if item["type"] == "domain-name":
+            assert item["value"] == "dvd-crossword.gl.at.ply.gg"
+            assert item["x_inthreat_tags"][0]["port"] == "43216"
+    assert count["file"] == 1

--- a/Triage/triage_modules/action_triage_to_observables.py
+++ b/Triage/triage_modules/action_triage_to_observables.py
@@ -6,8 +6,8 @@ from sekoia_automation.action import Action
 
 from triage_modules.utils import datetime_to_str, IPV4_ADDRESS_REGEX, URL_REGEX
 
-domain_regex = r"\b((?=[a-z0-9-_]{1,63}\.)(xn--)?[a-z0-9]+([-_]+[a-z0-9]+)*\.)+[a-z]{2,63}\b"
-domain_port_regex = r"\b((?=[a-z0-9-_]{1,63}\.)(xn--)?[a-z0-9]+([-_]+[a-z0-9]+)*\.)+[a-z]{2,63}\b:\d{2,5}"
+domain_regex = r"\b((?=[a-z0-9-_]{1,63}\.)(xn--)?[a-z0-9]+([-_]+[a-z0-9]+)*\.)+[a-z]{2,63}\b$"
+domain_port_regex = r"\b((?=[a-z0-9-_]{1,63}\.)(xn--)?[a-z0-9]+([-_]+[a-z0-9]+)*\.)+[a-z]{2,63}\b:\d{2,5}$"
 hash_regex = "^([a-f0-9]{32}|[0-9a-f]{40}|[0-9a-f]{64}|[0-9a-f]{128})$"
 ipv4_port_regex = r"^(?:(?:\d|[01]?\d\d|2[0-4]\d|25[0-5])\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d|\d)(?:\d{1,2})?:\d{2,5}$"
 url_without_scheme = (


### PR DESCRIPTION
## Issue

The Triage analysis https://tria.ge/250205-ep1g8synhz extracted the following C2s:
```
dvd-crossword.gl.at.ply.gg:43216:43216
dvd-crossword.gl.at.ply.gg:43216
```

The first `domain:port:port` pattern was incorrectly processed by the current code:
```
        # when the C2 corresponds to a domain:port
        if re.match(domain_port_regex, c2):
            [c2, port] = c2.split(":")
```
As it partially matches the `domain_port_regex` and then the full string is parsed by `c2.split(":")`.

## Fix

I improved the regex for `domain_regex` and `domain_port_regex` to prevent results that not fully matched the pattern.

To do this, I just added the `$` character at the end of the pattern

I added a test case to avoid any regressions.