### PR TITLE
S1 - fix event lag

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-07-17 - 1.20.10
+
+### Fixed
+
+- Fix event lag for the case when 0 events received
+
 ## 2025-07-04 - 1.20.9
 
 ### Changed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.20.9",
+  "version": "1.20.10",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -224,6 +224,7 @@ class SentinelOneActivityLogsConsumer(SentinelOneLogsConsumer):
             nb_activities = len(activities)
             logger.debug("Collected activities", nb=nb_activities)
             if nb_activities == 0:
+                EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(0)
                 break
 
             INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(nb_activities)
@@ -293,6 +294,7 @@ class SentinelOneThreatLogsConsumer(SentinelOneLogsConsumer):
             nb_threats = len(threats)
             logger.debug("Collected nb_threats", nb=nb_threats)
             if nb_threats == 0:
+                EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(0)
                 break
 
             # discard already collected events


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/760

## Summary by Sourcery

Bump SentinelOne integration to version 1.20.10 and ensure the event lag metric resets to zero when no events or threats are received

Bug Fixes:
- Reset EVENTS_LAG metric to zero when no activities or threats are collected

Documentation:
- Add changelog entry for version 1.20.10

Chores:
- Update manifest version to 1.20.10