### PR TITLE
fix(sekoiaio): returning empty list when fetching source references fa…

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-05-28 - 2.68.2
+
+### Fixed
+
+- Returning empty list when fetching source references failed.
+
 ## 2025-05-28 - 2.68.1
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.68.1",
+  "version": "2.68.2",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/synchronize_assets_with_ad.py
+++ b/Sekoia.io/sekoiaio/operation_center/synchronize_assets_with_ad.py
@@ -166,8 +166,8 @@ class SynchronizeAssetsWithAD(Action):
                 create_response = post_request(
                     endpoint="v2/asset-management/assets", json_data=json.dumps(payload_asset)
                 )
-                destination_asset = create_response.get("uuid", None)
-                if destination_asset is None:
+                destination_asset = create_response.get("uuid", "")
+                if destination_asset == "":
                     self.error("Asset creation response does not contain 'uuid'.")
 
                 # Merge found assets into the new asset

--- a/Sekoia.io/sekoiaio/triggers/intelligence.py
+++ b/Sekoia.io/sekoiaio/triggers/intelligence.py
@@ -106,9 +106,14 @@ class FeedConsumptionTrigger(Trigger):
             f"api/v2/inthreat/objects?match[id]={','.join(objects_id)}",
         )
         response = requests.get(url, headers={"Authorization": f"Bearer {api_key}"})
-
-        # manage the response
-        self._handle_response_error(response)
+        if not response.ok:
+            message = (
+                "Request on Sekoia.io API to fetch objects failed with status"
+                f" {response.status_code} - {response.reason},"
+                f"URL: {self.url}"
+            )
+            self.log(message=message, level="info")
+            return []
 
         # get data from the response
         data = response.json()

--- a/Sekoia.io/tests/ic_oc_triggers/test_intelligence.py
+++ b/Sekoia.io/tests/ic_oc_triggers/test_intelligence.py
@@ -101,6 +101,17 @@ def test_fetch_objects(trigger):
         assert objects == json["items"]
 
 
+def test_fetch_objects_error(trigger):
+    sources = ["source1", "source2"]
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            f"https://api.sekoia.io/api/v2/inthreat/objects?match[id]={','.join(sources)}", status_code=500, json={}
+        )
+
+        objects = trigger.fetch_objects(sources)
+        assert objects == []
+
+
 def test_resolve_sources(trigger):
     source_object1 = object_factory(1)
     source_object2 = object_factory(2)

--- a/Sekoia.io/trigger_sekoiaio_feed_consumption.json
+++ b/Sekoia.io/trigger_sekoiaio_feed_consumption.json
@@ -18,7 +18,7 @@
       },
       "resolve_sources": {
         "type": "boolean",
-        "description": "Adding x_inthreat_sources field in all objects with the resolved names of the sources",
+        "description": "Adding x_inthreat_sources field in all objects with the resolved names and confidences of the sources",
         "default": false
       }
     },

--- a/Sekoia.io/trigger_sekoiaio_feed_ioc_consumption.json
+++ b/Sekoia.io/trigger_sekoiaio_feed_ioc_consumption.json
@@ -18,7 +18,7 @@
       },
       "resolve_sources": {
         "type": "boolean",
-        "description": "Adding x_inthreat_sources field in all objects with the resolved names of the sources",
+        "description": "Adding x_inthreat_sources field in all objects with the resolved names and confidences of the sources",
         "default": false
       }
     },


### PR DESCRIPTION
fix(sekoiaio): returning empty list when fetching source references failed

## Summary by Sourcery

Return an empty list when source reference fetches fail and release version 2.68.2

Bug Fixes:
- Return an empty list on failed source reference fetch instead of raising an error

Build:
- Bump Sekoia.io integration version to 2.68.2

Documentation:
- Add changelog entry for version 2.68.2