### PR TITLE
fix(sekoiaio): return confidence when resolving sources

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2025-04-14 - 2.68.0
+## 2025-05-28 - 2.68.1
+
+### Fixed
+
+- Returning confidence when resolving source references from Feed consumption.
+
+## 2025-05-27 - 2.68.0
 
 ### Added
 

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.68.0",
+  "version": "2.68.1",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/triggers/intelligence.py
+++ b/Sekoia.io/sekoiaio/triggers/intelligence.py
@@ -136,7 +136,10 @@ class FeedConsumptionTrigger(Trigger):
         # Adding sources to the cache
         sources = self.fetch_objects(sources_to_fetch)
         for source in sources:
-            self.sources_caches[source["id"]] = source["name"]
+            self.sources_caches[source["id"]] = {
+                "name": source["name"],
+                "confidence": source.get("confidence", 0),
+            }
 
         # Getting sources from the cache
         for object in objects:

--- a/Sekoia.io/tests/ic_oc_triggers/test_intelligence.py
+++ b/Sekoia.io/tests/ic_oc_triggers/test_intelligence.py
@@ -27,6 +27,7 @@ def object_factory(index: int, sources: list[str] = []):
         "created": "2022-02-17T09:40:40.579507Z",
         "modified": "2025-05-26T12:17:29.594654Z",
         "revoked": False,
+        "confidence": 50,
         "x_inthreat_sources_refs": sources,
     }
 
@@ -119,14 +120,25 @@ def test_resolve_sources(trigger):
         )
 
         objects = trigger.resolve_sources(objects)
-        assert objects[0]["x_inthreat_sources"] == [source_object1["name"], source_object2["name"]]
+
+        assert objects[0]["x_inthreat_sources"] == [
+            {"name": source_object1["name"], "confidence": source_object1["confidence"]},
+            {"name": source_object2["name"], "confidence": source_object2["confidence"]},
+        ]
         assert objects[0]["x_inthreat_sources_refs"] == [source_object1["id"], source_object2["id"]]
-        assert objects[1]["x_inthreat_sources"] == [source_object2["name"], source_object3["name"]]
+        assert objects[0]["x_inthreat_sources"] == [
+            {"name": source_object1["name"], "confidence": source_object1["confidence"]},
+            {"name": source_object2["name"], "confidence": source_object2["confidence"]},
+        ]
         assert objects[1]["x_inthreat_sources_refs"] == [source_object2["id"], source_object3["id"]]
+        assert objects[1]["x_inthreat_sources"] == [
+            {"name": source_object2["name"], "confidence": source_object2["confidence"]},
+            {"name": source_object3["name"], "confidence": source_object3["confidence"]},
+        ]
         assert trigger.sources_caches == {
-            source_object1["id"]: source_object1["name"],
-            source_object2["id"]: source_object2["name"],
-            source_object3["id"]: source_object3["name"],
+            source_object1["id"]: {"name": source_object1["name"], "confidence": source_object1["confidence"]},
+            source_object2["id"]: {"name": source_object2["name"], "confidence": source_object2["confidence"]},
+            source_object3["id"]: {"name": source_object3["name"], "confidence": source_object3["confidence"]},
         }
 
 


### PR DESCRIPTION
Returning confidence + name for sources in feed consumption

## Summary by Sourcery

Return confidence values alongside source names when resolving sources in feed consumption

Bug Fixes:
- Include confidence in resolved source references for feed consumption

Build:
- Bump package version to 2.68.1 in manifest and changelog

Documentation:
- Update CHANGELOG for version 2.68.1

Tests:
- Adjust tests to expect name and confidence pairs in resolve_sources output