### PR TITLE
Action get telemetry agent

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-20 - 1.26.0
+
+### Added
+
+- Added action to retrieve agent telemetry
+
 ## 2024-10-24 - 1.25.0
 
 ### Added

--- a/HarfangLab/action_harfanglab_get_agent_telemetry.json
+++ b/HarfangLab/action_harfanglab_get_agent_telemetry.json
@@ -1,0 +1,46 @@
+{
+  "arguments": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "agent_id": {
+        "description": "HarfangLab agent id",
+        "type": "string"
+      },
+      "event_types": {
+        "description": "A list of telemetry event types to collect. Available event types: processes, windows_authentications, linux_authentications, macos_authentications, binary, network, dns, eventlog",
+        "type": "array",
+        "default": ["processes", "windows_authentications", "linux_authentications", "macos_authentications"]
+      },
+      "alert_created": {
+        "description": "Reference timestamp used to retrieve telemetry data",
+        "type": "string"
+      }, 
+      "timerange": {
+        "description": "Number of minutes before and after the reference timestamp used to define the data-collection time window",
+        "type": "integer",
+        "default": 15
+      }
+    },
+    "required": [ "agent_id", "alert_created" ],
+    "title": "Arguments",
+    "type": "object"
+  },
+  "description": "Get telemetry of an agent by its agentid",
+  "docker_parameters": "harfanglab_get_agent_telemetry",
+  "name": "Get agent telemetry",
+  "results": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "results": {
+        "description": "Telemetry results",
+        "type": "array",
+        "items": {
+          "type": "object"
+        }
+      }
+    },
+    "title": "Results",
+    "type": "object"
+  },
+  "uuid": "c95cf5c0-8d5c-425d-907f-09c9c2bb7edb"
+}

--- a/HarfangLab/harfanglab/get_agent_telemetry.py
+++ b/HarfangLab/harfanglab/get_agent_telemetry.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+
+# natives
+from typing import Any
+from datetime import datetime, timedelta
+
+import requests
+from sekoia_automation.action import Action
+
+
+class GetAgentTelemetry(Action):
+    """
+    Action to retrieve telemetry for a specific HarfangLab agent
+    """
+
+    def send_request(self, base_url, api_endpoint, api_token, params):
+        url = base_url.rstrip("/") + api_endpoint
+        resp = requests.get(
+            url,
+            headers={"Authorization": f"Token {api_token}"},
+            params=params,
+        )
+        resp.raise_for_status()
+        return resp
+
+    def run(self, arguments) -> dict:
+
+        telemetry_urls = {
+            "processes": "/api/data/telemetry/Processes/",
+            "binary": "/api/data/telemetry/Binary/",
+            "network": "/api/data/telemetry/Network/",
+            "eventlog": "/api/data/telemetry/FullEventLog/",
+            "dns": "/api/data/telemetry/DNSResolution/",
+            "windows_authentications": "/api/data/telemetry/authentication/AuthenticationWindows/",
+            "linux_authentications": "/api/data/telemetry/authentication/AuthenticationLinux/",
+            "macos_authentications": "/api/data/telemetry/authentication/AuthenticationMacos/",
+        }
+
+        agent_id = arguments.get("agent_id", "")
+        event_types = arguments.get(
+            "event_types", ["processes", "windows_authentications", "linux_authentications", "macos_authentications"]
+        )
+        alert_created = arguments.get("alert_created", "")
+        timerange = arguments.get("timerange", 15)
+        dt = datetime.fromisoformat(alert_created.replace("Z", "+00:00"))
+        start = (dt - timedelta(minutes=timerange)).isoformat().replace("+00:00", "Z")
+        end = (dt + timedelta(minutes=timerange)).isoformat().replace("+00:00", "Z")
+        instance_url: str = self.module.configuration["url"]
+        api_token: str = self.module.configuration["api_token"]
+
+        results = []
+        for event_type in event_types:
+            offset = 0
+            if event_type not in telemetry_urls.keys():
+                raise ValueError(f"Invalid event type: {event_type}. Must be one of {list(telemetry_urls.keys())}.")
+            while True:
+                resp = self.send_request(
+                    base_url=instance_url,
+                    api_endpoint=telemetry_urls[event_type],
+                    api_token=api_token,
+                    params={
+                        "agent.agentid": agent_id,
+                        "@event_create_date__gte": start,
+                        "@event_create_date__lte": end,
+                        "limit": 50,
+                        "offset": offset,
+                    },
+                )
+                js = resp.json()
+                next_query = js["next"]
+                for r in js["results"]:
+                    results.append(r)
+                if next_query is None:
+                    break
+                offset += len(js["results"])
+
+        return results

--- a/HarfangLab/harfanglab/get_agent_telemetry.py
+++ b/HarfangLab/harfanglab/get_agent_telemetry.py
@@ -23,7 +23,7 @@ class GetAgentTelemetry(Action):
         resp.raise_for_status()
         return resp
 
-    def run(self, arguments) -> dict:
+    def run(self, arguments) -> list[dict]:
 
         telemetry_urls = {
             "processes": "/api/data/telemetry/Processes/",

--- a/HarfangLab/main.py
+++ b/HarfangLab/main.py
@@ -8,6 +8,7 @@ from harfanglab.endpoint_actions import (
     EndpointGroupIsolationAction,
 )
 from harfanglab.get_hostnames_by_ip_action import GetHostnamesByIP
+from harfanglab.get_agent_telemetry import GetAgentTelemetry
 from harfanglab.get_pipe_list_action import GetPipeListAction
 from harfanglab.get_process_list_action import GetProcessListAction
 from harfanglab.iocs import CreateIOCs
@@ -22,6 +23,7 @@ if __name__ == "__main__":
     module.register(EndpointAgentIsolationAction, "harfanglab_endpoint_agent_isolation")
     module.register(EndpointAgentDeisolationAction, "harfanglab_endpoint_agent_deisolation")
     module.register(GetHostnamesByIP, "harfanglab_get_hostnames_by_ip")
+    module.register(GetAgentTelemetry, "harfanglab_get_agent_telemetry")
     module.register(DownloadFileFromEndpointAction, "harfanglab_download_file_from_endpoint")
     module.register(UpdateThreatStatus, "harfanglab_update_threat_status")
     module.register(AddCommentToThreat, "harfanglab_add_comment_to_threat")

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -21,6 +21,6 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "categories": ["Endpoint"]
 }

