### PR TITLE
Vectra: add parameter to include decreasing scores

### DIFF
--- a/Vectra/CHANGELOG.md
+++ b/Vectra/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-07-17 - 1.2.1
+
+### Added
+
+- Add a parameter to include decreasing scores
+
 ## 2025-07-17 - 1.2.0
 
 ### Changed

--- a/Vectra/connector_vectra_respond_ux_entity_scoring.json
+++ b/Vectra/connector_vectra_respond_ux_entity_scoring.json
@@ -28,6 +28,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "include_score_decreases": {
+        "type": "boolean",
+        "description": "Whether to include events with score decreases",
+        "default": false
       }
     },
     "required": [

--- a/Vectra/manifest.json
+++ b/Vectra/manifest.json
@@ -23,7 +23,7 @@
   "description": "AI-driven cybersecurity platform that detects attacker behaviors to protect your users and hosts from being compromised, regardless of location.",
   "name": "Vectra",
   "uuid": "45a8b20d-60f4-4384-b5d9-8ec0efcf604c",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "slug": "vectra",
   "categories": [
     "Network"

--- a/Vectra/tests/test_helpers.py
+++ b/Vectra/tests/test_helpers.py
@@ -1,0 +1,21 @@
+import pytest
+
+from vectra_modules.helpers import format_boolean
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        (True, "true"),
+        (False, "false"),
+    ],
+)
+def test_format_boolean(input_value, expected_output):
+    """
+    Test the format_boolean function with various inputs.
+
+    Parameters:
+    input_value: The value to be tested.
+    expected_output: The expected output of the function.
+    """
+    assert format_boolean(input_value) == expected_output

--- a/Vectra/trigger_vectra_respond_ux_entity_scoring.json
+++ b/Vectra/trigger_vectra_respond_ux_entity_scoring.json
@@ -28,6 +28,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "include_score_decreases": {
+        "type": "boolean",
+        "description": "Whether to include events with score decreases",
+        "default": false
       }
     },
     "required": [

--- a/Vectra/vectra_modules/helpers.py
+++ b/Vectra/vectra_modules/helpers.py
@@ -1,0 +1,11 @@
+def format_boolean(value: bool) -> str:
+    """
+    Format a boolean value as 'true' or 'false'.
+
+    Parameters:
+    value (bool): The boolean value to format.
+
+    Returns:
+        str: 'true' if value is True, 'false' if value is False.
+    """
+    return "true" if value else "false"


### PR DESCRIPTION
## Summary by Sourcery

Add a configuration parameter to include events with decreasing scores in the Vectra entity scoring connector, propagate it through API requests, implement and test a boolean formatting helper, bump version, and update documentation.

New Features:
- Introduce include_score_decreases configuration option to include events with score decreases in batch queries

Enhancements:
- Append include_score_decreases flag to Vectra API request parameters
- Implement format_boolean helper to serialize boolean values for requests
- Bump Vectra connector version to 1.2.1 in manifest

Documentation:
- Update CHANGELOG to document the new parameter and version bump

Tests:
- Add unit tests for the format_boolean helper function