### PR TITLE
Bump sekoia module version after the fix

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-04-14 - 2.67.15
+
+### Fixed
+
+- Fix datetime serialization problem
+
 ## 2025-04-10 - 2.67.14
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.67.14",
+  "version": "2.67.15",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Prepare Sekoia.io 2.67.15 release by bumping the module version and documenting the datetime serialization fix

Bug Fixes:
- Fix datetime serialization problem

Build:
- Bump Sekoia.io module version to 2.67.15

Documentation:
- Add 2.67.15 release entry to CHANGELOG.md