### PR TITLE
Add logs harfanglab asset connector

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-08-20 - 1.28.7
+
+### Added
+
+- Add some logs on harfanglab asset connector
+
 ## 2025-08-19 - 1.28.6
 
 ### Added

--- a/HarfangLab/harfanglab/asset_connector/device_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/device_assets.py
@@ -199,6 +199,7 @@ class HarfanglabAssetConnector(AssetConnector):
 
     def get_assets(self) -> Generator[DeviceOCSFModel, None, None]:
         self.log("Start the getting assets generator !!", level="info")
+        self.log(f"The data path is: {self._data_path.absolute()}", level="info")
         for devices in self.next_list_devices():
             for device in devices:
                 mapped_device: DeviceOCSFModel = self.map_fields(device)

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "categories": [
     "Endpoint"
   ],


### PR DESCRIPTION
## Summary by Sourcery

Add info-level logging of the data path in the HarfangLab asset connector get_assets method and update version to 1.28.7 in manifest and changelog.

Enhancements:
- Log data path at the start of the HarfangLab asset connector get_assets method.

Build:
- Bump HarfangLab connector version to 1.28.7 in manifest.

Documentation:
- Document added logs in CHANGELOG for version 1.28.7.