### PR TITLE
Revert pagination changes

### DIFF
--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2025-01-31 - 1.1.6
-
-### Fixed
-
-- Fixed issue with cursor
-
 ## 2025-01-24 - 1.1.5
 
 ### Changed

--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.6",
+  "version": "1.1.5",
   "categories": [
     "Email"
   ]

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -1,19 +1,20 @@
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from functools import cached_property
 from operator import itemgetter
-from pathlib import Path
 from threading import Event, Lock, Thread
 from typing import Generator
 
 import orjson
 import requests
+from dateutil.parser import isoparse
 from pyrate_limiter import Duration, Limiter, RequestRate
-from sekoia_automation.checkpoint import CheckpointCursor
 from sekoia_automation.connector import Connector, DefaultConnectorConfiguration
+from sekoia_automation.storage import PersistentJSON
 
 from . import MimecastModule
 from .client import ApiClient, ApiKeyAuthentication
-from .helpers import download_batches
+from .helpers import download_batches, get_upper_second
 from .logging import get_logger
 from .metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, INCOMING_MESSAGES, OUTCOMING_EVENTS
 
@@ -33,9 +34,8 @@ class MimecastSIEMWorker(Thread):
         self.log_type: str = log_type
         self.client: ApiClient = client
 
-        self.cursor = CheckpointCursor(
-            path=self.connector.data_path, subkey=self.log_type, lock=self.connector.context_lock
-        )
+        self.context = self.connector.context
+        self.from_date = self.most_recent_date_seen
 
         self._stop_event = Event()
 
@@ -52,21 +52,58 @@ class MimecastSIEMWorker(Thread):
     def running(self):
         return not self._stop_event.is_set()
 
-    def __fetch_next_events(self) -> Generator[list, None, None]:
+    @property
+    def most_recent_date_seen(self):
+        now = datetime.now(timezone.utc)
+
+        self.connector.context_lock.acquire()
+        with self.context as cache:
+            most_recent_date_seen_str = cache.get(self.log_type, {}).get("most_recent_date_seen")
+        self.connector.context_lock.release()
+
+        # if undefined, retrieve events from the last day
+        if most_recent_date_seen_str is None:
+            return now - timedelta(days=1)
+
+        # parse the most recent date seen
+        most_recent_date_seen = isoparse(most_recent_date_seen_str)
+
+        # We don't retrieve messages older than 7 days
+        seven_days_ago = now - timedelta(days=7)
+        if most_recent_date_seen < seven_days_ago:
+            most_recent_date_seen = seven_days_ago
+
+        return most_recent_date_seen
+
+    @most_recent_date_seen.setter
+    def most_recent_date_seen(self, dt: datetime) -> None:
+        self.connector.context_lock.acquire()
+        with self.context as cache:
+            if self.log_type not in cache:
+                cache[self.log_type] = {}
+
+            cache[self.log_type]["most_recent_date_seen"] = dt.isoformat()
+
+        self.connector.context_lock.release()
+
+    @staticmethod
+    def __format_datetime(dt: datetime) -> str:
+        base = dt.strftime("%Y-%m-%dT%H:%M:%S")
+        ms = dt.strftime("%f")[:3]
+        return f"{base}.{ms}Z"
+
+    def __fetch_next_events(self, from_date: datetime) -> Generator[list, None, None]:
+        result_from_date = from_date.astimezone(timezone.utc)
+        one_week_ago = datetime.now(timezone.utc) - timedelta(days=7)
+        if result_from_date < one_week_ago:
+            result_from_date = one_week_ago
+
         url = "https://api.services.mimecast.com/siem/v1/batch/events/cg"
         params: dict[str, int | str] = {
             "pageSize": self.connector.configuration.chunk_size,
             "type": self.log_type,
+            "dateRangeStartsAt": result_from_date.strftime("%Y-%m-%d"),
         }
-
-        if self.cursor.offset is None:
-            # provide date range to start
-            start_at = datetime.today()
-            params["dateRangeStartsAt"] = start_at.strftime("%Y-%m-%d")
-
-        else:
-            params["nextPage"] = self.cursor.offset
-
         response = self.client.get(url, params=params, timeout=60, headers={"Accept": "application/json"})
 
         while self.running:
@@ -74,12 +111,14 @@ class MimecastSIEMWorker(Thread):
 
             result = response.json()
 
-            next_page_token = result.get("@nextPage")
-            self.cursor.offset = next_page_token
-
             batch_urls = [item["url"] for item in result.get("value", [])]
             events = download_batches(urls=batch_urls)
             logger.debug("Collected events", nb_url=len(events))
