### PR TITLE
Fix: Add retry on GetAggregationQuery (801)

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-06-03 - 2.68.4
+
+### Fixed
+
+- Add retry logic when using GetAggregationQuery for ws connection.
+
 ## 2025-06-03 - 2.68.3
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.68.3",
+  "version": "2.68.4",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/get_aggregation_query.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_aggregation_query.py
@@ -1,4 +1,5 @@
 import json
+import time
 from posixpath import join as urljoin
 
 from sekoia_automation.action import Action
@@ -6,6 +7,9 @@ from websocket._core import create_connection
 
 
 class GetAggregationQuery(Action):
+    max_attempts = 3
+    backoff = 2  # seconds
+
     def run(self, arguments: dict):
         api_key = self.module.configuration["api_key"]
         base_url = self.module.configuration["base_url"]
@@ -19,11 +23,27 @@ class GetAggregationQuery(Action):
             "range": [arguments["earliest_time"], arguments["latest_time"]],
             "minutes_per_bucket": arguments["minutes_per_bucket"],
         }
-        ws = create_connection(
-            urljoin(ws_base_url, "api/v1/events/stats"),
-            header={"Authorization": f"Bearer {api_key}"},
-        )
-        ws.send(json.dumps(query))
-        result = ws.recv()
-        ws.close()
-        return json.loads(result)
+
+        attempt = 0
+        while attempt < self.max_attempts:
+            ws = create_connection(
+                urljoin(ws_base_url, "api/v1/events/stats"),
+                header={"Authorization": f"Bearer {api_key}"},
+            )
+
+            try:
+                ws.send(json.dumps(query))
+                result = ws.recv()
+                ws.close()
+
+                return json.loads(result)
+            except Exception as e:
+                self.log(f"WebSocket error (attempt {attempt}): {e}")
+
+                ws.close()
+
+                attempt += 1
+                if attempt >= self.max_attempts:
+                    raise RuntimeError(f"WebSocket failed after {self.max_attempts} attempts") from e
+
+                time.sleep(self.backoff * attempt)  # exponential backoff


### PR DESCRIPTION
Relates to [801](https://github.com/SekoiaLab/integration/issues/801)

## Summary by Sourcery

Implement retry logic with exponential backoff for GetAggregationQuery WebSocket calls and release as version 2.68.4.

Bug Fixes:
- Add up to three retry attempts with exponential backoff for WebSocket send/receive operations in GetAggregationQuery.

Build:
- Bump integration version to 2.68.4 in manifest.json.

Documentation:
- Update CHANGELOG with the fixed retry logic entry under version 2.68.4.