### PR TITLE
Add type to fake asset connector

### DIFF
--- a/AssetConnector/CHANGELOG.md
+++ b/AssetConnector/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2025-06-16 - 1.0.1
+
+### Added
+
+- Add type to Fake asset connector

--- a/AssetConnector/connector_fake_assets.json
+++ b/AssetConnector/connector_fake_assets.json
@@ -3,6 +3,7 @@
   "description": "Fake Asset Connector for testing purposes",
   "uuid": "8e8afb65-235a-4144-8cab-b44f94784587",
   "docker_parameters": "fake_asset_connector",
+  "type": "asset", 
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/AssetConnector/manifest.json
+++ b/AssetConnector/manifest.json
@@ -23,5 +23,5 @@
   "slug": "fakeassetconnector",
   "name": "FakeAssetConnector",
   "uuid": "61cc14ee-8dd4-4ebd-9cdb-179f1e888d4c",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
## Summary by Sourcery

Add the type attribute to the fake asset connector and release version 1.0.1 with updated changelog.

Enhancements:
- Add a type field to the fake asset connector configuration

Build:
- Bump AssetConnector version to 1.0.1 in manifest.json

Documentation:
- Update CHANGELOG.md for version 1.0.1