+
+            # The cursor is a date, not a datetime. Thus, we have to download all events from the
+            # day's start and then filter out all events with timestamps before `from_date`
+            events = [event for event in events if event["timestamp"] > from_date.timestamp() * 1000]
+            logger.debug("Filtered events", nb_url=len(events))
 
             if len(events) > 0:
                 INCOMING_MESSAGES.labels(intake_key=self.connector.configuration.intake_key).inc(len(events))
@@ -89,25 +128,27 @@ class MimecastSIEMWorker(Thread):
                 logger.info("The last page of events was empty", log_type=self.log_type)
                 return
 
-            if result["isCaughtUp"] is True:
+            next_page_token = result.get("@nextPage")
+
+            if not next_page_token:
                 return
 
             params["nextPage"] = next_page_token
             response = self.client.get(url, params=params, timeout=60, headers={"Accept": "application/json"})
 
     def fetch_events(self) -> Generator[list, None, None]:
-        most_recent_date_seen = None  # for measuring lag
+        most_recent_date_seen = self.from_date
         current_lag: int = 0
 
         try:
-            for next_events in self.__fetch_next_events():
+            for next_events in self.__fetch_next_events(most_recent_date_seen):
                 if next_events:
                     # extract latest timestamp
                     last_event = max(next_events, key=lambda x: x.get("timestamp"))
                     last_event_date = datetime.fromtimestamp(last_event["timestamp"] / 1000).astimezone(timezone.utc)
 
-                    if most_recent_date_seen is None or last_event_date > most_recent_date_seen:
-                        most_recent_date_seen = last_event_date
+                    if last_event_date > most_recent_date_seen:
+                        most_recent_date_seen = get_upper_second(last_event_date)  # get the upper second
 
                     yield next_events
 
@@ -138,7 +179,12 @@ class MimecastSIEMWorker(Thread):
 
         finally:
             # save the most recent date
-            if most_recent_date_seen is not None:
+            if most_recent_date_seen > self.from_date:
+                self.from_date = most_recent_date_seen
+
+                # save in context the most recent date seen
+                self.most_recent_date_seen = most_recent_date_seen
+
                 # Update the current lag only if the most_recent_date_seen was updated
                 delta_time = datetime.now(timezone.utc) - most_recent_date_seen
                 current_lag = int(delta_time.total_seconds())
@@ -213,6 +259,8 @@ class MimecastSIEMConnector(Connector):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+
+        self.context = PersistentJSON("context.json", self._data_path)
         self.context_lock = Lock()
 
         # 50 times within a 15 minutes fixed window
@@ -221,10 +269,6 @@ class MimecastSIEMConnector(Connector):
 
         default_rate = RequestRate(limit=20, interval=Duration.MINUTE)
         self.limiter_default = Limiter(default_rate)
-
-    @property
-    def data_path(self) -> Path:
-        return self._data_path
 
     def start_consumers(self, client: ApiClient) -> dict[str, MimecastSIEMWorker]:
         consumers = {}

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from operator import itemgetter
 from pathlib import Path
 from threading import Event, Lock, Thread
@@ -7,11 +7,9 @@ from typing import Generator
 
 import orjson
 import requests
-from dateutil.parser import isoparse
 from pyrate_limiter import Duration, Limiter, RequestRate
 from sekoia_automation.checkpoint import CheckpointCursor
 from sekoia_automation.connector import Connector, DefaultConnectorConfiguration
-from sekoia_automation.storage import PersistentJSON
 
 from . import MimecastModule
 from .client import ApiClient, ApiKeyAuthentication
@@ -35,9 +33,6 @@ class MimecastSIEMWorker(Thread):
         self.log_type: str = log_type
         self.client: ApiClient = client
 
-        # checking on `context.json` before setting up a proper cursor object
-        self.old_cursor = self.get_old_cursor()
-
         self.cursor = CheckpointCursor(
             path=self.connector.data_path, subkey=self.log_type, lock=self.connector.context_lock
         )
@@ -57,38 +52,6 @@ class MimecastSIEMWorker(Thread):
     def running(self):
         return not self._stop_event.is_set()
 
