### PR TITLE
Sophos: stop the connector when the authentication fails

### DIFF
--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-04-02 - 1.17.3
+
+### Fixed
+
+- Authenticate the connectors at the beginning and stop if the authentication fails
+
 ## 2024-11-20 - 1.17.2
 
 ### Fixed

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,7 +38,7 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "categories": [
     "Endpoint",
     "Network"

--- a/Sophos/sophos_module/client/auth.py
+++ b/Sophos/sophos_module/client/auth.py
@@ -6,6 +6,7 @@ from requests.adapters import HTTPAdapter, Retry
 from requests.auth import AuthBase
 
 from sophos_module.logging import get_logger
+from sophos_module.client.exceptions import SophosApiAuthenticationError
 
 logger = get_logger()
 
@@ -68,7 +69,8 @@ class SophosApiAuthentication(AuthBase):
                 reason=response.reason,
             )
 
-            response.raise_for_status()
+            if response.status_code > 399:
+                raise SophosApiAuthenticationError("Authentication failed. Check your client_id and client_secret.")
 
             credentials: SophosApiCredentials = SophosApiCredentials()
 
@@ -87,7 +89,9 @@ class SophosApiAuthentication(AuthBase):
                 status_code=response.status_code,
                 reason=response.reason,
             )
-            response.raise_for_status()
+
+            if response.status_code > 399:
+                raise SophosApiAuthenticationError("The Whoami call failed. Check your client_id and client_secret.")
 
             whoami: dict[str, Any] = response.json()
             credentials.tenancy_type = whoami["idType"]

--- a/Sophos/sophos_module/client/exceptions.py
+++ b/Sophos/sophos_module/client/exceptions.py
@@ -1,0 +1,4 @@
+class SophosApiAuthenticationError(Exception):
+    """Custom exception for authentication errors."""
+
+    pass

--- a/Sophos/sophos_module/trigger_sophos_edr_events.py
+++ b/Sophos/sophos_module/trigger_sophos_edr_events.py
@@ -56,14 +56,17 @@ class SophosEDREventsTrigger(SophosConnector):
         return max(self.configuration.chunk_size, 1000)
 
     @cached_property
