### PR TITLE
Fix: sentinel one custom errors (558)

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-05 - 1.20.6
+
+### Fixed
+
+- Add custom error handling
+
 ## 2025-05-05 - 1.20.5
 
 ### Fixed

--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2025-05-05 - 1.20.6
+## 2025-05-14 - 1.20.6
 
 ### Fixed
 
-- Add custom error handling
+- Improve error handling in the connector
 
 ## 2025-05-05 - 1.20.5
 

--- a/SentinelOne/CONFIGURE.md
+++ b/SentinelOne/CONFIGURE.md
@@ -6,11 +6,11 @@ For the action `Update Threat Incident`, there are two arguments `status` and `f
 
 **Arguments**
 
-| Name      |  Type   |  Description  |
-| --------- | ------- | --------------------------- |
-| `agent_ids` | `string` | List of Agent IDs to filter by |
-| `account_ids` | `array` | List of Account IDs to filter by |
-| `group_ids` | `array` | List of network group to filter by |
-| `site_ids` | `array` | List of Site IDs to filter by |
-| `ids` | `array` | List of threat IDs |
-| `analyst_verdicts` | `string` | Verdicts of the analyst |
+| Name               | Type     | Description                        |
+|--------------------|----------|------------------------------------|
+| `agent_ids`        | `string` | List of Agent IDs to filter by     |
+| `account_ids`      | `array`  | List of Account IDs to filter by   |
+| `group_ids`        | `array`  | List of network group to filter by |
+| `site_ids`         | `array`  | List of Site IDs to filter by      |
+| `ids`              | `array`  | List of threat IDs                 |
+| `analyst_verdicts` | `string` | Verdicts of the analyst            |

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.20.5",
+  "version": "1.20.6",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/exceptions.py
+++ b/SentinelOne/sentinelone_module/exceptions.py
@@ -1,3 +1,6 @@
+from management.mgmtsdk_v2.client import ManagementResponse
+
+
 class SentinelOneError(Exception):
     pass
 
@@ -79,3 +82,23 @@ class GetMalwaresTimeoutError(GetMalwaresError):
 
     def __init__(self, timeout: int):
         super().__init__(f"The malware retrieval reached the timeout: {timeout}s")
+
+
+class SentinelOneManagementResponseError(SentinelOneError):
+    """Exception raised when response contains errors inside the body"""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+    @classmethod
+    def create_and_raise(cls, response: ManagementResponse):
+        if response.errors:
+            raise SentinelOneManagementResponseError(
+                message=f"SentinelOne API response contains errors: {response.errors}"
+            )
+
+
+SENTINEL_ONE_EMPTY_RESPONSE = SentinelOneManagementResponseError(
+    message="Empty response from SentinelOne API",
+)


### PR DESCRIPTION
Closes [558](https://github.com/SekoiaLab/integration/issues/558)

## Summary by Sourcery

Improve error handling in SentinelOne logs connector by introducing custom exceptions for empty and error-filled API responses, updating consumers to validate and raise these errors, refining logging in next_batch, and updating documentation, tests, and versioning to 1.20.6

Enhancements:
- Introduce SentinelOneManagementResponseError and SENTINEL_ONE_EMPTY_RESPONSE to enforce error handling for empty or erroneous API responses
- Update pull_events in activity and threat consumers to validate responses and raise custom exceptions before processing
- Add specific exception handlers in next_batch to log contextual errors from SentinelOne API
- Rename event identifier variable from events_id to events_ids for consistency

Documentation:
- Reformat argument table in CONFIGURE.md and update version to 1.20.6 in manifest and CHANGELOG.md

Tests:
- Add test to assert SentinelOneManagementResponseError is raised when API responses contain errors

Chores:
- Bump package version to 1.20.6 and add release notes to CHANGELOG