### PR TITLE
Fix: Eset Add Headers (808)

### DIFF
--- a/Eset/CHANGELOG.md
+++ b/Eset/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 2025-08-04 - 1.0.1
+
+### Fixed
+
+- Add required header to all requests to the ESET API.

--- a/Eset/eset_modules/client/auth.py
+++ b/Eset/eset_modules/client/auth.py
@@ -53,9 +53,13 @@ class EsetProtectApiAuthentication(AuthBase):
                     "username": self.__username,
                     "password": self.__password,
                 },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "3rd-integration": "Sekoia.io",
+                },
                 timeout=60,
             )
+
             response.raise_for_status()
 
             api_credentials: dict = response.json()
@@ -70,4 +74,6 @@ class EsetProtectApiAuthentication(AuthBase):
 
     def __call__(self, request):
         request.headers["Authorization"] = self.get_credentials().authorization
+        request.headers["3rd-integration"] = "Sekoia.io"
+
         return request

--- a/Eset/manifest.json
+++ b/Eset/manifest.json
@@ -38,7 +38,7 @@
   "description": "ESET is a global cybersecurity company known for its antivirus and security software solutions for both businesses and consumers, providing advanced threat detection and malware protection.",
   "name": "Eset",
   "uuid": "91140c5a-770f-44c6-81ce-ea57daf3fe34",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "slug": "eset",
   "categories": [
     "Endpoint"


### PR DESCRIPTION
Relates to [808](https://github.com/SekoiaLab/integration/issues/808)

## Summary by Sourcery

Add the required "3rd-integration" header to all ESET API requests, bump the version to 1.0.1, and update the changelog

Bug Fixes:
- Include the "3rd-integration: Sekoia.io" header in the authentication request and all subsequent ESET API calls

Chores:
- Bump Eset integration version to 1.0.1 in manifest.json
- Add CHANGELOG entry for version 1.0.1