### PR TITLE
fix(http): Fix schema in URL request to accept JSON Array for JSON field

### DIFF
--- a/HTTP/CHANGELOG.md
+++ b/HTTP/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-06-26 - 1.119.2
+
+### Fixed
+
+- Fix URL Request schema to accept an array of JSON for the JSON field
+
 ## 2023-11-01 - 1.119.1
 
 ### Changed

--- a/HTTP/action_request.json
+++ b/HTTP/action_request.json
@@ -29,7 +29,13 @@
       },
       "json": {
         "description": "The JSON to attach as body of the request",
-        "type": "object"
+        "oneOf": [
+          {"type": "object"},
+          {
+            "type": "array",
+            "items": {"type": "object"}
+          }
+        ]
       },
       "params": {
         "description": "Query string parameters to append to the URL",

--- a/HTTP/manifest.json
+++ b/HTTP/manifest.json
@@ -9,7 +9,7 @@
   "name": "HTTP",
   "uuid": "5894985f-91eb-46db-9306-cc5ac6463d3d",
   "slug": "http",
-  "version": "1.119.1",
+  "version": "1.119.2",
   "categories": [
     "Generic"
   ]

--- a/HTTP/tests/test_request.py
+++ b/HTTP/tests/test_request.py
@@ -66,6 +66,58 @@ def test_post_request(symphony_storage):
         assert result["status_code"] == 202
         assert mock.request_history[0].text == "att1=val1"
 
+def test_post_request_json(symphony_storage):
+    """Test POST request with JSON data."""
+    action = RequestAction(data_path=symphony_storage)
+    action.module.configuration = {}
+
+    # JSON Object
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://api.sekoia.io",
+            json={"foo": "bar"},
+            status_code=202,
+            reason="Accepted",
+            headers={"h1": "foo", "h2": "bar", "Content-Type": "application/json"},
+        )
+
+        result = action.run({"method": "post", "url": "https://api.sekoia.io", "json": {"foo": "bar"}})
+        del result["elapsed"]
+        json.dumps(result)
+        assert result == {
+            "encoding": "utf-8",
+            "headers": {"h1": "foo", "h2": "bar", "Content-Type": "application/json"},
+            "json": {"foo": "bar"},
+            "reason": "Accepted",
+            "status_code": 202,
+            "text": '{"foo": "bar"}',
+            "url": "https://api.sekoia.io/",
+        }
+
+    # JSON Array
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://api.sekoia.io",
+            json=[{"foo": "bar"}, {"baz": "qux"}],
+            status_code=202,
+            reason="Accepted",
+            headers={"h1": "foo", "h2": "bar", "Content-Type": "application/json"},
+        )
+
+        result = action.run({"method": "post", "url": "https://api.sekoia.io", "json": [{"foo": "bar"}, {"baz": "qux"}]})
+        del result["elapsed"]
+        json.dumps(result)
+        assert result == {
+            "encoding": "utf-8",
+            "headers": {"h1": "foo", "h2": "bar", "Content-Type": "application/json"},
+            "json": [{"foo": "bar"}, {"baz": "qux"}],
+            "reason": "Accepted",
+            "status_code": 202,
+            "text": '[{"foo": "bar"}, {"baz": "qux"}]',
+            "url": "https://api.sekoia.io/",
+        }
+
+
 
 def test_post_request_no_verify(symphony_storage):
     action = RequestAction(data_path=symphony_storage)

--- a/HTTP/tests/test_request.py
+++ b/HTTP/tests/test_request.py
@@ -66,6 +66,7 @@ def test_post_request(symphony_storage):
         assert result["status_code"] == 202
         assert mock.request_history[0].text == "att1=val1"
 
+
 def test_post_request_json(symphony_storage):
     """Test POST request with JSON data."""
     action = RequestAction(data_path=symphony_storage)
@@ -104,7 +105,9 @@ def test_post_request_json(symphony_storage):
             headers={"h1": "foo", "h2": "bar", "Content-Type": "application/json"},
         )
 
-        result = action.run({"method": "post", "url": "https://api.sekoia.io", "json": [{"foo": "bar"}, {"baz": "qux"}]})
+        result = action.run(
+            {"method": "post", "url": "https://api.sekoia.io", "json": [{"foo": "bar"}, {"baz": "qux"}]}
+        )
         del result["elapsed"]
         json.dumps(result)
         assert result == {
@@ -116,7 +119,6 @@ def test_post_request_json(symphony_storage):
             "text": '[{"foo": "bar"}, {"baz": "qux"}]',
             "url": "https://api.sekoia.io/",
         }
-
 
 
 def test_post_request_no_verify(symphony_storage):


### PR DESCRIPTION
With the previous schema we were not able to make a post with a JSON array like: `[{"foo": "bar"},{"foo": "bar"}]`

This PR fixes that.

## Summary by Sourcery

Fix the HTTP action schema to accept JSON arrays, validate the change with new tests, and prepare the 1.119.2 release

Bug Fixes:
- Allow the HTTP request schema to accept JSON arrays for the JSON field

Build:
- Bump HTTP module version to 1.119.2 in manifest.json

Documentation:
- Update CHANGELOG.md with the 1.119.2 release and fix entry

Tests:
- Add tests for POST requests with both JSON objects and JSON arrays