### PR TITLE
Mimecast: settle Accept-Encoding header

### DIFF
--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-19 - 1.1.9
+
+### Fixed
+
+- Settle the Accept-Encoding header in the requests
+
 ## 2025-03-19 - 1.1.8
 
 ### Fixed

--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Settle the Accept-Encoding header in the requests
+- Set the Accept-Encoding header in requests
 
 ## 2025-03-19 - 1.1.8
 

--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "categories": [
     "Email"
   ]

--- a/Mimecast/mimecast_modules/client/__init__.py
+++ b/Mimecast/mimecast_modules/client/__init__.py
@@ -19,6 +19,7 @@ class ApiClient(requests.Session):
         self.auth = auth
         self.limiter_batch = limiter_batch
         self.limiter_default = limiter_default
+        self.headers.update({"Accept-Encoding": "gzip,deflate"})
 
         self.mount(
             "https://api.services.mimecast.com/siem/v1/batch/events/cg",


### PR DESCRIPTION
Set the `Accept-Encoding` header to `gzip` and `deflate`.
Recently, for not yet determined reason, the zstandard appear available if the last docker Python3.10 image we use.
As this module is now available, urllib3 (used by requests) add `zstd` as accepted encoding (see [code](https://github.com/urllib3/urllib3/blob/main/src/urllib3/util/request.py#L21-L36)).
However, the mimecast server doesn't accept this encoding proposal and return an 500 error.

## Summary by Sourcery

Sets the Accept-Encoding header to "gzip,deflate" to avoid issues with the Mimecast server rejecting requests with zstd encoding.

Bug Fixes:
- Sets the Accept-Encoding header to "gzip,deflate" to avoid issues with the Mimecast server rejecting requests with zstd encoding. 

Chores:
- Bumped version to 1.1.9.