### PR TITLE
BeyondTrust: Return when facing an API error

### DIFF
--- a/BeyondTrust/CHANGELOG.md
+++ b/BeyondTrust/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+## 2025-06-10 - 1.0.0
+
+### Fixed
+
+- return when the connector faces an API error 
 
 ## 2025-02-12 - 0.2.0
 

--- a/BeyondTrust/manifest.json
+++ b/BeyondTrust/manifest.json
@@ -35,5 +35,5 @@
     "Network"
   ],
   "uuid": "ab96c1e6-20b9-4589-aa9a-43d84043d857",
-  "version": "0.2.0"
+  "version": "1.0.0"
 }

--- a/BeyondTrust/tests/test_connector_pra_platform.py
+++ b/BeyondTrust/tests/test_connector_pra_platform.py
@@ -43,7 +43,6 @@ def test_fetch_events(trigger, sessions_list_xml_with_one, session_xml):
             [{"content": sessions_list_xml_with_one}, {"content": session_xml}],
         )
 
-        # mock_requests.get("https://tenant_id.okta.com/api/v1/logs", status_code=200, json=messages)
         trigger.from_date = 1732810704
         events = trigger.fetch_events()
 

--- a/BeyondTrust/tests/test_connector_pra_platform.py
+++ b/BeyondTrust/tests/test_connector_pra_platform.py
@@ -98,3 +98,28 @@ def test_next_batch_sleep_until_next_round(trigger, sessions_list_xml_with_one, 
 
         assert trigger.push_events_to_intakes.call_count == 1
         assert mock_time.sleep.call_count == 1
+
+
+def test_fetch_events_face_error(trigger, sessions_list_xml_with_one, session_xml):
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.register_uri(
+            "POST",
+            f"https://tenant.beyondtrustcloud.com/oauth2/token",
+            json={
+                "access_token": "foo-token",
+                "token_type": "bearer",
+                "expires_in": 1799,
+            },
+        )
+
+        mock_requests.register_uri(
+            "POST",
+            "https://tenant.beyondtrustcloud.com/api/reporting",
+            status_code=500,
+            json={"error": "Internal Server Error"},
+        )
+
+        trigger.from_date = 1732810704
+        events = trigger.fetch_events()
+
+        assert list(events) == []


### PR DESCRIPTION
In the `fecth_events` method, return when the connector faces an API error.

## Summary by Sourcery

Improve error handling in fetch_events to exit early on API errors and update the release version.

Enhancements:
- Make _handle_response_error return a boolean flag indicating error state
- Modify fetch_events to return immediately when an API error is encountered

Build:
- Bump connector version to 1.0.0

Documentation:
- Update changelog with API error handling fix and release details

Tests:
- Add test to confirm fetch_events yields no events on API error