--- a/HarfangLab/tests/test_get_agent_telemetry.py
+++ b/HarfangLab/tests/test_get_agent_telemetry.py
@@ -1,5 +1,6 @@
 import requests_mock
 from harfanglab.get_agent_telemetry import GetAgentTelemetry
+import pytest
 
 
 def test_integration_get_agent_telemetry():
@@ -89,3 +90,23 @@ def test_integration_get_agent_telemetry_next():
         response = action.run(arguments)
         assert response is not None
         assert len(response) == 3
+
+
+def test_integration_get_agent_telemetry_wrong_event_type():
+    instance_url = "https://test.hurukau.io"
+    api_token = "sss"
+
+    module_configuration = {
+        "api_token": api_token,
+        "url": instance_url,
+    }
+    action = GetAgentTelemetry()
+    action.module.configuration = module_configuration
+
+    arguments = {
+        "agent_id": "7e19e65f-7c91-4cd6-b365-b0e603576f0d",
+        "alert_created": "2025-04-29T17:54:49.326Z",
+        "event_types": ["test"],
+    }
+    with pytest.raises(ValueError):
+        action.run(arguments)

--- a/HarfangLab/tests/test_get_agent_telemetry.py
+++ b/HarfangLab/tests/test_get_agent_telemetry.py
@@ -38,3 +38,56 @@ def test_integration_get_agent_telemetry():
         response = action.run(arguments)
         assert response is not None
         assert len(response) == 2
+
+
+def test_integration_get_agent_telemetry_next():
+    instance_url = "https://test.hurukau.io"
+    api_token = "sss"
+
+    module_configuration = {
+        "api_token": api_token,
+        "url": instance_url,
+    }
+    action = GetAgentTelemetry()
+    action.module.configuration = module_configuration
+
+    with requests_mock.Mocker() as mock:
+        mocked_response = {
+            "count": 3,
+            "next": "next_url",
+            "previous": "previous_url",
+            "results": [
+                {"host": "host1"},
+                {"host": "host2"},
+            ],
+        }
+
+        mock.get(
+            f"{instance_url}/api/data/telemetry/Processes/",
+            json=mocked_response,
+            headers={"Authorization": f"Token {api_token}"},
+        )
+
+        mocked_response_next = {
+            "count": 3,
+            "next": None,
+            "previous": None,
+            "results": [
+                {"host": "host3"}
+            ],
+        }
+
+        mock.get(
+            f"{instance_url}/api/data/telemetry/Processes/?offset=2",
+            json=mocked_response_next,
+            headers={"Authorization": f"Token {api_token}"},
+        )
+
+        arguments = {
+            "agent_id": "7e19e65f-7c91-4cd6-b365-b0e603576f0d",
+            "alert_created": "2025-04-29T17:54:49.326Z",
+            "event_types": ["processes"],
+        }
+        response = action.run(arguments)
+        assert response is not None
+        assert len(response) == 3

--- a/HarfangLab/tests/test_get_agent_telemetry.py
+++ b/HarfangLab/tests/test_get_agent_telemetry.py
@@ -1,0 +1,40 @@
+import requests_mock
+from harfanglab.get_agent_telemetry import GetAgentTelemetry
+
+
+def test_integration_get_agent_telemetry():
+    instance_url = "https://test.hurukau.io"
+    api_token = "sss"
+
+    module_configuration = {
+        "api_token": api_token,
+        "url": instance_url,
+    }
+    action = GetAgentTelemetry()
+    action.module.configuration = module_configuration
+
+    with requests_mock.Mocker() as mock:
+        mocked_response = {
+            "count": 158,
+            "next": None,
+            "previous": None,
+            "results": [
+                {"host": "host1"},
+                {"host": "host2"},
+            ],
+        }
+
+        mock.get(
+            f"{instance_url}/api/data/telemetry/Processes/",
+            json=mocked_response,
+            headers={"Authorization": f"Token {api_token}"},
+        )
+
+        arguments = {
+            "agent_id": "7e19e65f-7c91-4cd6-b365-b0e603576f0d",
+            "alert_created": "2025-04-29T17:54:49.326Z",
+            "event_types": ["processes"],
+        }
+        response = action.run(arguments)
+        assert response is not None
+        assert len(response) == 2

--- a/HarfangLab/tests/test_get_agent_telemetry.py
+++ b/HarfangLab/tests/test_get_agent_telemetry.py
@@ -72,9 +72,7 @@ def test_integration_get_agent_telemetry_next():
             "count": 3,
             "next": None,
             "previous": None,
-            "results": [
-                {"host": "host3"}
-            ],
+            "results": [{"host": "host3"}],
         }
 
         mock.get(


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new action to fetch telemetry data for a HarfangLab agent across configurable event types and time ranges.

New Features:
- Add GetAgentTelemetry action to retrieve agent telemetry via multiple API endpoints

Documentation:
- Update CHANGELOG with 1.26.0 entry for the agent telemetry action

Tests:
- Add integration test for the GetAgentTelemetry action

Chores:
- Bump version to 1.26.0 in manifest