### PR TITLE
Mimecast: fix the version number of the module

### DIFF
--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "categories": [
     "Email"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump Mimecast module version from 1.1.11 to 1.1.12