### PR TITLE
feat(Triage) updating changelog and version

### DIFF
--- a/Triage/CHANGELOG.md
+++ b/Triage/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-07-21 - 1.40.0
+
+### Changed
+
+- Fix a bug in the option `excluded_signed`: to handle multiple signatures available
+
 ## 2025-02-05 - 1.39.0
 
 ### Changed

--- a/Triage/manifest.json
+++ b/Triage/manifest.json
@@ -25,7 +25,7 @@
   "name": "Triage",
   "uuid": "919705ab-7a64-493e-a92b-4049fafea325",
   "slug": "triage",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "categories": [
     "Threat Intelligence"
   ]


### PR DESCRIPTION
PR to fix the missing changelog and version for [that previous PR](https://github.com/SEKOIA-IO/automation-library/pull/1420/).

## Summary by Sourcery

Add missing changelog entry for version 1.40.0 and bump the Triage manifest version accordingly

Bug Fixes:
- Fix handling of multiple signatures in the excluded_signed option

Documentation:
- Add 2025-07-21 - 1.40.0 release entry to CHANGELOG

Chores:
- Update manifest.json version from 1.39.0 to 1.40.0