### PR TITLE
Delete the default value

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-05 - 1.20.4
+
+### Fixed
+
+- Fix the new verdict problem
+
 ## 2025-01-10 - 1.20.3
 
 ### Fixed

--- a/SentinelOne/action_update_threat_incident.json
+++ b/SentinelOne/action_update_threat_incident.json
@@ -10,7 +10,6 @@
       "new_analyst_verdict": {
         "description": "New verdict of the analyst to set",
         "type": "string",
-        "default": "-",
         "enum": [
           "-",
           "false_positive",

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.20.3",
+  "version": "1.20.4",
   "categories": [
     "Endpoint"
   ]


### PR DESCRIPTION
Delete the default value, because the value is required already.
Main Issue : [Issue](https://github.com/SekoiaLab/integration/issues/456)

## Summary by Sourcery

Update SentinelOne integration version and changelog to reflect a fix for a verdict problem

Bug Fixes:
- Fix the new verdict problem

Chores:
- Bump integration version from 1.20.3 to 1.20.4