### PR TITLE
Fix: Azure EventHub Add Categories (759)

### DIFF
--- a/Azure/CHANGELOG.md
+++ b/Azure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-08-12 - 2.7.0
+
+### Added
+
+- Add filtering on the Azure EventHub connector to only process messages with a specific category if provided
+
 ## 2025-05-07 - 2.6.5
 
 ### Added

--- a/Azure/connector_azure_eventhub.json
+++ b/Azure/connector_azure_eventhub.json
@@ -42,7 +42,7 @@
       },
       "categories": {
         "type": "array",
-        "description": "The categories to use for the events",
+        "description": "A list of events' categories to select (let empty to select all events)",
         "items": {
           "type": "string"
         },

--- a/Azure/connector_azure_eventhub.json
+++ b/Azure/connector_azure_eventhub.json
@@ -39,6 +39,14 @@
         "type": "integer",
         "description": "The max size of chunks for the batch processing",
         "default": 1000
+      },
+      "categories": {
+        "type": "array",
+        "description": "The categories to use for the events",
+        "items": {
+          "type": "string"
+        },
+        "default": []
       }
     },
     "required": [

--- a/Azure/manifest.json
+++ b/Azure/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Azure",
   "uuid": "525eecc0-9eee-484d-92bd-039117cf4dac",
   "slug": "azure",
-  "version": "2.6.5",
+  "version": "2.7.0",
   "categories": [
     "Cloud Providers"
   ]

--- a/Azure/trigger_azure_eventhub.json
+++ b/Azure/trigger_azure_eventhub.json
@@ -42,7 +42,7 @@
       },
       "categories": {
         "type": "array",
-        "description": "The categories to use for the events",
+        "description": "A list of events' categories to select (let empty to select all events)",
         "items": {
           "type": "string"
         },

--- a/Azure/trigger_azure_eventhub.json
+++ b/Azure/trigger_azure_eventhub.json
@@ -39,6 +39,14 @@
         "type": "integer",
         "description": "The max size of chunks for the batch processing",
         "default": 1000
+      },
+      "categories": {
+        "type": "array",
+        "description": "The categories to use for the events",
+        "items": {
+          "type": "string"
+        },
+        "default": []
       }
     },
     "required": [


### PR DESCRIPTION
Relates to [759](https://github.com/SekoiaLab/integration/issues/759)

## Summary by Sourcery

Allow the Azure EventHub connector to filter incoming messages based on a configurable list of categories, update the connector version and documentation accordingly, and add corresponding tests.

New Features:
- Add support for filtering Azure EventHub messages by configured categories

Enhancements:
- Bump Azure connector version to 2.7.0

Build:
- Update manifest.json version to 2.7.0

Documentation:
- Document category filtering feature in changelog

Tests:
- Add unit test for category-based message filtering