### PR TITLE
Mimecast: fix condition that stop the iteration over events

### DIFF
--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-03-20 - 1.1.11
+
+### Fixed
+
+- Fix condition to stop iteration over the list of events
+
 ## 2025-03-20 - 1.1.10
 
 ### Fixed

--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "categories": [
     "Email"
   ]

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -135,10 +135,6 @@ class MimecastSIEMWorker(Thread):
                     INCOMING_MESSAGES.labels(intake_key=self.connector.configuration.intake_key).inc(len(events))
                     yield events
 
-                else:
-                    logger.info("The last page of events was empty", log_type=self.log_type)
-                    return
-
             nextPageToken = result.get("@nextPage")
             if result["isCaughtUp"] is True or not nextPageToken:
                 return

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -128,7 +128,7 @@ class MimecastSIEMWorker(Thread):
             for events in batched(events_gen, EVENTS_BATCH_SIZE):
                 logger.debug("Collected events", nb_url=len(events), log_type=self.log_type)
 
-                events = [event for event in events if event["timestamp"] > from_date.timestamp() * 1000]
+                events = [event for event in events if event["timestamp"] > result_from_date.timestamp() * 1000]
                 logger.info("Filtered events", nb_url=len(events), log_type=self.log_type)
 
                 if len(events) > 0:


### PR DESCRIPTION
As we batch events by 10000 items, some batches can have been already processed and all events can be filtered from the list.
In that case, a condition breaks the loop while we still have events in the generator. We remove it.

## Summary by Sourcery

Fix the event iteration logic in the Mimecast SIEM connector to prevent premature loop termination

Bug Fixes:
- Resolve an issue where the event processing loop would incorrectly stop when a batch became empty, potentially missing events from the generator

Enhancements:
- Improve event filtering logic to continue iteration even when a batch becomes empty