### PR TITLE
fix(xsiam): regexp extracting stix pattern and add tests

### DIFF
--- a/PaloAltoXSIAM/CHANGELOG.md
+++ b/PaloAltoXSIAM/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 2025-05-28 - 0.1.0
+## 2026-03-31 - 1.0.1
+
+### Fixed
+
+- Regexp to extract value from STIX pattern
+
+## 2025-05-28 - 1.0.0
 
 ### Added
 

--- a/PaloAltoXSIAM/manifest.json
+++ b/PaloAltoXSIAM/manifest.json
@@ -9,7 +9,7 @@
   "name": "Palo Alto Cortex XSIAM",
   "uuid": "537e1880-5b6c-4b46-ae6c-f228cfc6c6e4",
   "slug": "paloalto_xsiam",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "categories": [
     "Endpoint"
   ]

--- a/PaloAltoXSIAM/pyproject.toml
+++ b/PaloAltoXSIAM/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "Automation module for Xsiam"
-version = "0.1.0"
+version = "1.0.1"
 description = ""
 authors = []
 package-mode = false

--- a/PaloAltoXSIAM/tests/test_stix_to_xsiam.py
+++ b/PaloAltoXSIAM/tests/test_stix_to_xsiam.py
@@ -71,6 +71,20 @@ def test_run():
                 "x_inthreat_sources_refs": [],
                 "confidence": 30,
             },
+            {
+                "id": "indicator--5",
+                "type": "indicator",
+                "pattern": "[network-traffic:dst_ref.value = '202.65.118.212' AND network-traffic:dst_port = 7002]]",
+                "x_ic_observable_types": ["ipv4-addr"],
+                "kill_chain_phases": [
+                    {"kill_chain_name": "lockheed-martin-cyber-kill-chain", "phase_name": "delivery"},
+                    {"kill_chain_name": "mitre-attack", "phase_name": "initial-access"},
+                ],
+                "valid_from": "2025-05-06T00:00:00Z",
+                "valid_until": "2025-11-24T00:00:00Z",
+                "x_inthreat_sources_refs": [],
+                "confidence": 30,
+            },
         ]
     )
 
@@ -127,9 +141,22 @@ def test_run():
                 },
             ],
         },
+        {
+            "class": "indicator--5",
+            "comment": "Valid from 2025-05-06T00:00:00Z AND STIX Pattern: "
+            "[network-traffic:dst_ref.value = '202.65.118.212' AND "
+            "network-traffic:dst_port = 7002]]",
+            "expiration_date": "1763942400000",
+            "indicator": "202.65.118.212",
+            "reliability": "D",
+            "reputation": "BAD",
+            "severity": "LOW",
+            "type": "IP",
+            "vendors": [],
+        },
     ]
 
     data = result["data"]
-    assert len(arguments.stix_objects) == 4
-    assert len(data) == 3
+    assert len(arguments.stix_objects) == 5
+    assert len(data) == 4
     assert data == expected_data

--- a/PaloAltoXSIAM/xsiam/stix_to_xsiam.py
+++ b/PaloAltoXSIAM/xsiam/stix_to_xsiam.py
@@ -124,7 +124,7 @@ class STIXToXSIAMAction(Action):
         ):
             return hashes
         else:
-            return re.findall(r":value\s?=\s?'(?P<value>.+?)'", pattern, flags=re.DOTALL | re.MULTILINE)
+            return re.findall(r"value\s?=\s?'(?P<value>.+?)'", pattern, flags=re.DOTALL | re.MULTILINE)
 
     def _get_type(self, stix_obj: dict) -> str:
         """
@@ -161,18 +161,6 @@ class STIXToXSIAMAction(Action):
 
     def _get_class(self, stix_obj: dict) -> str:
         return self._format_string_from_stix(stix_obj, self.class_override)
-
-    def _format_string_from_stix(self, stix_obj: dict, string: str) -> str:
-        """
-        Format the comment string with properties from the STIX object.
-        """
-        properties = re.findall(r"{(.*?)}", string, flags=re.DOTALL)
-        properties_dict = {}
-
-        for property in properties:
-            properties_dict[property] = stix_obj.get(property, "N/A")
-
-        return string.format(**properties_dict)
 
     def _get_reputation(self) -> str:
         return "BAD"
@@ -211,3 +199,15 @@ class STIXToXSIAMAction(Action):
             )
 
         return vendors
+
+    def _format_string_from_stix(self, stix_obj: dict, string: str) -> str:
+        """
+        Format the comment string with properties from the STIX object.
+        """
+        properties = re.findall(r"{(.*?)}", string, flags=re.DOTALL)
+        properties_dict = {}
+
+        for property in properties:
+            properties_dict[property] = stix_obj.get(property, "N/A")
+
+        return string.format(**properties_dict)


### PR DESCRIPTION
Fix regexp extracting stix pattern and add some tests

## Summary by Sourcery

Fix STIX pattern extraction, add tests, and bump version

Bug Fixes:
- Correct the regex in _get_patterns to properly extract values from STIX patterns

Build:
- Bump package version to 1.0.1 in manifest.json and pyproject.toml

Documentation:
- Update CHANGELOG for the 1.0.1 release

Tests:
- Add test case for parsing STIX patterns with nested network-traffic fields and update result count assertions

Chores:
- Relocate the _format_string_from_stix method within the codebase for clarity