### PR TITLE
Fix the naming of the action

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-04-10 - 2.67.14
+
+### Fixed
+
+- Rename get asset in the main script
+
 ## 2025-04-10 - 2.67.13
 
 ### Fixed

--- a/Sekoia.io/action_returns_an_asset_v2.json
+++ b/Sekoia.io/action_returns_an_asset_v2.json
@@ -1,7 +1,7 @@
 {
   "uuid": "25ebfce7-f980-46e3-a2b8-0b59f1905acb",
   "name": "Get Asset (V2)",
-  "docker_parameters": "get-asset-v2/{uuid}",
+  "docker_parameters": "get-asset-v2",
   "description": "Return an asset according to its identifier",
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/Sekoia.io/main.py
+++ b/Sekoia.io/main.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     module.register(ListAssets, "get-assets-v2")
     module.register(DeletesAsset, "delete-assets/{uuid}")
     module.register(DeletesAssetV2, "delete-assets-v2/{uuid}")
-    module.register(GetAsset, "get-asset-v2/{uuid}")
+    module.register(GetAsset, "get-asset-v2")
     module.register(ReturnsAsset, "get-assets/{uuid}")
     module.register(UpdateRule, "put-rules/{uuid}")
     module.register(GetAggregationQuery, "get-aggregation-query")

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.67.13",
+  "version": "2.67.14",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
As the action inherit from `Action` class directly so we don't need the {uuid} in the naming.
Main Issue : [Issue](https://github.com/SekoiaLab/integration/issues/564)

## Summary by Sourcery

Remove UUID from the get-asset-v2 endpoint registration

Bug Fixes:
- Corrected the endpoint registration for get-asset-v2 by removing the {uuid} parameter

Chores:
- Updated project version to 2.67.14
- Updated CHANGELOG.md with the fix