### PR TITLE
Fix return type

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-20 - 1.26.1
+
+### Added
+
+- Update return type for agent telemetry action
+
 ## 2025-05-20 - 1.26.0
 
 ### Added

--- a/HarfangLab/action_harfanglab_get_agent_telemetry.json
+++ b/HarfangLab/action_harfanglab_get_agent_telemetry.json
@@ -31,12 +31,9 @@
   "results": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
-      "results": {
+      "data": {
         "description": "Telemetry results",
-        "type": "array",
-        "items": {
-          "type": "object"
-        }
+        "type": "array"
       }
     },
     "title": "Results",

--- a/HarfangLab/harfanglab/get_agent_telemetry.py
+++ b/HarfangLab/harfanglab/get_agent_telemetry.py
@@ -23,7 +23,7 @@ class GetAgentTelemetry(Action):
         resp.raise_for_status()
         return resp
 
-    def run(self, arguments) -> list[dict]:
+    def run(self, arguments) -> dict[str, Any]:
 
         telemetry_urls = {
             "processes": "/api/data/telemetry/Processes/",
@@ -74,4 +74,4 @@ class GetAgentTelemetry(Action):
                     break
                 offset += len(js["results"])
 
-        return results
+        return {"data": results}

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -21,6 +21,6 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "categories": ["Endpoint"]
 }

--- a/HarfangLab/tests/test_get_agent_telemetry.py
+++ b/HarfangLab/tests/test_get_agent_telemetry.py
@@ -37,8 +37,8 @@ def test_integration_get_agent_telemetry():
             "event_types": ["processes"],
         }
         response = action.run(arguments)
-        assert response is not None
-        assert len(response) == 2
+        assert response["data"] is not None
+        assert len(response["data"]) == 2
 
 
 def test_integration_get_agent_telemetry_next():
@@ -88,8 +88,8 @@ def test_integration_get_agent_telemetry_next():
             "event_types": ["processes"],
         }
         response = action.run(arguments)
-        assert response is not None
-        assert len(response) == 3
+        assert response["data"] is not None
+        assert len(response["data"]) == 3
 
 
 def test_integration_get_agent_telemetry_wrong_event_type():


### PR DESCRIPTION
## Summary by Sourcery

Change get_agent_telemetry to return a dict containing the results under a "data" field, update tests and documentation, and bump the module version to 1.26.1.

Enhancements:
- Wrap telemetry results in a dictionary under the "data" key instead of returning a raw list.
- Update the return type annotation of the get_agent_telemetry action to reflect the new structure.

Documentation:
- Add a changelog entry for version 1.26.1 describing the return type update.

Tests:
- Adjust integration tests to assert against response["data"] and its length.

Chores:
- Bump manifest version to 1.26.1.