### PR TITLE
Mimecast: fix pagination

### DIFF
--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-19 - 1.1.8
+
+### Fixed
+
+- Fix the pagination
+
 ## 2025-03-12 - 1.1.7
 
 ### Fixed

--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "categories": [
     "Email"
   ]

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -132,10 +132,11 @@ class MimecastSIEMWorker(Thread):
                     logger.info("The last page of events was empty", log_type=self.log_type)
                     return
 
-            if result["isCaughtUp"] is True:
+            nextPageToken = result.get("@nextPage")
+            if result["isCaughtUp"] is True or not nextPageToken:
                 return
 
-            params["nextPage"] = result.get("@nextPage")
+            params["nextPage"] = nextPageToken
             response = self.client.get(url, params=params, timeout=60, headers={"Accept": "application/json"})
 
     def fetch_events(self) -> Generator[list, None, None]:


### PR DESCRIPTION
Test if nextPage token is defined

## Summary by Sourcery

Fixes an issue where pagination would fail when the nextPage token was not defined.

Bug Fixes:
- Fix the pagination

Chores:
- Update the version to 1.1.8.