### PR TITLE
Mimecast: Filter already collected events

### DIFF
--- a/Mimecast/CHANGELOG.md
+++ b/Mimecast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-13 - 1.1.14
+
+### Fixed
+
+- Filter already collected events
+
 ## 2025-05-13 - 1.1.13
 
 ### Fixed

--- a/Mimecast/manifest.json
+++ b/Mimecast/manifest.json
@@ -25,7 +25,7 @@
   "name": "Mimecast",
   "slug": "mimecast",
   "uuid": "72af1e06-84db-497d-b4ac-10defb1f265f",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "categories": [
     "Email"
   ]

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -9,6 +9,7 @@ from typing import Generator
 
 import orjson
 import requests
+from cachetools import Cache, LRUCache
 from dateutil.parser import isoparse
 from pyrate_limiter import Duration, Limiter, RequestRate
 from sekoia_automation.checkpoint import CheckpointCursor
@@ -17,7 +18,7 @@ from sekoia_automation.storage import PersistentJSON
 
 from . import MimecastModule
 from .client import ApiClient, ApiKeyAuthentication
-from .helpers import download_batches, batched
+from .helpers import download_batches, batched, filter_processed_events
 from .logging import get_logger
 from .metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, INCOMING_MESSAGES, OUTCOMING_EVENTS
 
@@ -55,6 +56,10 @@ class MimecastSIEMWorker(Thread):
             self._loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self._loop)
 
+        self.cache_context = PersistentJSON("cache.json", self.connector.data_path)
+        self.cache_size = 1000
+        self.events_cache: Cache = self.load_events_cache()
+
     def log(self, *args, **kwargs):
         self.connector.log(*args, **kwargs)
 
@@ -67,6 +72,37 @@ class MimecastSIEMWorker(Thread):
     @property
     def running(self):
         return not self._stop_event.is_set()
+
+    def load_events_cache(self) -> Cache:
+        """
+        Load the events cache.
+        """
+        cache: Cache = LRUCache(maxsize=self.cache_size)
+
+        events_cache = []
+        with self.connector.context_lock:
+            with self.cache_context as context:
+                # load the cache from the context
+                events_cache = context.get(self.log_type, {}).get("events_cache", [])
+
+        for event_hash in events_cache:
+            cache[event_hash] = True
+
+        return cache
+
+    def save_events_cache(self) -> None:
+        """
+        Save the events cache.
+        """
+
+        with self.connector.context_lock:
+            with self.cache_context as context:
+                # check if the context exists or create it
+                if self.log_type not in context:
+                    context[self.log_type] = {}
+
+                # save the events cache to the context
+                context[self.log_type]["events_cache"] = list(self.events_cache.keys())
 
     def get_old_cursor(self) -> datetime | None:
         """
@@ -125,11 +161,11 @@ class MimecastSIEMWorker(Thread):
 
     def __filter_events(self, events: list) -> list:
         """
-        Filter events based on the cursor.
+        Filter events based on the cursor and the cache
 
         If the cursor is a datetime, we filter out events that are older than the
