### PR TITLE
AWS: fix issues when reading S3 notification

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-05 - 1.32.5
+
+### Fixed
+
+- Fix typing issue and reset the records list when pushing it
+
 ## 2025-03-04 - 1.32.4
 
 ### Fixed

--- a/AWS/connectors/s3/__init__.py
+++ b/AWS/connectors/s3/__init__.py
@@ -165,7 +165,8 @@ class AbstractAwsS3QueuedConnector(AbstractAwsConnector, metaclass=ABCMeta):
 
                         if len(records) >= self.limit_of_events_to_push:
                             continue_receiving = False
-                            result += await self.push_data_to_intakes(events=records)
+                            result += len(await self.push_data_to_intakes(events=records))
+                            records = []
 
                     except Exception as e:
                         self.log(

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,7 +29,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.32.4",
+  "version": "1.32.5",
   "categories": [
     "Cloud Providers"
   ]


### PR DESCRIPTION
- Fix typing issue: a list (the list of event IDs) cannot be added to an integer (`results`)
- reset the records list when pushing it