### PR TITLE
Bump version

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-08-04 - 1.28.2
+
+### Fixed
+
+- Handling checkpoint
+
 ## 2025-06-04 - 1.28.1
 
 ### Fixed

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "categories": [
     "Endpoint"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Bump extension version to 1.28.2 and record the checkpoint handling fix

Bug Fixes:
- Fix checkpoint handling

Documentation:
- Add CHANGELOG entry for version 1.28.2