### PR TITLE
VadeSecure: check credentials at the starting

### DIFF
--- a/VadeSecure/CHANGELOG.md
+++ b/VadeSecure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-14 - 1.52.3
+
+### Fixed
+
+- Check the credentials at the starting of the trigger
+
 ## 2025-03-04 - 1.52.2
 
 ### Fixed

--- a/VadeSecure/manifest.json
+++ b/VadeSecure/manifest.json
@@ -36,7 +36,7 @@
   "name": "Vade Secure",
   "uuid": "1411df5b-5de1-40bd-a988-725cfe692aff",
   "slug": "vadesecure",
-  "version": "1.52.2",
+  "version": "1.52.3",
   "categories": [
     "Email"
   ]

--- a/VadeSecure/tests/test_m365_events_connector.py
+++ b/VadeSecure/tests/test_m365_events_connector.py
@@ -31,6 +31,13 @@ def trigger(symphony_storage):
     trigger.log = Mock()
     trigger.log_exception = Mock()
 
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            trigger.module.configuration.oauth2_authorization_url,
+            json={"token_type": "Bearer", "access_token": "123456", "expires_in": 5},
+        )
+        trigger.client = trigger.create_client()
+
     return trigger
 
 

--- a/VadeSecure/tests/test_m365_events_trigger.py
+++ b/VadeSecure/tests/test_m365_events_trigger.py
@@ -29,6 +29,13 @@ def trigger(symphony_storage):
     trigger.log = Mock()
     trigger.log_exception = Mock()
 
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            trigger.module.configuration.oauth2_authorization_url,
+            json={"token_type": "Bearer", "access_token": "123456", "expires_in": 5},
+        )
+        trigger.client = trigger.create_client()
+
     return trigger
 
 

--- a/VadeSecure/tests/test_m365_mixin.py
+++ b/VadeSecure/tests/test_m365_mixin.py
@@ -30,6 +30,13 @@ def trigger(symphony_storage):
     trigger.log = Mock()
     trigger.log_exception = Mock()
 
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            trigger.module.configuration.oauth2_authorization_url,
+            json={"token_type": "Bearer", "access_token": "123456", "expires_in": 5},
+        )
+        trigger.client = trigger.create_client()
+
     return trigger
 
 

--- a/VadeSecure/vadesecure_modules/client/__init__.py
+++ b/VadeSecure/vadesecure_modules/client/__init__.py
@@ -16,6 +16,7 @@ class ApiClient(requests.Session):
     ) -> None:
         super().__init__()
         self.auth: ApiKeyAuthentication = ApiKeyAuthentication(auth_url, client_id, client_secret)
+        self.auth.authenticate()
 
         rate_limiter = LimiterAdapter(
             per_second=ratelimit_per_second,

--- a/VadeSecure/vadesecure_modules/client/auth.py
+++ b/VadeSecure/vadesecure_modules/client/auth.py
@@ -56,7 +56,7 @@ class ApiKeyAuthentication(AuthBase):
         Returns the access token and uses the OAuth2 to compute it if required
         """
         self.authenticate()
-        return f"{self.__api_credentials['token_type'].title()} {self.__api_credentials['access_token']}"
+        return f"{self.__api_credentials['token_type'].title()} {self.__api_credentials['access_token']}"  # type: ignore
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
         request.headers["Authorization"] = self.get_authorization()

--- a/VadeSecure/vadesecure_modules/client/auth.py
+++ b/VadeSecure/vadesecure_modules/client/auth.py
@@ -25,11 +25,10 @@ class ApiKeyAuthentication(AuthBase):
             ),
         )
 
-    def get_authorization(self) -> str:
+    def authenticate(self) -> None:
         """
-        Returns the access token and uses the OAuth2 to compute it if required
+        Generate or refresh the OAUTH2.0 access token
         """
-
         if (
             self.__api_credentials is None
             or datetime.utcnow() + timedelta(seconds=300) >= self.__api_credentials["expires_in"]
@@ -52,6 +51,11 @@ class ApiKeyAuthentication(AuthBase):
             api_credentials["expires_in"] = current_dt + timedelta(seconds=api_credentials["expires_in"])
             self.__api_credentials = api_credentials
 
+    def get_authorization(self) -> str:
+        """
+        Returns the access token and uses the OAuth2 to compute it if required
+        """
+        self.authenticate()
         return f"{self.__api_credentials['token_type'].title()} {self.__api_credentials['access_token']}"
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:


### PR DESCRIPTION
Check the credentials at the starting of the trigger

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the credentials were not being checked at the start of the trigger.