### PR TITLE
Checkpoint Harmony: fix alert model

### DIFF
--- a/Checkpoint/CHANGELOG.md
+++ b/Checkpoint/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-20 - 1.4.3
+
+### Fixed
+
+- Fix the Alert model
+
 ## 2025-05-16 - 1.4.2
 
 ### Changed

--- a/Checkpoint/client/schemas/harmony_mobile_schemas.py
+++ b/Checkpoint/client/schemas/harmony_mobile_schemas.py
@@ -15,7 +15,7 @@ class HarmonyMobileSchema(BaseModel):
     device_rooted: bool
     attack_vector: str
     details: str
-    device_id: str | int # A string according to the openapi spec, but an integer according to the API response
+    device_id: str | int  # A string according to the openapi spec, but an integer according to the API response
     email: str
     event: str
     mdm_uuid: str

--- a/Checkpoint/client/schemas/harmony_mobile_schemas.py
+++ b/Checkpoint/client/schemas/harmony_mobile_schemas.py
@@ -8,14 +8,14 @@ class HarmonyMobileSchema(BaseModel):
     Model that represent Harmony Mobile Result schema.
 
     More information is here:
-    https://app.swaggerhub.com/apis-docs/Check-Point/harmony-mobile/1.0.0-oas3#/Events/GetAlerts
+    https://app.swaggerhub.com/apis-docs/Check-Point/harmony-mobile/ then search for "Get /external_api/v3/alerts"
     """
 
     id: int
     device_rooted: bool
     attack_vector: str
     details: str
-    device_id: str
+    device_id: str | int # A string according to the openapi spec, but an integer according to the API response
     email: str
     event: str
     mdm_uuid: str

--- a/Checkpoint/manifest.json
+++ b/Checkpoint/manifest.json
@@ -35,7 +35,7 @@
   "name": "Check Point",
   "uuid": "096f4eda-68dd-11ee-8c99-0242ac120002",
   "slug": "checkpoint",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "categories": [
     "Network"
   ]


### PR DESCRIPTION
According to the [openAPI spec](https://app.swaggerhub.com/apis-docs/Check-Point/harmony-mobile/1.0.0-oas6#/), the device id must be a string. However, according to the API, it seems to be an integer.

## Summary by Sourcery

Fix Alert model to accept integer device_id values alongside strings to match API responses and prepare for the 1.4.3 release

Bug Fixes:
- Allow device_id in the Alert schema to be either a string or an integer per actual API behavior

Chores:
- Update CHANGELOG with the 1.4.3 release entry dated 2025-05-20
- Bump manifest.json version from 1.4.2 to 1.4.3