### PR TITLE
Fix return variable for Get common values module

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-18 - 2.67.7
+
+### Fixed
+
+Fix the return variable for the Get Common Values module
+
 ## 2025-02-04 - 2.67.6
 
 ### Added

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.67.6",
+  "version": "2.67.7",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/get_event_field_common_values.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_event_field_common_values.py
@@ -42,6 +42,6 @@ class GetEventFieldCommonValues(BaseGetEvents):
                 must_continue_in_pages = True
 
         return {
-            "fields": [{"name": field_name, "common_values": field_values}]
-            for field_name, field_values in results.items()
+            "fields": [{"name": field_name, "common_values": field_values}
+            for field_name, field_values in results.items()]
         }

--- a/Sekoia.io/sekoiaio/operation_center/get_event_field_common_values.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_event_field_common_values.py
@@ -42,6 +42,7 @@ class GetEventFieldCommonValues(BaseGetEvents):
                 must_continue_in_pages = True
 
         return {
-            "fields": [{"name": field_name, "common_values": field_values}
-            for field_name, field_values in results.items()]
+            "fields": [
+                {"name": field_name, "common_values": field_values} for field_name, field_values in results.items()
+            ]
         }

--- a/Sekoia.io/tests/operation_center_action/test_get_event_field_common_values.py
+++ b/Sekoia.io/tests/operation_center_action/test_get_event_field_common_values.py
@@ -126,11 +126,24 @@ def test_get_event_field_common_values(requests_mock):
     assert results == {
         "fields": [
             {
+                "common_values": [],
+                "name": "action.id",
+            },
+            {
+                "common_values": [
+                    {
+                        "name": "openssh",
+                        "value": 100.0,
+                    },
+                ],
+                "name": "event.dialect",
+            },
+            {
                 "name": "action.outcome",
                 "common_values": [
                     {"value": 50.0, "name": "False"},
                     {"value": 50.0, "name": "True"},
                 ],
-            }
+            },
         ]
     }


### PR DESCRIPTION
## Summary by Sourcery

Fix the return variable for the Get Common Values module and update the manifest version.

Bug Fixes:
- Fix the return variable for the Get Common Values module to ensure correct data is returned.

Chores:
- Update the manifest version to 2.67.7.