### PR TITLE
Mimecast: Fix the asyncio loop in the workers

### DIFF
--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-20 - 1.1.10
+
+### Fixed
+
+- Fix asyncio loop in thread
+
 ## 2025-03-19 - 1.1.9
 
 ### Fixed

--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "categories": [
     "Email"
   ]

--- a/Mimecast/mimecast_modules/helpers.py
+++ b/Mimecast/mimecast_modules/helpers.py
@@ -87,9 +87,9 @@ async def async_download_batch(urls: list[str]) -> AsyncGenerator[dict, None]:
                 yield json.loads(line)
 
 
-def download_batches(urls: list[str], use_async=True) -> Generator[dict, None, None]:
-    if use_async:
-        yield from AsyncGeneratorConverter(async_download_batch(urls), asyncio.get_event_loop())
+def download_batches(urls: list[str], loop: asyncio.AbstractEventLoop | None = None) -> Generator[dict, None, None]:
+    if loop:
+        yield from AsyncGeneratorConverter(async_download_batch(urls), loop)
 
     else:
         yield from sync_download_batch(urls)

--- a/Mimecast/tests/test_helpers.py
+++ b/Mimecast/tests/test_helpers.py
@@ -49,7 +49,7 @@ def test_download_batches_synchronously(event_1):
     with requests_mock.Mocker() as mocked_requests:
         mocked_requests.get(url, content=gzip.compress(events.encode("utf-8")))
 
-        assert list(download_batches([url] * 3, use_async=False)) == [event_1] * 30
+        assert list(download_batches([url] * 3)) == [event_1] * 30
 
 
 def test_download_batches_synchronously_empty_response(event_1):
@@ -58,10 +58,10 @@ def test_download_batches_synchronously_empty_response(event_1):
     with requests_mock.Mocker() as mocked_requests:
         mocked_requests.get(url, content=gzip.compress(b""))
 
-        assert list(download_batches([url], use_async=False)) == []
+        assert list(download_batches([url])) == []
 
 
-def test_download_batches_asynchronously(event_1):
+def test_download_batches_asynchronously(event_1, event_loop):
     url = "https://storage.mydomain.com/path/object.gz"
     serialized_event = json.dumps(event_1)
     events = "\n".join([serialized_event] * 10)
@@ -69,16 +69,16 @@ def test_download_batches_asynchronously(event_1):
     with aioresponses() as mocked_requests:
         mocked_requests.get(url, body=gzip.compress(events.encode("utf-8")), repeat=4)
 
-        assert list(download_batches([url] * 4, use_async=True)) == [event_1] * 40
+        assert list(download_batches([url] * 4, loop=event_loop)) == [event_1] * 40
 
 
-def test_download_batches_asynchronously_empty_response(event_1):
+def test_download_batches_asynchronously_empty_response(event_1, event_loop):
     url = "https://storage.mydomain.com/path/object.gz"
 
     with aioresponses() as mocked_requests:
         mocked_requests.get(url, body=gzip.compress(b""), repeat=2)
 
-        assert list(download_batches([url] * 2, use_async=True)) == []
+        assert list(download_batches([url] * 2, loop=event_loop)) == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Set the asyncio loop in each Mimecast workers (by default, the asyncio loop is not set for thread and this generates runtime errors).

## Summary by Sourcery

Initialise the asyncio loop for each worker thread to prevent runtime errors when downloading batches asynchronously.

Bug Fixes:
- Fix asyncio loop not being set in worker threads, causing runtime errors.

Enhancements:
- Remove the `use_async` parameter from the `download_batches` function and instead rely on the presence of an event loop to determine whether to use asyncio.

Tests:
- Update tests to pass the event loop to the `download_batches` function when running asynchronously.