-    def get_old_cursor(self) -> datetime | None:
-        """
-        We previously used datetime as a cursor but later switched to page tokens. To ensure a smooth transition,
-        we still support the old cursor type. On startup, we check if the old cursor is present and, if it is, use it
-        for the first API request instead of defaulting to today's date.
-        """
-        self.connector.context_lock.acquire()
-        with self.connector.context as cache:
-            most_recent_date_seen_str = cache.get(self.log_type, {}).get("most_recent_date_seen")
-
-            # clean up
-            if self.log_type in cache and "most_recent_date_seen" in cache[self.log_type]:
-                del cache[self.log_type]["most_recent_date_seen"]
-
-        self.connector.context_lock.release()
-
-        if most_recent_date_seen_str is None:
-            # there is no datetime cursor
-            return None
-
-        # parse the most recent date seen
-        most_recent_date_seen = isoparse(most_recent_date_seen_str)
-
-        # We don't retrieve messages older than 7 days
-        now = datetime.now(timezone.utc)
-        seven_days_ago = now - timedelta(days=7)
-        if most_recent_date_seen < seven_days_ago:
-            # saved datetime is old, so we can use default workflow anyway
-            return None
-
-        return most_recent_date_seen
-
     def __fetch_next_events(self) -> Generator[list, None, None]:
         url = "https://api.services.mimecast.com/siem/v1/batch/events/cg"
         params: dict[str, int | str] = {
@@ -96,11 +59,7 @@ class MimecastSIEMWorker(Thread):
             "type": self.log_type,
         }
 
-        if self.old_cursor is not None:
-            logger.info("Starting with old datetime cursor", datetime=self.old_cursor.isoformat())
-            params["dateRangeStartsAt"] = self.old_cursor.strftime("%Y-%m-%d")
-
-        elif self.cursor.offset is None:
+        if self.cursor.offset is None:
             # provide date range to start
             start_at = datetime.today()
             params["dateRangeStartsAt"] = start_at.strftime("%Y-%m-%d")
@@ -121,15 +80,6 @@ class MimecastSIEMWorker(Thread):
             batch_urls = [item["url"] for item in result.get("value", [])]
             events = download_batches(urls=batch_urls)
             logger.debug("Collected events", nb_url=len(events))
-
-            if self.old_cursor is not None:
-                # The datetime cursor was actually a date, not a full datetime. Thus, we have to download all
-                # events from the day's start and then filter out all events with timestamps before saved datetime
-                events = [event for event in events if event["timestamp"] > self.old_cursor.timestamp() * 1000]
-                logger.info("Filtered events", nb_url=len(events))
-
-                # We don't need this anymore - it's for the first page only
-                self.old_cursor = None
 
             if len(events) > 0:
                 INCOMING_MESSAGES.labels(intake_key=self.connector.configuration.intake_key).inc(len(events))
@@ -263,7 +213,6 @@ class MimecastSIEMConnector(Connector):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.context = PersistentJSON("context.json", self._data_path)
         self.context_lock = Lock()
 
         # 50 times within a 15 minutes fixed window

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -66,6 +66,11 @@ class MimecastSIEMWorker(Thread):
         self.connector.context_lock.acquire()
         with self.connector.context as cache:
             most_recent_date_seen_str = cache.get(self.log_type, {}).get("most_recent_date_seen")
+
+            # clean up
+            if self.log_type in cache and "most_recent_date_seen" in cache[self.log_type]:
+                del cache[self.log_type]["most_recent_date_seen"]
+
         self.connector.context_lock.release()
 
         if most_recent_date_seen_str is None:
@@ -91,13 +96,11 @@ class MimecastSIEMWorker(Thread):
             "type": self.log_type,
         }
 
-        if self.cursor.offset is None and self.old_cursor is not None:
-            logger.info(
-                "Starting with old datetime cursor", log_type=self.log_type, datetime=self.old_cursor.isoformat()
-            )
+        if self.old_cursor is not None:
+            logger.info("Starting with old datetime cursor", datetime=self.old_cursor.isoformat())
             params["dateRangeStartsAt"] = self.old_cursor.strftime("%Y-%m-%d")
 
-        elif self.cursor.offset is None and self.old_cursor is None:
+        elif self.cursor.offset is None:
             # provide date range to start
             start_at = datetime.today()
             params["dateRangeStartsAt"] = start_at.strftime("%Y-%m-%d")
@@ -117,13 +120,13 @@ class MimecastSIEMWorker(Thread):
 
             batch_urls = [item["url"] for item in result.get("value", [])]
             events = download_batches(urls=batch_urls)
-            logger.debug("Collected events", nb_url=len(events), log_type=self.log_type)
+            logger.debug("Collected events", nb_url=len(events))
 
             if self.old_cursor is not None:
                 # The datetime cursor was actually a date, not a full datetime. Thus, we have to download all
                 # events from the day's start and then filter out all events with timestamps before saved datetime
                 events = [event for event in events if event["timestamp"] > self.old_cursor.timestamp() * 1000]
