### PR TITLE
VadeCloud: Change the way to handle 401 and 500 errors

### DIFF
--- a/VadeCloud/CHANGELOG.md
+++ b/VadeCloud/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-02-28 - 1.5.2
+
+### Changed
+
+- Change the way to handle 401 and 500 HTTP errors when the connector is running
+
 ## 2024-10-29 - 1.5.1
 
 ### Fixed

--- a/VadeCloud/manifest.json
+++ b/VadeCloud/manifest.json
@@ -31,7 +31,7 @@
   "name": "Vade Cloud",
   "slug": "vade-cloud",
   "uuid": "203d043e-a1ea-4b5c-81ef-6fc0f8a6a9d3",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "categories": [
     "Email"
   ]

--- a/VadeCloud/tests/test_vade_cloud_logs_trigger_unitary.py
+++ b/VadeCloud/tests/test_vade_cloud_logs_trigger_unitary.py
@@ -190,10 +190,8 @@ def test_auth_error(trigger: VadeCloudLogsConnector):
             json={"error": {"code": 404, "message": "Not found", "reason": "USER_UNKNOWN", "trKey": "USER_UNKNOWN"}},
         )
 
-        consumer = VadeCloudConsumer(connector=trigger, name="inbound", params={"stream": "Inbound"})
-
         with pytest.raises(requests.exceptions.HTTPError) as context:
-            consumer.next_batch()
+            trigger.create_client()
 
 
 def test_auth_user_invalid(trigger: VadeCloudLogsConnector):
@@ -212,10 +210,8 @@ def test_auth_user_invalid(trigger: VadeCloudLogsConnector):
             json={"error": {"code": 400, "message": "ID specified is not a user account", "trKey": "INVALID_USER"}},
         )
 
-        consumer = VadeCloudConsumer(connector=trigger, name="inbound", params={"stream": "Inbound"})
-
         with pytest.raises(requests.exceptions.HTTPError) as context:
-            consumer.next_batch()
+            trigger.create_client()
 
 
 def test_timeout_error(trigger: VadeCloudLogsConnector):
@@ -234,8 +230,7 @@ def test_timeout_error(trigger: VadeCloudLogsConnector):
         )
 
         with pytest.raises(TimeoutError):
-            consumer = VadeCloudConsumer(connector=trigger, name="inbound", params={"stream": "Inbound"})
-            client = consumer.client  # this will trigger authorization request
+            trigger.create_client()
 
 
 def test_request_with_account_id_administrator(
@@ -247,8 +242,11 @@ def test_request_with_account_id_administrator(
             status_code=200,
             json=auth_message_admin,
         )
+        api_client = trigger.create_client()
 
-        consumer = VadeCloudConsumer(connector=trigger, name="inbound", params={"stream": "Inbound"})
+        consumer = VadeCloudConsumer(
+            connector=trigger, name="inbound", client=api_client, params={"stream": "Inbound"}
+        )
 
         assert consumer.client.account_id == 222
 
@@ -262,8 +260,11 @@ def test_request_with_account_id_quarantine(
             status_code=200,
             json=auth_message_quarantine,
         )
+        api_client = trigger.create_client()
 
-        consumer = VadeCloudConsumer(connector=trigger, name="inbound", params={"stream": "Inbound"})
+        consumer = VadeCloudConsumer(
+            connector=trigger, name="inbound", client=api_client, params={"stream": "Inbound"}
+        )
 
         assert consumer.client.account_id == 7676
 
@@ -296,7 +297,10 @@ def test_request_error(trigger: VadeCloudLogsConnector, auth_message):
             ],
         )
 
-        consumer = VadeCloudConsumer(connector=trigger, name="inbound", params={"stream": "Inbound"})
+        api_client = trigger.create_client()
+        consumer = VadeCloudConsumer(
+            connector=trigger, name="inbound", client=api_client, params={"stream": "Inbound"}
+        )
 
         with pytest.raises(FetchEventException):
             consumer.next_batch()
@@ -330,23 +334,37 @@ def test_fetch_event(trigger: VadeCloudLogsConnector, auth_message, response_mes
         end_time = start_time + batch_duration
         mock_time.time.side_effect = [start_time, end_time, end_time]
 
-        consumer = VadeCloudConsumer(connector=trigger, name="inbound", params={"stream": "Inbound"})
+        api_client = trigger.create_client()
+        consumer = VadeCloudConsumer(
+            connector=trigger, name="inbound", client=api_client, params={"stream": "Inbound"}
+        )
         consumer.next_batch()
 
         assert trigger.push_events_to_intakes.call_count == 1
         mock_time.sleep.assert_called_once_with(44)
 
 
-def test_start_consumers(trigger):
+@pytest.fixture
+def api_client(trigger, auth_message):
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.post(
+            "https://cloud-preview.vadesecure.com/rest/v3.0/login/login",
+            status_code=200,
+            json=auth_message,
+        )
+        return trigger.create_client()
+
+
+def test_start_consumers(trigger, api_client):
     with patch("vadecloud_modules.trigger_vade_cloud_logs.VadeCloudConsumer.start") as mock_start:
-        consumers = trigger.start_consumers()
+        consumers = trigger.start_consumers(client=api_client)
 
         assert "inbound" in consumers
         assert "outbound" in consumers
         assert mock_start.called
 
 
-def test_supervise_consumers(trigger):
+def test_supervise_consumers(trigger, api_client):
     with patch("vadecloud_modules.trigger_vade_cloud_logs.VadeCloudConsumer.start") as mock_start:
         consumers = {
             "param_set_1": Mock(**{"is_alive.return_value": False, "running": True}),
@@ -355,7 +373,7 @@ def test_supervise_consumers(trigger):
             "param_set_4": Mock(**{"is_alive.return_value": False, "running": False}),
         }
 
-        trigger.supervise_consumers(consumers)
+        trigger.supervise_consumers(consumers, client=api_client)
         assert mock_start.call_count == 2
 
 
@@ -375,8 +393,8 @@ def test_stop_consumers(trigger):
         assert offline_consumer.stop.called
 
 
-def test_last_timestamp(trigger: VadeCloudLogsConnector):
-    consumer = VadeCloudConsumer(connector=trigger, name="test", params={})
+def test_last_timestamp(trigger: VadeCloudLogsConnector, api_client):
+    consumer = VadeCloudConsumer(connector=trigger, name="test", client=api_client, params={})
 
     now = int(time.time() * 1000)  # in milliseconds
     ts = now - 10_000

--- a/VadeCloud/vadecloud_modules/trigger_vade_cloud_logs.py
+++ b/VadeCloud/vadecloud_modules/trigger_vade_cloud_logs.py
@@ -94,7 +94,7 @@ class VadeCloudConsumer(Thread):
         if not response.ok:
             message = f"Request on Vade Cloud API to fetch `{self.name}` logs failed with status {response.status_code} - {response.reason}"
 
-            if response.status_code in [401, 403]:
+            if response.status_code == 403:
                 self.log(message=message, level="critical")
             else:
                 try:


### PR DESCRIPTION
Change the way to handle errors from VadeCloud Errors:

- During startup, if we face a 401, 403 or 400 errors, the connector is immediately stopped
- During collect, if we face a 403 error, the connector is immediately stopped
- During collect, if we face a 401 or 500 error, the connector is paused and retry later.