### PR TITLE
Fix rate limiter problem

### DIFF
--- a/Bitsight/CHANGELOG.md
+++ b/Bitsight/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-10-30 - 1.1.1
+
+### Added
+
+- Add concurrency to the rate limiter
+
 ## 2024-10-30 - 1.1.0
 
 ### Changed

--- a/Bitsight/client/http_client.py
+++ b/Bitsight/client/http_client.py
@@ -31,7 +31,6 @@ class BitsightClient(object):
         self._concurrency_limiter = asyncio.Semaphore(3)
         self._session = ClientSession()
 
-
     @classmethod
     def default_limiter(cls) -> AsyncLimiter:
         """
@@ -44,7 +43,6 @@ class BitsightClient(object):
         # 16 requests per second to stay under 5000 requests per 5 minutes
         # 5000 requests per 5 minutes = 16.666 requests per second
         return AsyncLimiter(16, 1)
-
 
     @asynccontextmanager
     async def session(self) -> AsyncGenerator[ClientSession, None]:

--- a/Bitsight/manifest.json
+++ b/Bitsight/manifest.json
@@ -28,7 +28,7 @@
   "name": "Bitsight",
   "uuid": "59b7f559-0a07-456f-b1c0-41d9fbe6ad4a",
   "slug": "bitsight",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "categories": [
     "Threat Intelligence"
   ]


### PR DESCRIPTION
- Fix a problem on the rate limiter, as the [documentation](https://help.bitsighttech.com/hc/en-us/articles/360036941374-Errors-and-Status-Codes) says we can't have more than 3 concurrent requests.

## Summary by Sourcery

Limit concurrent requests and adjust rate limiting in the Bitsight client to align with API constraints.

Enhancements:
- Restrict the client to a maximum of 3 concurrent requests.
- Update the rate limiter settings to 16 requests per second.

Chores:
- Increment the package version to 1.1.1.
- Update the changelog.