### PR TITLE
fix the sekoia base url

### DIFF
--- a/TheHiveV5/CHANGELOG.md
+++ b/TheHiveV5/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2024-05-27 - 1.0.0
-
-### Added
-
-- Add for the first time theHive action for the version 2 of thehive4py
-
 ## 2025-07-16 - 1.0.1
 
 ### Added
 
 - Add SEKOIA_BASE_URL parameter to allows users to change the region of sekoia
+
+## 2024-05-27 - 1.0.0
+
+### Added
+
+- Add for the first time theHive action for the version 2 of thehive4py

--- a/TheHiveV5/CHANGELOG.md
+++ b/TheHiveV5/CHANGELOG.md
@@ -12,3 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add for the first time theHive action for the version 2 of thehive4py
+
+## 2025-07-16 - 1.0.1
+
+### Added
+
+- Add SEKOIA_BASE_URL parameter to allows users to change the region of sekoia

--- a/TheHiveV5/action_create_alert.json
+++ b/TheHiveV5/action_create_alert.json
@@ -6,6 +6,11 @@
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
+      "sekoia_base_url": {
+        "description": "[Optional] Sekoia base url, depends of the region you want to use",
+        "default": "https://app.sekoia.io",
+        "type": "string"
+      },
       "alert": {
         "description": "A Sekoia.io alert",
         "type": "object"

--- a/TheHiveV5/manifest.json
+++ b/TheHiveV5/manifest.json
@@ -31,7 +31,7 @@
   "name": "The Hive V5",
   "uuid": "d6c96586-707c-451f-b9f6-d31b3291f87d",
   "slug": "thehivev5",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "categories": [
     "Collaboration Tools"
   ]

--- a/TheHiveV5/tests/test_create_alert.py
+++ b/TheHiveV5/tests/test_create_alert.py
@@ -3,6 +3,8 @@ import requests_mock
 
 from thehive.create_alert import TheHiveCreateAlertV5
 
+SEKOIA_BASE_URL: str = "https://app.sekoia.io"
+
 ALERT: dict[str, Any] = {
     "uuid": "4764296a-f8d5-485f-92f1-bf4b28885ef6",
     "short_id": "AL123456789",
@@ -51,7 +53,7 @@ def test_create_alert_action_success():
     with requests_mock.Mocker() as mock_requests:
         mock_requests.post(url="https://thehive-project.org/api/v1/alert", status_code=200, json=HIVE_OUTPUT)
 
-        result = action.run({"alert": ALERT})
+        result = action.run({"sekoia_base_url": SEKOIA_BASE_URL, "alert": ALERT})
         assert result is not None
         assert result["title"] == ALERT["title"]
 
@@ -66,7 +68,7 @@ def test_create_alert_action_api_error(requests_mock):
         "organisation": "SEKOIA",
     }
 
-    result = action.run({"alert": ALERT})
+    result = action.run({"sekoia_base_url": SEKOIA_BASE_URL, "alert": ALERT})
 
     assert not result
     assert mock_alert.call_count == 1

--- a/TheHiveV5/thehive/create_alert.py
+++ b/TheHiveV5/thehive/create_alert.py
@@ -14,12 +14,13 @@ class TheHiveCreateAlertV5(Action):
             organisation=self.module.configuration["organisation"],
         )
 
+        arg_sekoia_server = arguments["sekoia_base_url"]
         arg_alert = arguments["alert"]
 
         alert_type = f"{arg_alert['alert_type']['category']}/{arg_alert['alert_type']['value']}"
         if len(alert_type) > 32:
             alert_type = arg_alert["alert_type"]["category"][:32]  # limit to 32 char, max of thehive api
-        link = f"https://app.sekoia.io/operations/alerts/{arg_alert['short_id']}"
+        link = f"{arg_sekoia_server}/operations/alerts/{arg_alert['short_id']}"
         alert: InputAlert = InputAlert(
             severity=arg_alert["urgency"]["severity"] // 25 + 1,  # from 0-100 to 1-4
             date=arg_alert["created_at"] * 1000,  # date in ms for TheHive instead of sec in Sekoia

--- a/TheHiveV5/thehive/create_alert.py
+++ b/TheHiveV5/thehive/create_alert.py
@@ -4,6 +4,7 @@ from sekoia_automation.action import Action
 from thehive4py import TheHiveApi
 from thehive4py.types.alert import InputAlert, OutputAlert
 from requests import HTTPError
+from posixpath import join as urljoin
 
 
 class TheHiveCreateAlertV5(Action):
@@ -20,7 +21,7 @@ class TheHiveCreateAlertV5(Action):
         alert_type = f"{arg_alert['alert_type']['category']}/{arg_alert['alert_type']['value']}"
         if len(alert_type) > 32:
             alert_type = arg_alert["alert_type"]["category"][:32]  # limit to 32 char, max of thehive api
-        link = f"{arg_sekoia_server}/operations/alerts/{arg_alert['short_id']}"
+        link = urljoin(arg_sekoia_server.rstrip("/"), f"/operations/alerts/{arg_alert['short_id']}")
         alert: InputAlert = InputAlert(
             severity=arg_alert["urgency"]["severity"] // 25 + 1,  # from 0-100 to 1-4
             date=arg_alert["created_at"] * 1000,  # date in ms for TheHive instead of sec in Sekoia


### PR DESCRIPTION
## Summary by Sourcery

Switch create_alert action to use a dynamic sekoia_base_url input for constructing alert links instead of a hardcoded URL and update related tests and schema accordingly.

Bug Fixes:
- Fix hardcoded Sekoia base URL in alert link construction by sourcing it from input arguments.

Enhancements:
- Add sekoia_base_url as a required action input and use it when building the alert link.
- Update action_create_alert.json schema to include the new sekoia_base_url parameter.

Tests:
- Update create_alert action tests to supply the new sekoia_base_url argument.