### PR TITLE
AWS: Allow to override the number of max messages fetched from the sqs queue

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-05 - 1.32.6
+
+### Changed
+
+- Refactor the way to define the number of max messages fetched from the SQS queue
+
 ## 2025-03-05 - 1.32.5
 
 ### Fixed

--- a/AWS/connectors/s3/__init__.py
+++ b/AWS/connectors/s3/__init__.py
@@ -34,6 +34,7 @@ class AbstractAwsS3QueuedConnector(AbstractAwsConnector, metaclass=ABCMeta):
 
         super().__init__(*args, **kwargs)
         self.limit_of_events_to_push = int(os.getenv("AWS_BATCH_SIZE", 10000))
+        self.sqs_max_messages = int(os.getenv("AWS_SQS_MAX_MESSAGES", 10))
 
     @cached_property
     def s3_wrapper(self) -> S3Wrapper:
@@ -131,7 +132,7 @@ class AbstractAwsS3QueuedConnector(AbstractAwsConnector, metaclass=ABCMeta):
         continue_receiving = True
 
         while continue_receiving:
-            async with self.sqs_wrapper.receive_messages(max_messages=10) as messages:
+            async with self.sqs_wrapper.receive_messages(max_messages=self.sqs_max_messages) as messages:
                 message_records = []
 
                 if not messages:

--- a/AWS/connectors/trigger_sqs_messages.py
+++ b/AWS/connectors/trigger_sqs_messages.py
@@ -30,6 +30,7 @@ class AwsSqsMessagesTrigger(AbstractAwsConnector):
 
         super().__init__(*args, **kwargs)
         self.limit_of_events_to_push = int(os.getenv("AWS_BATCH_SIZE", 10000))
+        self.sqs_max_messages = int(os.getenv("AWS_SQS_MAX_MESSAGES", 10))
 
     @cached_property
     def sqs_wrapper(self) -> SqsWrapper:
@@ -64,7 +65,7 @@ class AwsSqsMessagesTrigger(AbstractAwsConnector):
 
         continue_receiving = True
         while continue_receiving:
-            async with self.sqs_wrapper.receive_messages(max_messages=10) as messages:
+            async with self.sqs_wrapper.receive_messages(max_messages=self.sqs_max_messages) as messages:
                 if not messages:
                     continue_receiving = False
 

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,7 +29,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.32.5",
+  "version": "1.32.6",
   "categories": [
     "Cloud Providers"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce the environment variable AWS_SQS_MAX_MESSAGES to configure the maximum number of messages fetched from the SQS queue.