### PR TITLE
S1DV: fix the way to read lines from the S3 Object

### DIFF
--- a/SentinelOneDeepVisibility/CHANGELOG.md
+++ b/SentinelOneDeepVisibility/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-04-07 - 1.1.5
+
+### Fixed
+
+- Read the S3 object as an async generator to avoid loading and reading the entire object into memory.
+
 ## 2025-03-22 - 1.1.4
 
 ### Changed

--- a/SentinelOneDeepVisibility/deep_visibility/connector_s3_logs.py
+++ b/SentinelOneDeepVisibility/deep_visibility/connector_s3_logs.py
@@ -30,9 +30,10 @@ class DeepVisibilityConnector(AbstractAwsS3QueuedConnector):
         Returns:
              Generator:
         """
-        records = (line.rstrip(b"\n") for line in await stream.readlines())
+        # Use the iterator protocol to read the stream line by line. Using readline() would uncompress the entire file in memory
+        records = (line.rstrip(b"\n") async for line in stream)
 
-        for record in records:
+        async for record in records:
             if len(record) > 0:
                 try:
                     json_record = orjson.loads(record)

--- a/SentinelOneDeepVisibility/manifest.json
+++ b/SentinelOneDeepVisibility/manifest.json
@@ -29,7 +29,7 @@
   "name": "SentinelOneDeepVisibility",
   "uuid": "7282a633-0fc2-4b27-a185-3c94f5a3a36f",
   "slug": "sentinelonedeepvisibility",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "categories": [
     "Endpoint"
   ]


### PR DESCRIPTION
Use the iterator protocol on the stream to read the contents of the S3 object line by line.
The `readlines` method returns a list of lines, so if the S3 object is compressed, this method will uncompress the entire contents of the S3 object in memory.

## Summary by Sourcery

Optimize S3 object reading to use an async generator, preventing full object loading into memory

Bug Fixes:
- Modify S3 object reading method to stream lines asynchronously instead of loading entire object at once

Enhancements:
- Implement memory-efficient line reading from S3 objects using async iteration

Not required, but it will be nice having [this PR](https://github.com/SEKOIA-IO/automation-library/pull/1342) merged before.