### PR TITLE
Fix/asset connector harfang

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-08-19 - 1.28.5
+
+### Added
+
+- Fix harfanglab asset connector
+
 ## 2025-08-08 - 1.28.4
 
 ### Added

--- a/HarfangLab/harfanglab/asset_connector/device_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/device_assets.py
@@ -1,3 +1,4 @@
+import tempfile
 from functools import cached_property
 from collections.abc import Generator
 from typing import Any, Union
@@ -34,7 +35,9 @@ class HarfanglabAssetConnector(AssetConnector):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.context = PersistentJSON("context.json", self._data_path)
+        # Temporary path to store the context
+        self.context_path = tempfile.gettempdir()
+        self.context = PersistentJSON("context.json", self.context_path)
 
     @property
     def most_recent_date_seen(self) -> str | None:

--- a/HarfangLab/harfanglab/asset_connector/device_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/device_assets.py
@@ -1,4 +1,5 @@
 import tempfile
+import uuid
 from functools import cached_property
 from collections.abc import Generator
 from typing import Any, Union
@@ -37,7 +38,8 @@ class HarfanglabAssetConnector(AssetConnector):
         super().__init__(*args, **kwargs)
         # Temporary path to store the context
         self.context_path = tempfile.gettempdir()
-        self.context = PersistentJSON("context.json", self.context_path)
+        tempfile_name = str(uuid.uuid4())
+        self.context = PersistentJSON(tempfile_name, self.context_path)
 
     @property
     def most_recent_date_seen(self) -> str | None:

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.28.4",
+  "version": "1.28.5",
   "categories": [
     "Endpoint"
   ],


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Switch HarfanglabAssetConnector context storage from a fixed 'context.json' under data path to a UUID-named file in the system temp directory