### PR TITLE
SentinelOne: fix metrics

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-07-17 - 1.20.11
+
+### Fixed
+
+- Fix metrics
+
 ## 2025-07-17 - 1.20.10
 
 ### Fixed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -26,7 +26,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.20.10",
+  "version": "1.20.11",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -224,7 +224,7 @@ class SentinelOneActivityLogsConsumer(SentinelOneLogsConsumer):
             nb_activities = len(activities)
             logger.debug("Collected activities", nb=nb_activities)
             if nb_activities == 0:
-                EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(0)
+                EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="activities").set(0)
                 break
 
             INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(nb_activities)
@@ -294,7 +294,7 @@ class SentinelOneThreatLogsConsumer(SentinelOneLogsConsumer):
             nb_threats = len(threats)
             logger.debug("Collected nb_threats", nb=nb_threats)
             if nb_threats == 0:
-                EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(0)
+                EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="threats").set(0)
                 break
 
             # discard already collected events


### PR DESCRIPTION
A label was missing from the metrics, in the last PR. Currently, we have the following error:
```
ValueError: Incorrect label names
```

## Summary by Sourcery

Fix missing label in EVENTS_LAG metrics by adding the required "type" label for activities and threats, update changelog entry, and bump integration version to 1.20.11.

Bug Fixes:
- Add missing "type" label to EVENTS_LAG metrics for activities and threats to resolve incorrect label names error

Documentation:
- Update CHANGELOG.md with 1.20.11 release entry

Chores:
- Bump SentinelOne integration version to 1.20.11 in manifest.json