### PR TITLE
Mimecast: Handle temporary unauthorized errors

### DIFF
--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-13 - 1.1.13
+
+### Fixed
+
+- Handle temporary errors when fetching events
+
 ## 2025-04-10 - 1.1.12
 
 ### Fixed

--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "categories": [
     "Email"
   ]

--- a/Mimecast/mimecast_modules/client/__init__.py
+++ b/Mimecast/mimecast_modules/client/__init__.py
@@ -8,9 +8,11 @@ from .retry import Retry
 
 
 class ApiClient(requests.Session):
+    auth: ApiKeyAuthentication
+
     def __init__(
         self,
-        auth: AuthBase,
+        auth: ApiKeyAuthentication,
         limiter_batch: Limiter,
         limiter_default: Limiter,
         nb_retries: int = 5,

--- a/Mimecast/mimecast_modules/client/auth.py
+++ b/Mimecast/mimecast_modules/client/auth.py
@@ -47,7 +47,11 @@ class ApiKeyAuthentication(AuthBase):
         if self.__credentials is None or current_dt + timedelta(seconds=300) >= self.__credentials.expires_at:
             response = self.__http_session.post(
                 url=self.AUTH_URL,
-                data=f"client_id={self.__client_id}&client_secret={self.__client_secret}&grant_type=client_credentials",
+                data={
+                    "client_id": self.__client_id,
+                    "client_secret": self.__client_secret,
+                    "grant_type": "client_credentials",
+                },
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
                 timeout=60,
             )

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -142,10 +142,16 @@ class MimecastSIEMWorker(Thread):
 
         return events
 
+    def __get_next_batch_of_events(self, url: str, params: dict[str, int | str]) -> requests.Response:
+        """
+        Get the next batch of events from the API.
+        """
+        return self.client.get(url, params=params, timeout=60, headers={"Accept": "application/json"})
+
     def __fetch_next_events(self) -> Generator[list, None, None]:
         url = "https://api.services.mimecast.com/siem/v1/batch/events/cg"
         params = self.__build_fetch_params()
-        response = self.client.get(url, params=params, timeout=60, headers={"Accept": "application/json"})
+        response = self.__get_next_batch_of_events(url, params)
 
         while self.running:
             response.raise_for_status()
@@ -170,7 +176,7 @@ class MimecastSIEMWorker(Thread):
                 return
 
             params["nextPage"] = nextPageToken
-            response = self.client.get(url, params=params, timeout=60, headers={"Accept": "application/json"})
+            response = self.__get_next_batch_of_events(url, params)
 
     def fetch_events(self) -> Generator[list, None, None]:
         most_recent_date_seen = None  # for measuring lag


### PR DESCRIPTION
When getting the next batch of events, handle the response.
If the connector faces a 401 Unauthorized error, we refresh the access token and retry once of the request.

## Summary by Sourcery

Implement retry logic for temporary unauthorized errors when fetching batch events by refreshing the OAuth token and retrying the request.

Enhancements:
- Wrap batch event fetches in a helper that detects 401 responses, refreshes credentials, and retries once.

Tests:
- Add end-to-end test to simulate a 401 Unauthorized response and verify token refresh, retry, and sleep behavior.

Chores:
- Bump connector version to 1.1.13 and update CHANGELOG and manifest.json.
- Adjust OAuth token request payload to use a structured form data dict.