### PR TITLE
chore(HarfangLab): Bump module version

### DIFF
--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -21,6 +21,6 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "categories": ["Endpoint"]
 }


### PR DESCRIPTION
We sometimes have strange errors when trying to run actions from this module:

```
CommandNotFoundError: Could not find any Action or Trigger matching command 'harfanglab_update_threat_status'
CommandNotFoundError: Could not find any Action or Trigger matching command 'harfanglab_add_comment_to_threat'
```

I'm wondering if we may not have an issue with this version.

## Summary by Sourcery

Chores:
- Bump module version from 1.24.0 to 1.25.0.