-                logger.info("Filtered events", nb_url=len(events), log_type=self.log_type)
+                logger.info("Filtered events", nb_url=len(events))
 
                 # We don't need this anymore - it's for the first page only
                 self.old_cursor = None

--- a/Mimecast/mimecast_modules/helpers.py
+++ b/Mimecast/mimecast_modules/helpers.py
@@ -1,10 +1,22 @@
 import asyncio
 import gzip
 import json
+from datetime import datetime, timedelta
 from io import BytesIO
 
 import aiohttp
 import requests
+
+
+def get_upper_second(time: datetime) -> datetime:
+    """
+    Return the upper second from a datetime
+
+    :param datetime time: The starting datetime
+    :return: The upper second of the starting datetime
+    :rtype: datetime
+    """
+    return (time + timedelta(seconds=1)).replace(microsecond=0)
 
 
 async def gather_with_concurrency(n: int, *tasks):

--- a/Mimecast/poetry.lock
+++ b/Mimecast/poetry.lock
@@ -2421,18 +2421,18 @@ jeepney = ">=0.6"
 
 [[package]]
 name = "sekoia-automation-sdk"
-version = "1.18.2"
+version = "1.18.0"
 description = "SDK to create Sekoia.io playbook modules"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "sekoia_automation_sdk-1.18.2-py3-none-any.whl", hash = "sha256:4a54d17948d336b3d3299f1e6bd4988418abe23b82667a7606a3734afc79264c"},
-    {file = "sekoia_automation_sdk-1.18.2.tar.gz", hash = "sha256:12b6e39980ecd8fb2d47566059ac55a782f46357e7d25be1774966b5bc30afe5"},
+    {file = "sekoia_automation_sdk-1.18.0-py3-none-any.whl", hash = "sha256:ab71ed1cbfd4697d8add59803af077422fc20e3cede89dc3db969a54c2c96b89"},
+    {file = "sekoia_automation_sdk-1.18.0.tar.gz", hash = "sha256:b5b6241dc8d5e80f354a4ec3478fc0caeb116a0d1db6fb7f79a0c3f51b2da585"},
 ]
 
 [package.dependencies]
 black = "*"
-boto3 = "<1.36"
+boto3 = ">=1.28,<2.0"
 cookiecutter = ">=2.1,<3.0"
 Jinja2 = ">=3.0.3,<4.0.0"
 jsonschema = ">=4.22.0,<5.0.0"
@@ -3004,4 +3004,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "ad8cffe230dea7dbf170fd3d05c41370797a3a9c7acb032990d8b87ffcb2a109"
+content-hash = "38bae8ca94fdfbaddca84be207b5532fed118410dfbfe4ea06c9fd1cc8614170"

--- a/Mimecast/pyproject.toml
+++ b/Mimecast/pyproject.toml
@@ -7,7 +7,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
-sekoia-automation-sdk = "^1.18.2"
+sekoia-automation-sdk = "^1.18.0"
 requests = "^2.32.3"
 requests-ratelimiter = "^0.7.0"
 python-dateutil = "^2.9.0.post0"
@@ -38,22 +38,5 @@ line_length = 119
 omit = [
     "tests/*",
     "main.py",
-    "dev.py",
+    "dev.py"
 ]
-
-[tool.pytest.ini_options]
-minversion = "6.0"
-testpaths = [
-    "tests",
-]
-addopts = '''
-  --strict-markers
-  --tb=short
-  --cov=mimecast_modules
-  --cov-branch
-  --cache-clear
-  --cov-report=html
-  --cov-report=term-missing:skip-covered
-  --cov-fail-under=5
-  --capture=sys
-'''

--- a/Mimecast/tests/test_helpers.py
+++ b/Mimecast/tests/test_helpers.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+from mimecast_modules.helpers import get_upper_second
+
+
+def test_get_upper_second():
+    starting_datetime = datetime(2022, 12, 11, 23, 45, 26, 208)
+    expected_datetime = datetime(2022, 12, 11, 23, 45, 27)
+
+    assert get_upper_second(starting_datetime) == expected_datetime

--- a/Mimecast/tests/test_mimecast_siem_logs.py
+++ b/Mimecast/tests/test_mimecast_siem_logs.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
@@ -9,6 +10,20 @@ from mimecast_modules import MimecastModule
 from mimecast_modules.client import ApiClient
 from mimecast_modules.client.auth import ApiKeyAuthentication
 from mimecast_modules.connector_mimecast_siem import MimecastSIEMConnector, MimecastSIEMWorker
