### PR TITLE
Azure: bump version number

### DIFF
--- a/Azure/CHANGELOG.md
+++ b/Azure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-07 - 2.6.5
+
+### Added
+
+- Add new connector to collect Azure Network Watcher Virtual network flow logs
+
 ## 2024-12-04 - 2.6.4
 
 ### Fixed

--- a/Azure/manifest.json
+++ b/Azure/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Azure",
   "uuid": "525eecc0-9eee-484d-92bd-039117cf4dac",
   "slug": "azure",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "categories": [
     "Cloud Providers"
   ]


### PR DESCRIPTION
Bump the version number to integrate the Auzre Network Watcher Virtual Network flow logs

## Summary by Sourcery

Bump Azure integration to version 2.6.5 and add connector for Azure Network Watcher Virtual Network flow logs

New Features:
- Add connector to collect Azure Network Watcher Virtual Network flow logs

Enhancements:
- Bump version number to 2.6.5