-    def client(self) -> SophosApiClient:
-        auth = SophosApiAuthentication(
+    def authentication(self) -> SophosApiAuthentication:
+        return SophosApiAuthentication(
             api_host=self.module.configuration.api_host,
             authorization_url=self.module.configuration.oauth2_authorization_url,
             client_id=self.module.configuration.client_id,
             client_secret=self.module.configuration.client_secret,
         )
-        return SophosApiClient(auth=auth)
+
+    @cached_property
+    def client(self) -> SophosApiClient:
+        return SophosApiClient(auth=self.authentication)
 
     def run(self) -> None:  # pragma: no cover
         self.log(message="Sophos Events Trigger has started", level="info")

--- a/Sophos/sophos_module/trigger_sophos_xdr_query.py
+++ b/Sophos/sophos_module/trigger_sophos_xdr_query.py
@@ -65,15 +65,17 @@ class SophosXDRQueryTrigger(SophosConnector):
         return max(self.configuration.chunk_size, 1000)
 
     @cached_property
-    def client(self) -> SophosApiClient:
-        auth = SophosApiAuthentication(
+    def authentication(self) -> SophosApiAuthentication:
+        return SophosApiAuthentication(
             api_host=self.module.configuration.api_host,
             authorization_url=self.module.configuration.oauth2_authorization_url,
             client_id=self.module.configuration.client_id,
             client_secret=self.module.configuration.client_secret,
         )
 
-        return SophosApiClient(auth=auth)
+    @cached_property
+    def client(self) -> SophosApiClient:
+        return SophosApiClient(auth=self.authentication)
 
     def run(self) -> None:  # pragma: no cover
         self.log(message="Sophos Events Trigger has started", level="info")

--- a/Sophos/sophos_module/trigger_sophos_xdr_query.py
+++ b/Sophos/sophos_module/trigger_sophos_xdr_query.py
@@ -13,6 +13,7 @@ from urllib3.exceptions import HTTPError as BaseHTTPError
 from sophos_module.base import SophosConnector
 from sophos_module.client import SophosApiClient
 from sophos_module.client.auth import SophosApiAuthentication
+from sophos_module.client.exceptions import SophosApiAuthenticationError
 from sophos_module.metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, INCOMING_EVENTS, OUTCOMING_EVENTS
 
 
@@ -81,6 +82,9 @@ class SophosXDRQueryTrigger(SophosConnector):
         self.log(message="Sophos Events Trigger has started", level="info")
 
         try:
+            # Authenticate with the Sophos API
+            self.authentication.get_credentials()
+
             while self.running:
                 start = time.time()
                 try:
@@ -101,6 +105,11 @@ class SophosXDRQueryTrigger(SophosConnector):
                 # if greater than 0, sleep
                 if delta_sleep > 0:
                     time.sleep(delta_sleep)
+
+        except SophosApiAuthenticationError as ex:
+            # Log a critical message, that will stop the connector, when the authentication fails
+            self.log(message=str(ex), level="critical")
+
         finally:
             self.log(message="Sophos Events Trigger has stopped", level="info")
 

--- a/Sophos/tests/client/test_auth.py
+++ b/Sophos/tests/client/test_auth.py
@@ -5,6 +5,7 @@ import pytest
 import requests_mock
 
 from sophos_module.client.auth import SophosApiAuthentication
+from sophos_module.client.exceptions import SophosApiAuthenticationError
 
 
 def test_get_credentials():
@@ -113,6 +114,78 @@ def test_get_credentials_request_new_token_only_when_needed():
         assert p1.called
         assert p2.called
         assert not p3.called
+
+
+def test_failing_authentication():
+    api_host_url = "https://api-eu.central.sophos.com"
+    authorization_url = "https://id.sophos.com/api/v2/oauth2/token"
+    client_id = "foo"
+    client_secret = "bar"
+    auth = SophosApiAuthentication(api_host_url, authorization_url, client_id, client_secret)
+
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            authorization_url,
+            status_code=401,
+            json={
+                "errorCode": "oauth.invalid_client_secret",
+                "message": "Unauthorized",
+            },
+        )
+
+        whoiam_mock = mock.get(
+            f"{api_host_url}/whoami/v1",
+            status_code=200,
+            json={
+                "id": "ea106f70-96b1-4851-bd31-e4395ea407d2",
+                "idType": "tenant",
+                "apiHosts": {
+                    "global": "https://api.central.sophos.com",
+                    "dataRegion": "https://api-eu02.central.sophos.com",
+                },
+            },
+        )
+
+        current_dt = datetime.utcnow()
+
+        with pytest.raises(SophosApiAuthenticationError) as excinfo:
+            auth.get_credentials()
+
+        assert not whoiam_mock.called
+
+
+def test_failing_whoami():
+    api_host_url = "https://api-eu.central.sophos.com"
+    authorization_url = "https://id.sophos.com/api/v2/oauth2/token"
+    client_id = "foo"
+    client_secret = "bar"
+    auth = SophosApiAuthentication(api_host_url, authorization_url, client_id, client_secret)
+
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            authorization_url,
+            json={
+                "access_token": "foo-token",
+                "token_type": "bearer",
+                "scope": "our-scope",
+                "expires_in": 1799,
+            },
+        )
+
+        whoiam_mock = mock.get(
+            f"{api_host_url}/whoami/v1",
+            status_code=401,
+            json={
+                "error": "Unauthorized",
+            },
+        )
+
+        current_dt = datetime.utcnow()
+
+        with pytest.raises(SophosApiAuthenticationError) as excinfo:
+            auth.get_credentials()
 
 
 @pytest.mark.skipif("{'SOPHOS_CLIENT_ID', 'SOPHOS_CLIENT_SECRET'}.issubset(os.environ.keys()) == False")


### PR DESCRIPTION
Authenticate the connector at the starting and stop it if the authentication process fails.