### PR TITLE
Harfanglab: Add Timeout exception

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-08-08 - 1.28.4
+
+### Added
+
+- Add timeout exception to the credential validator
+
 ## 2025-08-08 - 1.28.3
 
 ### Added

--- a/HarfangLab/harfanglab/account_validator.py
+++ b/HarfangLab/harfanglab/account_validator.py
@@ -9,7 +9,6 @@ from harfanglab.client import ApiClient
 from harfanglab.helpers import handle_uri
 
 
-
 class HarfanglabCredentialsTimeoutError(Exception):
     pass
 
@@ -31,7 +30,7 @@ class HarfanglabAccountValidator(AccountValidator):
         check_cred_url = urljoin(self.base_url, self.AUTHENTICATION_ENDPOINT)
         params: dict = {}
 
-        try :
+        try:
             check_cred_response = self.client.get(check_cred_url, params=params, timeout=self.TIMEOUT)
             check_cred_response.raise_for_status()
             return check_cred_response.json(), check_cred_response.status_code

--- a/HarfangLab/harfanglab/account_validator.py
+++ b/HarfangLab/harfanglab/account_validator.py
@@ -32,7 +32,6 @@ class HarfanglabAccountValidator(AccountValidator):
 
         try:
             check_cred_response = self.client.get(check_cred_url, params=params, timeout=self.TIMEOUT)
-            check_cred_response.raise_for_status()
             return check_cred_response.json(), check_cred_response.status_code
         except requests.Timeout:
             raise HarfanglabCredentialsTimeoutError(

--- a/HarfangLab/harfanglab/account_validator.py
+++ b/HarfangLab/harfanglab/account_validator.py
@@ -2,10 +2,16 @@ from functools import cached_property
 from typing import Any
 from urllib.parse import urljoin
 
+import requests
 from sekoia_automation.account_validator import AccountValidator
 
 from harfanglab.client import ApiClient
 from harfanglab.helpers import handle_uri
+
+
+
+class HarfanglabCredentialsTimeoutError(Exception):
+    pass
 
 
 class HarfanglabAccountValidator(AccountValidator):
@@ -25,9 +31,14 @@ class HarfanglabAccountValidator(AccountValidator):
         check_cred_url = urljoin(self.base_url, self.AUTHENTICATION_ENDPOINT)
         params: dict = {}
 
-        check_cred_response = self.client.get(check_cred_url, params=params, timeout=self.TIMEOUT)
-
-        return check_cred_response.json(), check_cred_response.status_code
+        try :
+            check_cred_response = self.client.get(check_cred_url, params=params, timeout=self.TIMEOUT)
+            check_cred_response.raise_for_status()
+            return check_cred_response.json(), check_cred_response.status_code
+        except requests.Timeout:
+            raise HarfanglabCredentialsTimeoutError(
+                f"Timeout while checking credentials for Harfanglab asset connector at {check_cred_url}"
+            )
 
     def validate(self) -> bool:
         check_cred_response, status_code = self._check_credentials_request()

--- a/HarfangLab/harfanglab/asset_connector/device_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/device_assets.py
@@ -135,7 +135,7 @@ class HarfanglabAssetConnector(AssetConnector):
         )
 
     def __fetch_devices(self, from_date: str | None) -> Generator[list[dict[str, Any]], None, None]:
-        self.log("Start fetching devices from Harfanglab API", level="info")
+        self.log(f"Start fetching devices from Harfanglab API from date {from_date}", level="info")
 
         devices_url = urljoin(self.base_url, self.AGENT_ENDPOINT)
 

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "categories": [
     "Endpoint"
   ],

--- a/HarfangLab/tests/test_account_validator.py
+++ b/HarfangLab/tests/test_account_validator.py
@@ -1,9 +1,10 @@
 import pytest
 from unittest.mock import Mock
 
+import requests
 from sekoia_automation.module import Module
 
-from harfanglab.account_validator import HarfanglabAccountValidator
+from harfanglab.account_validator import HarfanglabAccountValidator, HarfanglabCredentialsTimeoutError
 
 
 @pytest.fixture
@@ -50,3 +51,13 @@ def test_validate_unexpected_status(harfanglab_account_validator, requests_mock)
     )
 
     assert harfanglab_account_validator.validate() is False
+
+
+def test_check_timeout(harfanglab_account_validator, requests_mock):
+    requests_mock.get(
+        "https://example.com/api/auth/users/me",
+        exc=requests.Timeout,
+    )
+
+    with pytest.raises(HarfanglabCredentialsTimeoutError):
+        harfanglab_account_validator.validate()


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/platform/issues/72992)

## Summary by Sourcery

Add timeout handling to HarfanglabAccountValidator and bump the connector version

New Features:
- Introduce HarfanglabCredentialsTimeoutError and catch request timeouts during credential validation

Enhancements:
- Invoke raise_for_status to propagate HTTP errors from the credentials check

Documentation:
- Update CHANGELOG.md with version 1.28.4 and the new timeout exception entry

Chores:
- Bump Harfanglab connector version to 1.28.4 in manifest.json