### PR TITLE
Fix: Checkpoint Harmony Hours Window (615)

### DIFF
--- a/Checkpoint/CHANGELOG.md
+++ b/Checkpoint/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-16 - 1.4.2
+
+### Changed
+
+- Make hour window configurable
+
 ## 2024-10-30 - 1.4.1
 
 ### Fixed

--- a/Checkpoint/connector_checkpoint_harmony_mobile_events.json
+++ b/Checkpoint/connector_checkpoint_harmony_mobile_events.json
@@ -27,6 +27,11 @@
         "description": "Batch frequency in seconds",
         "default": 60,
         "type": "integer"
+      },
+      "hours_ago": {
+        "description": "Number of hours to go back in time to collect events. Will be used during the first run",
+        "default": 6,
+        "type": "integer"
       }
     },
     "required": [

--- a/Checkpoint/manifest.json
+++ b/Checkpoint/manifest.json
@@ -35,7 +35,7 @@
   "name": "Check Point",
   "uuid": "096f4eda-68dd-11ee-8c99-0242ac120002",
   "slug": "checkpoint",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "categories": [
     "Network"
   ]

--- a/Checkpoint/tests/connectors/test_checkpoint_harmony_mobile_connector.py
+++ b/Checkpoint/tests/connectors/test_checkpoint_harmony_mobile_connector.py
@@ -116,7 +116,7 @@ async def test_checkpoint_harmony_connector_last_event_date(
         cache["last_event_date"] = None
 
     current_date = datetime.now(timezone.utc).replace(microsecond=0)
-    one_hour_ago = current_date - timedelta(hours=1)
+    one_hour_ago = current_date - timedelta(hours=6)
 
     assert checkpoint_harmony_connector.last_event_date == one_hour_ago
 

--- a/Checkpoint/trigger_checkpoint_harmony_mobile_events.json
+++ b/Checkpoint/trigger_checkpoint_harmony_mobile_events.json
@@ -27,6 +27,11 @@
         "description": "Batch frequency in seconds",
         "default": 60,
         "type": "integer"
+      },
+      "hours_ago": {
+        "description": "Number of hours to go back in time to collect events. Will be used during the first run",
+        "default": 6,
+        "type": "integer"
       }
     },
     "required": [


### PR DESCRIPTION
Closes [615](https://github.com/SekoiaLab/integration/issues/615)

## Summary by Sourcery

Enable customizing the event fetch window for the Checkpoint Harmony Mobile connector by introducing an hours_ago parameter (defaulting to 6 hours) and update the release version to 1.4.2.

Enhancements:
- Add configurable hours_ago setting to control the lookback window for event retrieval
- Apply the hours_ago configuration in last_event_date instead of a fixed one-hour window

Documentation:
- Update CHANGELOG with version 1.4.2 and note the configurable hour window

Chores:
- Bump connector version to 1.4.2 in manifest.json