### PR TITLE
TheHiveV5: Set default value if the sekoia_base_url is not set.

### DIFF
--- a/TheHiveV5/CHANGELOG.md
+++ b/TheHiveV5/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-07-31 - 1.0.2
+
+### Fixed
+
+- Set a default value if the sekoia_base_url parameter is not set in the configuration file
+
 ## 2025-07-16 - 1.0.1
 
 ### Added

--- a/TheHiveV5/manifest.json
+++ b/TheHiveV5/manifest.json
@@ -31,7 +31,7 @@
   "name": "The Hive V5",
   "uuid": "d6c96586-707c-451f-b9f6-d31b3291f87d",
   "slug": "thehivev5",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "categories": [
     "Collaboration Tools"
   ]

--- a/TheHiveV5/thehive/create_alert.py
+++ b/TheHiveV5/thehive/create_alert.py
@@ -15,7 +15,7 @@ class TheHiveCreateAlertV5(Action):
             organisation=self.module.configuration["organisation"],
         )
 
-        arg_sekoia_server = arguments["sekoia_base_url"]
+        arg_sekoia_server = arguments.get("sekoia_base_url", "https://app.sekoia.io")
         arg_alert = arguments["alert"]
 
         alert_type = f"{arg_alert['alert_type']['category']}/{arg_alert['alert_type']['value']}"


### PR DESCRIPTION
For existing playbooks, the `sekoia_base_url` will be missing from the parameters.
Update the action to handle this case.

## Summary by Sourcery

Provide a default value for sekoia_base_url when missing and bump the package version to 1.0.2.

Bug Fixes:
- Set a default sekoia_base_url ('https://app.sekoia.io') if the parameter is not provided

Chores:
- Bump manifest version to 1.0.2 and update the CHANGELOG with the new release entry