### PR TITLE
VadeSecure: change the way to handle 401 and 500 HTTP erros

### DIFF
--- a/VadeSecure/CHANGELOG.md
+++ b/VadeSecure/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-04 - 1.52.2
+
+### Fixed
+
+- Change the way to handle the 401 and 500 HTTP errors from the Vade Secure API
+
+### Changed
+
+- Change how to pause the trigger between two fetches
+
 ## 2024-11-15 - 1.52.1
 
 ### Fixed

--- a/VadeSecure/manifest.json
+++ b/VadeSecure/manifest.json
@@ -36,7 +36,7 @@
   "name": "Vade Secure",
   "uuid": "1411df5b-5de1-40bd-a988-725cfe692aff",
   "slug": "vadesecure",
-  "version": "1.52.1",
+  "version": "1.52.2",
   "categories": [
     "Email"
   ]

--- a/VadeSecure/tests/test_m365_mixin.py
+++ b/VadeSecure/tests/test_m365_mixin.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, Mock, patch, call
+
+import pytest
+import requests_mock
+
+from vadesecure_modules import VadeSecureModule
+from vadesecure_modules.connector_m365_events import M365EventsConnector
+from vadesecure_modules.m365_mixin import EventType, APIException
+
+
+@pytest.fixture
+def trigger(symphony_storage):
+    module = VadeSecureModule()
+    trigger = M365EventsConnector(module=module, data_path=symphony_storage)
+
+    trigger.module.configuration = {
+        "oauth2_authorization_url": "https://api-test.vadesecure.com/oauth2/v2/token",
+        "api_host": "https://api.vadesecure.com",
+        "client_id": "my-id",
+        "client_secret": "my-password",
+    }
+    trigger.configuration = {
+        "frequency": 604800,
+        "tenant_id": "e49e7162-0df6-48e9-a75e-237d54871e8b",
+        "chunk_size": 1,
+        "intake_key": "INTAKE_KEY",
+    }
+    trigger.push_events_to_intakes = MagicMock()
+    trigger.log = Mock()
+    trigger.log_exception = Mock()
+
+    return trigger
+
+
+def test_fetch_events_with_authentication_error(trigger):
+    trigger.module.configuration.api_host = "https://api-test.vadesecure.com/////"
+    trigger.client.auth.get_authorization = MagicMock(return_value="Bearer 123456")
+    with requests_mock.Mocker() as mock, patch("vadesecure_modules.connector_m365_events.time.sleep"):
+        mock.post(
+            "https://api-test.vadesecure.com/api/v1/tenants/e49e7162-0df6-48e9-a75e-237d54871e8b/logs/emails/search",
+            status_code=401,
+        )
+        with pytest.raises(APIException):
+            trigger._fetch_next_events(
+                last_message_id="1", last_message_date=datetime.utcnow(), event_type=EventType.EMAILS
+            )
+
+
+def test_fetch_events_with_internal_server_error(trigger):
+    trigger.module.configuration.api_host = "https://api-test.vadesecure.com/////"
+    trigger.client.auth.get_authorization = MagicMock(return_value="Bearer 123456")
+    with requests_mock.Mocker() as mock, patch("vadesecure_modules.connector_m365_events.time.sleep"):
+        mock.post(
+            "https://api-test.vadesecure.com/api/v1/tenants/e49e7162-0df6-48e9-a75e-237d54871e8b/logs/emails/search",
+            status_code=500,
+        )
+        with pytest.raises(APIException):
+            trigger._fetch_next_events(
+                last_message_id="1", last_message_date=datetime.utcnow(), event_type=EventType.EMAILS
+            )
+
+
+@pytest.mark.parametrize(
+    "error,expected_message",
+    [
+        (
+            APIException(401, "Unauthorized", "content"),
+            "The VadeCloud API raised an authentication issue. Please check our credentials",
+        ),
+        (
+            APIException(500, "Internal error", "context deadline exceeded"),
+            "The VadeCloud API raised an internal error. Please contact the Vade support if the issue persist",
+        ),
+        (
+            APIException(
+                429,
+                "Too many request",
+                "content",
+            ),
+            "Unexpected API error 429 - Too many request - content",
+        ),
+    ],
+)
+def test_handle_api_exception(trigger: M365EventsConnector, error, expected_message):
+    with requests_mock.Mocker() as mock, patch("vadesecure_modules.connector_m365_events.time.sleep"):
+        trigger.client.auth.get_authorization = MagicMock(return_value="Bearer 123456")
+
+        trigger.handle_api_exception(error)
+        call(
+            level="error",
+            message=expected_message,
+        ) in trigger.log.mock_calls

