### PR TITLE
TrendMicro Vision One - fix result type

### DIFF
--- a/TrendMicroVisionOne/manifest.json
+++ b/TrendMicroVisionOne/manifest.json
@@ -31,6 +31,6 @@
   "name": "TrendMicro VisionOne",
   "slug": "trend-micro-vision-one",
   "uuid": "6f3d8a54-d51c-47d0-b77c-dbcf31393d59",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "categories": ["Endpoint"]
 }

--- a/TrendMicroVisionOne/trendmicro_visionone_modules/action_vision_one_base.py
+++ b/TrendMicroVisionOne/trendmicro_visionone_modules/action_vision_one_base.py
@@ -31,8 +31,8 @@ class TrendMicroVisionOneBaseAction(Action, ABC):
         if "application/json" in response.headers.get("Content-Type", ""):
             body = response.json()
             if isinstance(body, list):
-                # multiple responses - return as is
-                return body
+                # multiple responses - wrap as dict
+                return {"result": body}
 
         else:
             body = response.text


### PR DESCRIPTION
## Summary by Sourcery

Wrap multiple JSON responses in a standardized dict format and bump package version

Enhancements:
- Wrap list-type JSON responses in a 'result' dictionary key instead of returning raw lists

Chores:
- Increment extension version from 0.1.2 to 0.1.3