### PR TITLE
Hotfix: s1 cache size

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-07-04 - 1.20.9
+
+### Changed
+
+- Update cache size for connector to 10000
+
 ## 2025-05-30 - 1.20.8
 
 ### Changed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.20.8",
+  "version": "1.20.9",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -99,7 +99,7 @@ class SentinelOneLogsConsumer(Thread):
         return Management(hostname=self.module.configuration.hostname, api_token=self.module.configuration.api_token)
 
     def load_events_cache(self) -> Cache:
-        events_cache: LRUCache = LRUCache(maxsize=10000) # Update cache size to 10_000
+        events_cache: LRUCache = LRUCache(maxsize=10000)
 
         with self.cursor._context as ctx:
             for cached_id in ctx.get("events_cache", []):

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -99,7 +99,7 @@ class SentinelOneLogsConsumer(Thread):
         return Management(hostname=self.module.configuration.hostname, api_token=self.module.configuration.api_token)
 
     def load_events_cache(self) -> Cache:
-        events_cache: LRUCache = LRUCache(maxsize=1000)
+        events_cache: LRUCache = LRUCache(maxsize=10000) # Update cache size to 10_000
 
         with self.cursor._context as ctx:
             for cached_id in ctx.get("events_cache", []):


### PR DESCRIPTION
## Summary by Sourcery

Bump connector version to 1.20.9 and increase the events cache size to 10,000

Enhancements:
- Increase events_cache maxsize from 1,000 to 10,000

Build:
- Update manifest.json version to 1.20.9

Documentation:
- Add CHANGELOG entry for version 1.20.9 with cache size update