--- a/VadeSecure/vadesecure_modules/connector_m365_events.py
+++ b/VadeSecure/vadesecure_modules/connector_m365_events.py
@@ -102,12 +102,3 @@ class M365EventsConnector(Connector, M365Mixin):
                 level="debug",
             )  # pragma: no cover
             time.sleep(delta_sleep)
-
-    def run(self) -> None:  # pragma: no cover
-        """Run the trigger."""
-        while self.running:
-            try:
-                self._fetch_events()
-            except Exception as ex:
-                self.log_exception(ex, message="An unknown exception occurred")
-                raise

--- a/VadeSecure/vadesecure_modules/m365_mixin.py
+++ b/VadeSecure/vadesecure_modules/m365_mixin.py
@@ -145,3 +145,12 @@ class M365Mixin(Trigger, ABC):
             )
 
             return result
+
+    def run(self) -> None:  # pragma: no cover
+        """Run the trigger."""
+        while True:
+            try:
+                self._fetch_events()
+            except Exception as ex:
+                self.log_exception(ex, message="An unknown exception occurred")
+                raise

--- a/VadeSecure/vadesecure_modules/trigger_m365_events.py
+++ b/VadeSecure/vadesecure_modules/trigger_m365_events.py
@@ -29,8 +29,6 @@ class M365EventsTrigger(M365Mixin):
                 self.log_exception(ex, message="An unknown exception occurred")
                 raise
 
-            time.sleep(self.configuration.frequency)
-
     def _chunk_events(self, events: Sequence[Any], chunk_size: int) -> Generator[list[Any], None, None]:
         """
         Group events by chunk
@@ -79,6 +77,8 @@ class M365EventsTrigger(M365Mixin):
         Successively queries the m365 events pages while more are available
         and the current batch is not too big.
         """
+        fetch_start_time = time.time()
+
         for event_type in EventType:
             message_batch: Deque[dict[str, Any]] = collections.deque()
             has_more_message = True
@@ -122,3 +122,14 @@ class M365EventsTrigger(M365Mixin):
                     )
 
             self.update_event_type_context(last_message_date, last_message_id, event_type)
+
+        fetch_end_time = time.time()
+        fetch_duration = fetch_end_time - fetch_start_time
+        # compute the remaining sleeping time. If greater than 0, sleep
+        delta_sleep = self.configuration.frequency - fetch_duration
+        if delta_sleep > 0:
+            self.log(
+                message=f"Next batches in the future. Waiting {delta_sleep} seconds",
+                level="debug",
+            )  # pragma: no cover
+            time.sleep(delta_sleep)

--- a/VadeSecure/vadesecure_modules/trigger_m365_events.py
+++ b/VadeSecure/vadesecure_modules/trigger_m365_events.py
@@ -20,15 +20,6 @@ class M365EventsTrigger(M365Mixin):
     - A margin of 300sec is added to the expiration date of oauth2 token.
     """
 
-    def run(self) -> None:  # pragma: no cover
-        """Run the trigger."""
-        while True:
-            try:
-                self._fetch_events()
-            except Exception as ex:
-                self.log_exception(ex, message="An unknown exception occurred")
-                raise
-
     def _chunk_events(self, events: Sequence[Any], chunk_size: int) -> Generator[list[Any], None, None]:
         """
         Group events by chunk


### PR DESCRIPTION
Change the way to handle errors from VadeSecure Errors:

During startup, if we face a 401or 403 errors, the connector is immediately stopped
During collect, if we face a 403 error, the connector is immediately stopped
During collect, if we face a 401 or 500 error, the connector is paused and retry later.