+
+
+@pytest.fixture
+def fake_time():
+    yield datetime(2024, 5, 1, 11, 59, 59, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def patch_datetime_now(fake_time):
+    with patch("mimecast_modules.connector_mimecast_siem.datetime") as mock_datetime:
+        mock_datetime.now.return_value = fake_time
+        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_datetime.fromtimestamp = lambda ts: datetime.fromtimestamp(ts)
+        yield mock_datetime
 
 
 @pytest.fixture
@@ -53,7 +68,7 @@ def trigger(data_storage, client_id, client_secret):
 
 @pytest.fixture
 def batch_events_response_empty():
-    return {"value": [], "@nextPage": "tokenNextPageLast==", "isCaughtUp": True}
+    return {"value": [], "@nextPage": "tokenNextPageLast=="}
 
 
 @pytest.fixture
@@ -66,7 +81,6 @@ def batch_events_response_1():
                 "expiry": "2024-06-05T11:50:06.389Z",
             }
         ],
-        "isCaughtUp": False,
         "@nextPage": "tokenNextPage1=",
     }
 
@@ -94,7 +108,9 @@ def batch_event_1():
     }
 
 
-def test_fetch_batches(trigger, batch_events_response_1, batch_events_response_empty, batch_event_1, api_client):
+def test_fetch_batches(
+    trigger, patch_datetime_now, batch_events_response_1, batch_events_response_empty, batch_event_1, api_client
+):
     with requests_mock.Mocker() as mock_requests, patch(
         "mimecast_modules.connector_mimecast_siem.download_batches"
     ) as mock_download_batches, patch("mimecast_modules.connector_mimecast_siem.time") as mock_time:
@@ -124,6 +140,11 @@ def test_fetch_batches(trigger, batch_events_response_1, batch_events_response_e
 
         assert trigger.push_events_to_intakes.call_count == 1
         mock_time.sleep.assert_called_once_with(44)
+
+
+def test_most_recent_datetime_seen(trigger, patch_datetime_now, fake_time, api_client):
+    consumer = MimecastSIEMWorker(connector=trigger, log_type="process", client=api_client)
+    assert consumer.most_recent_date_seen == fake_time - timedelta(days=1)
 
 
 def test_start_consumers(trigger, api_client):
@@ -167,7 +188,7 @@ def test_stop_consumers(trigger):
 
 
 def test_authentication_failed(
-    trigger, batch_events_response_1, batch_events_response_empty, batch_event_1, api_client
+    trigger, patch_datetime_now, batch_events_response_1, batch_events_response_empty, batch_event_1, api_client
 ):
     with requests_mock.Mocker() as mock_requests, patch(
         "mimecast_modules.connector_mimecast_siem.download_batches"
@@ -200,7 +221,9 @@ def test_authentication_failed(
         ]
 
 
-def test_permission_denied(trigger, batch_events_response_1, batch_events_response_empty, batch_event_1, api_client):
+def test_permission_denied(
+    trigger, patch_datetime_now, batch_events_response_1, batch_events_response_empty, batch_event_1, api_client
+):
     with requests_mock.Mocker() as mock_requests, patch(
         "mimecast_modules.connector_mimecast_siem.download_batches"
     ) as mock_download_batches, patch("mimecast_modules.connector_mimecast_siem.time") as mock_time:

--- a/Mimecast/tests/test_mimecast_siem_logs.py
+++ b/Mimecast/tests/test_mimecast_siem_logs.py
@@ -293,12 +293,3 @@ def test_old_cursor(
 
         assert consumer.old_cursor is None
         assert consumer.cursor.offset == "tokenNextPageLast=="
-
-        first_batch_request = next(
-            item for item in mock_requests.request_history if "/siem/v1/batch/events/cg" in item.url
-        )
-        fake_date_ymd = fake_date.strftime("%Y-%m-%d")
-        assert (
-            first_batch_request.url == "https://api.services.mimecast.com/siem/v1/batch/events/cg?"
-            f"pageSize=100&type=process&dateRangeStartsAt={fake_date_ymd}"
-        )


### PR DESCRIPTION
Revert changes not yet validated for the memory issue fix

## Summary by Sourcery

Revert recent pagination changes in the Mimecast SIEM connector due to unresolved memory issues and reintroduce previous cursor handling logic. Add a utility function to compute the upper second of a datetime and include a corresponding test for this function.

Bug Fixes:
- Revert changes related to pagination and cursor handling in the Mimecast SIEM connector to address unvalidated memory issues.

Enhancements:
- Introduce a utility function 'get_upper_second' to calculate the upper second of a given datetime.

Tests:
- Add a test for the new 'get_upper_second' function to ensure its correctness.