-        cursor.
-        If the cursor is a page token, we don't filter the events.
+        cursor then we filter out events that are already in the cache.
+        If the cursor is a page token, we only filter the events that are already in the cache.
         """
         if self.old_cursor is not None:
             # The datetime cursor was actually a date, not a full datetime. Thus, we have to download all
@@ -139,6 +175,9 @@ class MimecastSIEMWorker(Thread):
 
             # We don't need this anymore - it's for the first page only
             self.old_cursor = None
+
+        # Filter out events that are already in the cache
+        events = filter_processed_events(events, self.events_cache)
 
         return events
 
@@ -293,6 +332,8 @@ class MimecastSIEMWorker(Thread):
 
                 # In case of exception, pause the thread before the next attempt
                 time.sleep(self.connector.configuration.frequency)
+
+        self.save_events_cache()
 
 
 class MimecastSIEMConnector(Connector):

--- a/Mimecast/mimecast_modules/connector_mimecast_siem.py
+++ b/Mimecast/mimecast_modules/connector_mimecast_siem.py
@@ -176,9 +176,6 @@ class MimecastSIEMWorker(Thread):
 
             result = response.json()
 
-            nextPageToken = result.get("@nextPage")
-            self.cursor.offset = nextPageToken
-
             batch_urls = [item["url"] for item in result.get("value", [])]
             events_gen = download_batches(urls=batch_urls, loop=self._loop)
 
@@ -189,6 +186,9 @@ class MimecastSIEMWorker(Thread):
                 if len(events) > 0:
                     INCOMING_MESSAGES.labels(intake_key=self.connector.configuration.intake_key).inc(len(events))
                     yield events
+
+            nextPageToken = result.get("@nextPage")
+            self.cursor.offset = nextPageToken
 
             if result["isCaughtUp"] is True or not nextPageToken:
                 return

--- a/Mimecast/mimecast_modules/helpers.py
+++ b/Mimecast/mimecast_modules/helpers.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import aiohttp
 import requests
+import xxhash
 
 
 class AsyncGeneratorConverter:
@@ -93,3 +94,19 @@ def batched(iterable: Iterable, n: int) -> Generator[list, None, None]:
     iterator = iter(iterable)
     while batch := list(islice(iterator, n)):
         yield batch
+
+
+def compute_hash_event(event: dict) -> str:
+    """
+    Compute a hash id for the event
+    """
+    parts = [
+        event["aggregateId"],
+        event["processingId"],
+        event.get("type") or event.get("eventType") or "",
+        event.get("senderEnvelope") or "",
+        event.get("recipients") or "",
+        event.get("messageId") or event.get("sha1") or "",
+    ]
+
+    return xxhash.xxh64("-".join(parts)).hexdigest()

--- a/Mimecast/mimecast_modules/helpers.py
+++ b/Mimecast/mimecast_modules/helpers.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from itertools import islice
 from typing import Any
 
+from cachetools import Cache
 import aiohttp
 import requests
 import xxhash
@@ -110,3 +111,25 @@ def compute_hash_event(event: dict) -> str:
     ]
 
     return xxhash.xxh64("-".join(parts)).hexdigest()
+
+
+def filter_processed_events(events: list[dict], cache: Cache) -> list[dict]:
+    """
+    Filter out events that have already been processed
+    """
+    filtered_events = []
+
+    # Use a cache to store the hashes of processed events
+    for event in events:
+        # Compute the hash of the event
+        event_hash = compute_hash_event(event)
+
+        # Check if the event hash is already in the cache
+        if event_hash not in cache:
+            # If not, add the event to the filtered list
+            filtered_events.append(event)
+
+            # Add the event hash to the cache
+            cache[event_hash] = True
+
+    return filtered_events

--- a/Mimecast/poetry.lock
+++ b/Mimecast/poetry.lock
@@ -358,6 +358,18 @@ filecache = ["filelock (>=3.8.0)"]
 redis = ["redis (>=2.10.5)"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
+    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -3114,6 +3126,139 @@ cffi = ">=1.16.0"
 test = ["pytest"]
 
 [[package]]
+name = "xxhash"
+version = "3.5.0"
+description = "Python binding for xxHash"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "xxhash-3.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ece616532c499ee9afbb83078b1b952beffef121d989841f7f4b3dc5ac0fd212"},
+    {file = "xxhash-3.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3171f693dbc2cef6477054a665dc255d996646b4023fe56cb4db80e26f4cc520"},
+    {file = "xxhash-3.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c5d3e570ef46adaf93fc81b44aca6002b5a4d8ca11bd0580c07eac537f36680"},
+    {file = "xxhash-3.5.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7cb29a034301e2982df8b1fe6328a84f4b676106a13e9135a0d7e0c3e9f806da"},
+    {file = "xxhash-3.5.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d0d307d27099bb0cbeea7260eb39ed4fdb99c5542e21e94bb6fd29e49c57a23"},
+    {file = "xxhash-3.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0342aafd421795d740e514bc9858ebddfc705a75a8c5046ac56d85fe97bf196"},
+    {file = "xxhash-3.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3dbbd9892c5ebffeca1ed620cf0ade13eb55a0d8c84e0751a6653adc6ac40d0c"},
+    {file = "xxhash-3.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4cc2d67fdb4d057730c75a64c5923abfa17775ae234a71b0200346bfb0a7f482"},
+    {file = "xxhash-3.5.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:ec28adb204b759306a3d64358a5e5c07d7b1dd0ccbce04aa76cb9377b7b70296"},
+    {file = "xxhash-3.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:1328f6d8cca2b86acb14104e381225a3d7b42c92c4b86ceae814e5c400dbb415"},
+    {file = "xxhash-3.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8d47ebd9f5d9607fd039c1fbf4994e3b071ea23eff42f4ecef246ab2b7334198"},
+    {file = "xxhash-3.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b96d559e0fcddd3343c510a0fe2b127fbff16bf346dd76280b82292567523442"},
+    {file = "xxhash-3.5.0-cp310-cp310-win32.whl", hash = "sha256:61c722ed8d49ac9bc26c7071eeaa1f6ff24053d553146d5df031802deffd03da"},
+    {file = "xxhash-3.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:9bed5144c6923cc902cd14bb8963f2d5e034def4486ab0bbe1f58f03f042f9a9"},
+    {file = "xxhash-3.5.0-cp310-cp310-win_arm64.whl", hash = "sha256:893074d651cf25c1cc14e3bea4fceefd67f2921b1bb8e40fcfeba56820de80c6"},
+    {file = "xxhash-3.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:02c2e816896dc6f85922ced60097bcf6f008dedfc5073dcba32f9c8dd786f3c1"},
+    {file = "xxhash-3.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6027dcd885e21581e46d3c7f682cfb2b870942feeed58a21c29583512c3f09f8"},
+    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1308fa542bbdbf2fa85e9e66b1077eea3a88bef38ee8a06270b4298a7a62a166"},
+    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c28b2fdcee797e1c1961cd3bcd3d545cab22ad202c846235197935e1df2f8ef7"},
+    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:924361811732ddad75ff23e90efd9ccfda4f664132feecb90895bade6a1b4623"},
+    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89997aa1c4b6a5b1e5b588979d1da048a3c6f15e55c11d117a56b75c84531f5a"},
+    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:685c4f4e8c59837de103344eb1c8a3851f670309eb5c361f746805c5471b8c88"},
+    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dbd2ecfbfee70bc1a4acb7461fa6af7748ec2ab08ac0fa298f281c51518f982c"},
+    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:25b5a51dc3dfb20a10833c8eee25903fd2e14059e9afcd329c9da20609a307b2"},
+    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a8fb786fb754ef6ff8c120cb96629fb518f8eb5a61a16aac3a979a9dbd40a084"},
+    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:a905ad00ad1e1c34fe4e9d7c1d949ab09c6fa90c919860c1534ff479f40fd12d"},
+    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:963be41bcd49f53af6d795f65c0da9b4cc518c0dd9c47145c98f61cb464f4839"},
+    {file = "xxhash-3.5.0-cp311-cp311-win32.whl", hash = "sha256:109b436096d0a2dd039c355fa3414160ec4d843dfecc64a14077332a00aeb7da"},
+    {file = "xxhash-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:b702f806693201ad6c0a05ddbbe4c8f359626d0b3305f766077d51388a6bac58"},
+    {file = "xxhash-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:c4dcb4120d0cc3cc448624147dba64e9021b278c63e34a38789b688fd0da9bf3"},
+    {file = "xxhash-3.5.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:14470ace8bd3b5d51318782cd94e6f94431974f16cb3b8dc15d52f3b69df8e00"},
+    {file = "xxhash-3.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:59aa1203de1cb96dbeab595ded0ad0c0056bb2245ae11fac11c0ceea861382b9"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08424f6648526076e28fae6ea2806c0a7d504b9ef05ae61d196d571e5c879c84"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:61a1ff00674879725b194695e17f23d3248998b843eb5e933007ca743310f793"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2f2c61bee5844d41c3eb015ac652a0229e901074951ae48581d58bfb2ba01be"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d32a592cac88d18cc09a89172e1c32d7f2a6e516c3dfde1b9adb90ab5df54a6"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70dabf941dede727cca579e8c205e61121afc9b28516752fd65724be1355cc90"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e5d0ddaca65ecca9c10dcf01730165fd858533d0be84c75c327487c37a906a27"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e5b5e16c5a480fe5f59f56c30abdeba09ffd75da8d13f6b9b6fd224d0b4d0a2"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149b7914451eb154b3dfaa721315117ea1dac2cc55a01bfbd4df7c68c5dd683d"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:eade977f5c96c677035ff39c56ac74d851b1cca7d607ab3d8f23c6b859379cab"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fa9f547bd98f5553d03160967866a71056a60960be00356a15ecc44efb40ba8e"},
+    {file = "xxhash-3.5.0-cp312-cp312-win32.whl", hash = "sha256:f7b58d1fd3551b8c80a971199543379be1cee3d0d409e1f6d8b01c1a2eebf1f8"},
+    {file = "xxhash-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:fa0cafd3a2af231b4e113fba24a65d7922af91aeb23774a8b78228e6cd785e3e"},
+    {file = "xxhash-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:586886c7e89cb9828bcd8a5686b12e161368e0064d040e225e72607b43858ba2"},
+    {file = "xxhash-3.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37889a0d13b0b7d739cfc128b1c902f04e32de17b33d74b637ad42f1c55101f6"},
+    {file = "xxhash-3.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:97a662338797c660178e682f3bc180277b9569a59abfb5925e8620fba00b9fc5"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f85e0108d51092bdda90672476c7d909c04ada6923c14ff9d913c4f7dc8a3bc"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd2fd827b0ba763ac919440042302315c564fdb797294d86e8cdd4578e3bc7f3"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82085c2abec437abebf457c1d12fccb30cc8b3774a0814872511f0f0562c768c"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07fda5de378626e502b42b311b049848c2ef38784d0d67b6f30bb5008642f8eb"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c279f0d2b34ef15f922b77966640ade58b4ccdfef1c4d94b20f2a364617a493f"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:89e66ceed67b213dec5a773e2f7a9e8c58f64daeb38c7859d8815d2c89f39ad7"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bcd51708a633410737111e998ceb3b45d3dbc98c0931f743d9bb0a209033a326"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ff2c0a34eae7df88c868be53a8dd56fbdf592109e21d4bfa092a27b0bf4a7bf"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:4e28503dccc7d32e0b9817aa0cbfc1f45f563b2c995b7a66c4c8a0d232e840c7"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a6c50017518329ed65a9e4829154626f008916d36295b6a3ba336e2458824c8c"},
+    {file = "xxhash-3.5.0-cp313-cp313-win32.whl", hash = "sha256:53a068fe70301ec30d868ece566ac90d873e3bb059cf83c32e76012c889b8637"},
+    {file = "xxhash-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:80babcc30e7a1a484eab952d76a4f4673ff601f54d5142c26826502740e70b43"},
+    {file = "xxhash-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:4811336f1ce11cac89dcbd18f3a25c527c16311709a89313c3acaf771def2d4b"},
+    {file = "xxhash-3.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6e5f70f6dca1d3b09bccb7daf4e087075ff776e3da9ac870f86ca316736bb4aa"},
+    {file = "xxhash-3.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e76e83efc7b443052dd1e585a76201e40b3411fe3da7af4fe434ec51b2f163b"},
+    {file = "xxhash-3.5.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:33eac61d0796ca0591f94548dcfe37bb193671e0c9bcf065789b5792f2eda644"},
+    {file = "xxhash-3.5.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ec70a89be933ea49222fafc3999987d7899fc676f688dd12252509434636622"},
+    {file = "xxhash-3.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86b8e7f703ec6ff4f351cfdb9f428955859537125904aa8c963604f2e9d3e7"},
+    {file = "xxhash-3.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0adfbd36003d9f86c8c97110039f7539b379f28656a04097e7434d3eaf9aa131"},
+    {file = "xxhash-3.5.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:63107013578c8a730419adc05608756c3fa640bdc6abe806c3123a49fb829f43"},
+    {file = "xxhash-3.5.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:683b94dbd1ca67557850b86423318a2e323511648f9f3f7b1840408a02b9a48c"},
+    {file = "xxhash-3.5.0-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:5d2a01dcce81789cf4b12d478b5464632204f4c834dc2d064902ee27d2d1f0ee"},
+    {file = "xxhash-3.5.0-cp37-cp37m-musllinux_1_2_s390x.whl", hash = "sha256:a9d360a792cbcce2fe7b66b8d51274ec297c53cbc423401480e53b26161a290d"},
+    {file = "xxhash-3.5.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:f0b48edbebea1b7421a9c687c304f7b44d0677c46498a046079d445454504737"},
+    {file = "xxhash-3.5.0-cp37-cp37m-win32.whl", hash = "sha256:7ccb800c9418e438b44b060a32adeb8393764da7441eb52aa2aa195448935306"},
+    {file = "xxhash-3.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c3bc7bf8cb8806f8d1c9bf149c18708cb1c406520097d6b0a73977460ea03602"},
+    {file = "xxhash-3.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:74752ecaa544657d88b1d1c94ae68031e364a4d47005a90288f3bab3da3c970f"},
+    {file = "xxhash-3.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:dee1316133c9b463aa81aca676bc506d3f80d8f65aeb0bba2b78d0b30c51d7bd"},
+    {file = "xxhash-3.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:602d339548d35a8579c6b013339fb34aee2df9b4e105f985443d2860e4d7ffaa"},
+    {file = "xxhash-3.5.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:695735deeddfb35da1677dbc16a083445360e37ff46d8ac5c6fcd64917ff9ade"},
+    {file = "xxhash-3.5.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1030a39ba01b0c519b1a82f80e8802630d16ab95dc3f2b2386a0b5c8ed5cbb10"},
+    {file = "xxhash-3.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5bc08f33c4966f4eb6590d6ff3ceae76151ad744576b5fc6c4ba8edd459fdec"},
+    {file = "xxhash-3.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:160e0c19ee500482ddfb5d5570a0415f565d8ae2b3fd69c5dcfce8a58107b1c3"},
+    {file = "xxhash-3.5.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:f1abffa122452481a61c3551ab3c89d72238e279e517705b8b03847b1d93d738"},
+    {file = "xxhash-3.5.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:d5e9db7ef3ecbfc0b4733579cea45713a76852b002cf605420b12ef3ef1ec148"},
+    {file = "xxhash-3.5.0-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:23241ff6423378a731d84864bf923a41649dc67b144debd1077f02e6249a0d54"},
+    {file = "xxhash-3.5.0-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:82b833d5563fefd6fceafb1aed2f3f3ebe19f84760fdd289f8b926731c2e6e91"},
+    {file = "xxhash-3.5.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0a80ad0ffd78bef9509eee27b4a29e56f5414b87fb01a888353e3d5bda7038bd"},
+    {file = "xxhash-3.5.0-cp38-cp38-win32.whl", hash = "sha256:50ac2184ffb1b999e11e27c7e3e70cc1139047e7ebc1aa95ed12f4269abe98d4"},
+    {file = "xxhash-3.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:392f52ebbb932db566973693de48f15ce787cabd15cf6334e855ed22ea0be5b3"},
+    {file = "xxhash-3.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bfc8cdd7f33d57f0468b0614ae634cc38ab9202c6957a60e31d285a71ebe0301"},
+    {file = "xxhash-3.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e0c48b6300cd0b0106bf49169c3e0536408dfbeb1ccb53180068a18b03c662ab"},
+    {file = "xxhash-3.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe1a92cfbaa0a1253e339ccec42dbe6db262615e52df591b68726ab10338003f"},
+    {file = "xxhash-3.5.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:33513d6cc3ed3b559134fb307aae9bdd94d7e7c02907b37896a6c45ff9ce51bd"},
+    {file = "xxhash-3.5.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eefc37f6138f522e771ac6db71a6d4838ec7933939676f3753eafd7d3f4c40bc"},
+    {file = "xxhash-3.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a606c8070ada8aa2a88e181773fa1ef17ba65ce5dd168b9d08038e2a61b33754"},
+    {file = "xxhash-3.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42eca420c8fa072cc1dd62597635d140e78e384a79bb4944f825fbef8bfeeef6"},
+    {file = "xxhash-3.5.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:604253b2143e13218ff1ef0b59ce67f18b8bd1c4205d2ffda22b09b426386898"},
+    {file = "xxhash-3.5.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:6e93a5ad22f434d7876665444a97e713a8f60b5b1a3521e8df11b98309bff833"},
+    {file = "xxhash-3.5.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:7a46e1d6d2817ba8024de44c4fd79913a90e5f7265434cef97026215b7d30df6"},
+    {file = "xxhash-3.5.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:30eb2efe6503c379b7ab99c81ba4a779748e3830241f032ab46bd182bf5873af"},
+    {file = "xxhash-3.5.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c8aa771ff2c13dd9cda8166d685d7333d389fae30a4d2bb39d63ab5775de8606"},
+    {file = "xxhash-3.5.0-cp39-cp39-win32.whl", hash = "sha256:5ed9ebc46f24cf91034544b26b131241b699edbfc99ec5e7f8f3d02d6eb7fba4"},
+    {file = "xxhash-3.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:220f3f896c6b8d0316f63f16c077d52c412619e475f9372333474ee15133a558"},
+    {file = "xxhash-3.5.0-cp39-cp39-win_arm64.whl", hash = "sha256:a7b1d8315d9b5e9f89eb2933b73afae6ec9597a258d52190944437158b49d38e"},
+    {file = "xxhash-3.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:2014c5b3ff15e64feecb6b713af12093f75b7926049e26a580e94dcad3c73d8c"},
+    {file = "xxhash-3.5.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fab81ef75003eda96239a23eda4e4543cedc22e34c373edcaf744e721a163986"},
+    {file = "xxhash-3.5.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e2febf914ace002132aa09169cc572e0d8959d0f305f93d5828c4836f9bc5a6"},
+    {file = "xxhash-3.5.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5d3a10609c51da2a1c0ea0293fc3968ca0a18bd73838455b5bca3069d7f8e32b"},
+    {file = "xxhash-3.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:5a74f23335b9689b66eb6dbe2a931a88fcd7a4c2cc4b1cb0edba8ce381c7a1da"},
+    {file = "xxhash-3.5.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2b4154c00eb22e4d543f472cfca430e7962a0f1d0f3778334f2e08a7ba59363c"},
+    {file = "xxhash-3.5.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d30bbc1644f726b825b3278764240f449d75f1a8bdda892e641d4a688b1494ae"},
+    {file = "xxhash-3.5.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fa0b72f2423e2aa53077e54a61c28e181d23effeaafd73fcb9c494e60930c8e"},
+    {file = "xxhash-3.5.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:13de2b76c1835399b2e419a296d5b38dc4855385d9e96916299170085ef72f57"},
+    {file = "xxhash-3.5.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:0691bfcc4f9c656bcb96cc5db94b4d75980b9d5589f2e59de790091028580837"},
+    {file = "xxhash-3.5.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:297595fe6138d4da2c8ce9e72a04d73e58725bb60f3a19048bc96ab2ff31c692"},
+    {file = "xxhash-3.5.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc1276d369452040cbb943300dc8abeedab14245ea44056a2943183822513a18"},
+    {file = "xxhash-3.5.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2061188a1ba352fc699c82bff722f4baacb4b4b8b2f0c745d2001e56d0dfb514"},
+    {file = "xxhash-3.5.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:38c384c434021e4f62b8d9ba0bc9467e14d394893077e2c66d826243025e1f81"},
+    {file = "xxhash-3.5.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e6a4dd644d72ab316b580a1c120b375890e4c52ec392d4aef3c63361ec4d77d1"},
+    {file = "xxhash-3.5.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:531af8845aaadcadf951b7e0c1345c6b9c68a990eeb74ff9acd8501a0ad6a1c9"},
+    {file = "xxhash-3.5.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ce379bcaa9fcc00f19affa7773084dd09f5b59947b3fb47a1ceb0179f91aaa1"},
+    {file = "xxhash-3.5.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd1b2281d01723f076df3c8188f43f2472248a6b63118b036e641243656b1b0f"},
+    {file = "xxhash-3.5.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c770750cc80e8694492244bca7251385188bc5597b6a39d98a9f30e8da984e0"},
+    {file = "xxhash-3.5.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:b150b8467852e1bd844387459aa6fbe11d7f38b56e901f9f3b3e6aba0d660240"},
+    {file = "xxhash-3.5.0.tar.gz", hash = "sha256:84f2caddf951c9cbf8dc2e22a89d4ccf5d86391ac6418fe81e3c67d0cf60b45f"},
+]
+
+[[package]]
 name = "yarl"
 version = "1.18.0"
 description = "Yet another URL library"
@@ -3233,4 +3378,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "4c321d73a281e5b03a3b90ffc34ea073d496d7012d6020580fdf5a2210bdf1e8"
+content-hash = "75d44985fe4b88957a1b0cfa2e99e39c81d1fcc112818360961ab31a672db454"

--- a/Mimecast/pyproject.toml
+++ b/Mimecast/pyproject.toml
@@ -14,6 +14,8 @@ python-dateutil = "^2.9.0.post0"
 orjson = "^3.10.3"
 aiohttp = "^3.9.5"
 structlog = "^24.4.0"
+cachetools = "^5.5.2"
+xxhash = "^3.5.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/Mimecast/tests/test_helpers.py
+++ b/Mimecast/tests/test_helpers.py
@@ -370,3 +370,50 @@ def test_filter_processed_events():
     cache = LRUCache(maxsize=100)
     assert len(filter_processed_events(events, cache)) == 4
     assert len(cache) == 4
+
+
+def test_filter_processed_events_empty_list():
+    cache = LRUCache(maxsize=100)
+
+    # Should handle empty input without errors
+    result = filter_processed_events([], cache)
+    assert result == []
+
+
+def test_filter_processed_events_with_prepopulated_cache():
+    cache = LRUCache(maxsize=100)
+
+    # Pre-populate the cache by processing initial events
+    base_events = [
+        {
+            "processingId": "id1",
+            "aggregateId": "agg1",
+            "senderEnvelope": "a@example.com",
+            "recipients": "b@example.com",
+            "messageId": "<msg1>",
+            "type": "test",
+        },
+        {
+            "processingId": "id2",
+            "aggregateId": "agg2",
+            "senderEnvelope": "c@example.com",
+            "recipients": "d@example.com",
+            "messageId": "<msg2>",
+            "type": "test",
+        },
+    ]
+    first_run = filter_processed_events(base_events, cache)
+    assert first_run == base_events
+
+    # Only a new event should be returned on subsequent calls
+    new_event = {
+        "processingId": "id3",
+        "aggregateId": "agg3",
+        "senderEnvelope": "e@example.com",
+        "recipients": "f@example.com",
+        "messageId": "<msg3>",
+        "type": "test",
+    }
+    mixed = base_events + [new_event]
+    second_run = filter_processed_events(mixed, cache)
+    assert second_run == [new_event]

--- a/Mimecast/tests/test_helpers.py
+++ b/Mimecast/tests/test_helpers.py
@@ -8,7 +8,7 @@ import pytest
 import requests_mock
 from aioresponses import aioresponses
 
-from mimecast_modules.helpers import AsyncGeneratorConverter, download_batches, batched
+from mimecast_modules.helpers import AsyncGeneratorConverter, download_batches, batched, compute_hash_event
 
 
 @pytest.fixture
@@ -145,3 +145,164 @@ def test_async_generator_converter_empty_generator(event_loop):
     sync_generator = AsyncGeneratorConverter(async_empty_generator(), event_loop)
     assert isinstance(sync_generator, Iterable)
     assert list(sync_generator) == []
+
+
+def test_compute_hash_event_0():
+    event = {
+        "processingId": "processingId",
+        "aggregateId": "aggregateId",
+        "sha1": "816b013c8be6e5708690645964b5d442c085041e",
+        "eventType": "attachment protect",
+    }
+    expected_hash = "02eddf2a8696fee8"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_1():
+    event = {
+        "processingId": "processingId",
+        "aggregateId": "aggregateId",
+        "eventType": "av",
+        "sha1": "816b013c8be6e5708690645964b5d442c085041e",
+    }
+    expected_hash = "574e5293b45f309c"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_2():
+    event = {
+        "processingId": "processingId",
+        "aggregateId": "aggregateId",
+        "messageId": "<11111111111111111111111111111111111111@mail.gmail.com>",
+        "senderEnvelope": "john.doe@example.org",
+        "recipients": "jane.doe@example.com",
+        "type": "delivery",
+    }
+    expected_hash = "a35ffb02f9760e7b"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_3():
+    event = {
+        "processingId": "processingId",
+        "aggregateId": "aggregateId",
+        "senderEnvelope": "auser@mimecast.com",
+        "messageId": "",
+        "eventType": "impersonation protect",
+        "recipients": "auser@mimecast.com",
+    }
+    expected_hash = "d11ab383ea2333e3"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_4():
+    event = {
+        "processingId": "processingId",
+        "aggregateId": "aggregateId",
+        "messageId": "<11111111111111111111111111111111111111@mail.gmail.com>",
+        "senderEnvelope": "john.doe@example.org",
+        "recipients": "jane.doe@example.com",
+        "type": "internal email protect",
+    }
+    expected_hash = "0d63710a4d0f504c"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_5():
+    event = {
+        "aggregateId": "vC80NNxvOWKkBPnzSs04FA_1715699686",
+        "processingId": "PGZfGuxEAu_kE-nGy1sjThBr5EYbm1ZcDKg-vXbRHLA_1715699686",
+        "senderEnvelope": "newsletter@stub.com",
+        "recipients": "neo@gmail.fr",
+        "type": "journal",
+    }
+    expected_hash = "3746a53dd8723b0e"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_6():
+    event = {
+        "aggregateId": "J5JwSy0HNvG7AvCg1sgDvQ_1715708284",
+        "processingId": "hP5f7mBanAVkWJWfh4vYvca3zOi9I3jROBmH3Z_Kysk_1715708284",
+        "senderEnvelope": "john.doe015@gmail.com",
+        "messageId": "<777777777777777777777777777777777777777777777777777@mail.gmail.com>",
+        "type": "process",
+    }
+    expected_hash = "a6551d97df29ce95"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_7():
+    event = {
+        "processingId": "processingId",
+        "aggregateId": "aggregateId",
+        "senderEnvelope": "auser@mimecast.com",
+        "messageId": "messageId",
+        "eventType": "process",
+    }
+    expected_hash = "fe9d2e277f8a02e5"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_8():
+    event = {
+        "aggregateId": "aggId1",
+        "processingId": "AAA_123",
+        "senderEnvelope": "johndoe@gmail.com",
+        "messageId": "1@mail.gmail.com>",
+        "type": "process",
+    }
+    expected_hash = "3255b48e58585be1"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_9():
+    event = {
+        "aggregateId": "J5JwSy0HNvG7AvCg1sgDvQ_1715708284",
+        "processingId": "hP5f7mBanAVkWJWfh4vYvca3zOi9I3jROBmH3Z_Kysk_1715708284",
+        "senderEnvelope": "john.doe@gmail.com",
+        "messageId": "<444444444444444444444444444444444444444444444444444@mail.gmail.com>",
+        "recipients": "admin@example.org",
+        "type": "receipt",
+    }
+    expected_hash = "beeba37b97f065c0"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_10():
+    event = {
+        "aggregateId": "YvXi4vUANvSwDaBxkq6SYA",
+        "processingId": "RMkDQFp7L5gGaZ5jnsGVW4zLmvTVvWVb0lQeO9EBDRo_1736242544",
+        "senderEnvelope": "john.doe@gmail.com",
+        "messageId": "<111111111111111111111111111111111111111111111111111@mail.gmail.com>",
+        "recipients": "admin@example.org",
+        "type": "receipt",
+    }
+    expected_hash = "5e3912e39fc44867"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_11():
+    event = {
+        "processingId": "processingId",
+        "aggregateId": "aggregateId",
+        "messageId": "<11111111111111111111111111111111111111@mail.gmail.com>",
+        "senderEnvelope": "john.doe@example.org",
+        "recipients": "jane.doe@example.com",
+        "type": "spam",
+    }
+    expected_hash = "d3121312806537c0"
+    assert compute_hash_event(event) == expected_hash
+
+
+def test_compute_hash_event_12():
+    event = {
+        "processingId": "req-aa8ae4a3334b30fbb07bbb9c2fb69048_1715766931",
+        "aggregateId": "Y12X0yjKNr6A6yhIH48Wkw_1715766931",
+        "senderEnvelope": "jeanne@gmail.com",
+        "recipients": "john@example.org",
+        "messageId": "<555555555555555555555555555555555555555555555555555@mail.gmail.com>",
+        "type": "url protect",
+    }
+    expected_hash = "20245787bb2fc8f7"
+    assert compute_hash_event(event) == expected_hash


### PR DESCRIPTION
Add and persist a cache to filter out already collected events.

## Summary by Sourcery

Add hash-based event deduplication with a persistent LRU cache to filter out already collected Mimecast SIEM events

New Features:
- Compute a unique hash for each event and filter out already processed events
- Persist the event hash cache across runs using a JSON-backed LRU cache

Enhancements:
- Integrate cache loading and saving into the SIEM connector to apply deduplication during event fetch
- Update connector logic to skip events present in the cache before pushing to intake

Build:
- Add cachetools and xxhash dependencies

Documentation:
- Bump version to 1.1.14 in manifest and update CHANGELOG

Tests:
- Add unit tests for event hashing and filter logic
- Add end-to-end test to verify deduplication during SIEM batch processing