### PR TITLE
Fix: SentinelOne split checkpoint (678)

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-30 - 1.20.8
+
+### Changed
+
+- Split checkpoints by consumer type
+
 ## 2025-05-26 - 1.20.7
 
 ### Changed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.20.7",
+  "version": "1.20.8",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -65,6 +65,7 @@ class SentinelOneLogsConsumer(Thread):
         result_path = self.connector.data_path / consumer_type
         new_context = result_path / "context.json"
         if not result_path.exists():
+            logger.info("Migrating context file for consumer type", consumer_type=consumer_type)
             result_path.mkdir(parents=True, exist_ok=True)
             old_context = self.connector.data_path / "context.json"
             if old_context.exists():
@@ -72,6 +73,7 @@ class SentinelOneLogsConsumer(Thread):
                     with new_context.open("w") as new_file:
                         new_file.write(old_file.read())
 
+        logger.info("Checkpoint path for consumer", consumer_type=consumer_type, path=result_path)
         return result_path
 
     def stop(self):

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -44,13 +44,35 @@ class SentinelOneLogsConsumer(Thread):
         self._stop_event = Event()
 
         self.cursor = CheckpointDatetime(
-            path=self.connector.data_path,
+            path=self.get_data_path(consumer_type),
             start_at=timedelta(days=1),
             ignore_older_than=timedelta(days=1),
             lock=self.connector.context_lock,
         )
         self.from_date = self.cursor.offset
         self.session_events_cache: Cache = self.load_events_cache()
+
+    def get_data_path(self, consumer_type: str) -> Path:
+        # TEMPORARY SOLUTION ONLY!
+        #
+        # Checkpoint uses data path under the hood like below:
+        # PersistentJSON("context.json", path)
+        #
+        # Where `path` is the data path of the connector
+        # As we want to split checkpoints by consumer type we should perform transitional migration
+        #
+        # So if result_path does not exists, we should copy the context.json file into it
+        result_path = self.connector.data_path / consumer_type
+        new_context = result_path / "context.json"
+        if not result_path.exists():
+            result_path.mkdir(parents=True, exist_ok=True)
+            old_context = self.connector.data_path / "context.json"
+            if old_context.exists():
+                with old_context.open("r") as old_file:
+                    with new_context.open("w") as new_file:
+                        new_file.write(old_file.read())
+
+        return result_path
 
     def stop(self):
         """Sets the stop event for the thread"""
@@ -313,6 +335,7 @@ class SentinelOneLogsConnector(Connector):
     @property
     def data_path(self) -> Path:
         path_to_data: Path = self._data_path
+
         return path_to_data
 
     def start_consumers(self) -> dict:


### PR DESCRIPTION
Closes [678](https://github.com/SekoiaLab/integration/issues/678)

## Summary by Sourcery

Split checkpoint storage by consumer type with transitional migration and update the integration version.

Enhancements:
- Migrate existing context.json into consumer-specific data directories when initializing checkpoints
- Initialize CheckpointDatetime using a subfolder per consumer to isolate checkpoint files

Chores:
- Bump SentinelOne version to 1.20.8 and update CHANGELOG.md accordingly