### PR TITLE
Azure Monitor - raise exception

### DIFF
--- a/AzureMonitor/azure_monitor_modules/action_query.py
+++ b/AzureMonitor/azure_monitor_modules/action_query.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
+from azure.core.exceptions import HttpResponseError
 from azure.monitor.query import LogsQueryStatus
 from pydantic.v1 import BaseModel, Field
 

--- a/AzureMonitor/azure_monitor_modules/action_query.py
+++ b/AzureMonitor/azure_monitor_modules/action_query.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, ClientAuthenticationError
 from azure.monitor.query import LogsQueryStatus
 from pydantic.v1 import BaseModel, Field
 
@@ -72,3 +72,4 @@ class AzureMonitorQueryAction(AzureMonitorBaseAction):
 
         except HttpResponseError as err:
             self.log(message=str(err), level="error")
+            raise

--- a/AzureMonitor/manifest.json
+++ b/AzureMonitor/manifest.json
@@ -28,5 +28,5 @@
   "slug": "azure-monitor",
   "categories": ["Cloud Providers"],
   "uuid": "28d53bf5-738a-42a4-8ce4-67e00195590e",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/532

## Summary by Sourcery

Modify Azure Monitor module to re-raise HTTP response errors instead of just logging them

Bug Fixes:
- Ensure HTTP response errors are propagated up the call stack instead of being silently logged

Chores:
- Bump Azure Monitor module version from 1.0.0 to 1.0.1

## Summary by Sourcery

Modify Azure Monitor module to propagate HTTP response errors by re-raising exceptions instead of silently logging them

Bug Fixes:
- Ensure HTTP response errors are raised to the caller instead of being silently logged

Chores:
- Bump Azure Monitor module version from 1.0.0 to 1.0.1