### PR TITLE
fix(HTTP): fix URL Request schema to accept an array of JSON for the JSON field

### DIFF
--- a/HTTP/CHANGELOG.md
+++ b/HTTP/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-06-26 - 1.119.3
+
+### Fixed
+
+- Fix URL Request schema to accept any JSON
+
+
 ## 2025-06-26 - 1.119.2
 
 ### Fixed

--- a/HTTP/action_request.json
+++ b/HTTP/action_request.json
@@ -28,14 +28,7 @@
         "type": "string"
       },
       "json": {
-        "description": "The JSON to attach as body of the request",
-        "oneOf": [
-          {"type": "object"},
-          {
-            "type": "array",
-            "items": {"type": "object"}
-          }
-        ]
+        "description": "The JSON to attach as body of the request"
       },
       "params": {
         "description": "Query string parameters to append to the URL",

--- a/HTTP/manifest.json
+++ b/HTTP/manifest.json
@@ -9,7 +9,7 @@
   "name": "HTTP",
   "uuid": "5894985f-91eb-46db-9306-cc5ac6463d3d",
   "slug": "http",
-  "version": "1.119.2",
+  "version": "1.119.3",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
New fix following this one: https://github.com/SEKOIA-IO/automation-library/pull/1405

By removing the type, it will allow any JSON.

## Summary by Sourcery

Bump HTTP integration to version 1.119.3, update CHANGELOG, and loosen the URL Request action schema to accept any JSON payload (including arrays).

Bug Fixes:
- Allow the JSON field in URL Request schema to accept any JSON value, including arrays.

Build:
- Bump HTTP manifest version to 1.119.3.

Documentation:
- Add a new entry for version 1.119.3 in the CHANGELOG.