### PR TITLE
Fortigate: change the output of the action that add new Address group

### DIFF
--- a/Fortigate/CHANGELOG.md
+++ b/Fortigate/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-04-07 - 1.29.1
+
+### Fixed
+
+- Fix the output of the `Add new Address group to a Fortigate firewall` action
+
 ## 2024-05-28 - 1.29.0
 
 ### Added

--- a/Fortigate/action_fortigate_add_address_group.json
+++ b/Fortigate/action_fortigate_add_address_group.json
@@ -24,6 +24,19 @@
   "description": "Add a new Address Group to a Fortigate Firewall",
   "docker_parameters": "fortigate_add_group_address",
   "name": "Post Fortigate Address Group",
-  "results": {},
+  "results": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "objects": {
+        "description": "The OBJECT list added to the Address Group.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "title": "Results",
+    "type": "object"
+  },
   "uuid": "d98acb88-88ca-4afe-95d0-b9996fe37cfc"
 }

--- a/Fortigate/fortigate/action_fortigate_add_group_address.py
+++ b/Fortigate/fortigate/action_fortigate_add_group_address.py
@@ -50,7 +50,7 @@ class FortigateAddGroupAddress(Action):
             else:
                 self.add_fw_address_group(name, new_member_list)
 
-        return objects
+        return {"objects": objects}
 
     def add_api(self, url, data=None):
         try:

--- a/Fortigate/fortigate/action_fortigate_add_group_address.py
+++ b/Fortigate/fortigate/action_fortigate_add_group_address.py
@@ -8,7 +8,7 @@ class FortigateAddGroupAddress(Action):
     Action to Add a Group Address on a remote fortigate
     """
 
-    def run(self, arguments: dict) -> list:
+    def run(self, arguments: dict) -> dict:
         """
         Modify the members of the address group on the firewall.
         Parameters

--- a/Fortigate/manifest.json
+++ b/Fortigate/manifest.json
@@ -49,7 +49,7 @@
   "name": "Fortigate Firewalls",
   "uuid": "ca9a9497-bcd2-4d0c-b0c1-72699231feb2",
   "slug": "fortigate",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "categories": [
     "Network"
   ]


### PR DESCRIPTION
- Lists are not supported as output of the `run` method. Wrap the returned list into a dict.

## Summary by Sourcery

Bug Fixes:
- Fix the output of the 'Add new Address group to a Fortigate firewall' action by wrapping the returned list into a dictionary