### PR TITLE
Fix: SentinelOne SSL Verification And Hostname Validation (828)

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-07-17 - 1.20.12
+
+### Added
+
+- Add an ability to define SSL verification
+
 ## 2025-07-17 - 1.20.11
 
 ### Fixed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -12,6 +12,11 @@
         "title": "API Token",
         "description": "The API token to authenticate to SentinelOne",
         "type": "string"
+      },
+      "verify_ssl": {
+        "title": "Verify SSL",
+        "description": "Whether to verify the SSL certificate of the SentinelOne instance",
+        "type": "boolean"
       }
     },
     "required": [
@@ -26,7 +31,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.20.11",
+  "version": "1.20.12",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/base.py
+++ b/SentinelOne/sentinelone_module/base.py
@@ -9,6 +9,9 @@ from sekoia_automation.module import Module
 class SentinelOneConfiguration(BaseModel):
     hostname: str = Field(..., description="The url to the SentinelOne instance")
     api_token: str = Field(secret=True, description="The API token to authenticate the requests")
+    verify_ssl: bool | None = Field(
+        default=None, description="Whether to verify the SSL certificate of the SentinelOne instance"
+    )
 
 
 class SentinelOneModule(Module):

--- a/SentinelOne/sentinelone_module/singularity/connectors.py
+++ b/SentinelOne/sentinelone_module/singularity/connectors.py
@@ -45,6 +45,7 @@ class AbstractSingularityConnector(AsyncConnector, ABC):
         return SingularityClient(
             hostname=self.module.configuration.hostname,
             api_token=self.module.configuration.api_token,
+            verify_ssl=self.module.configuration.verify_ssl,
         )
 
     def stop(self, *args: Any, **kwargs: Optional[Any]) -> None:

--- a/SentinelOne/tests/singularity/test_client.py
+++ b/SentinelOne/tests/singularity/test_client.py
@@ -66,9 +66,19 @@ async def test_session(mock_limiter, mock_client, mock_transport, client):
     mock_transport.assert_called_once_with(
         url=f"https://{client.hostname}/web/api/v2.1/unifiedalerts/graphql",
         headers={"Authorization": f"Bearer {client.api_token}"},
+        ssl=False,
     )
     mock_client.assert_called_once_with(transport=mock_transport_instance)
     mock_limiter.assert_called_once_with(max_rate=25, time_period=1)
+
+
+@pytest.mark.asyncio
+async def test_create_client(client):
+    with pytest.raises(ValueError):
+        SingularityClient("", "testhost")
+
+    with pytest.raises(ValueError):
+        SingularityClient("test_token", "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Relates to [828](https://github.com/SekoiaLab/integration/issues/828)

## Summary by Sourcery

Add SSL verification configuration and input validation to the SentinelOne Singularity client, update manifest and changelog, and extend tests accordingly.

New Features:
- Introduce an optional verify_ssl parameter in the SingularityClient constructor to toggle SSL certificate verification

Bug Fixes:
- Enforce non-empty API token and hostname by raising ValueError on invalid inputs

Enhancements:
- Propagate verify_ssl configuration from module settings to the client transport

Build:
- Bump SentinelOne integration version to 1.20.12

Documentation:
- Add verify_ssl property to manifest.json and configuration schema
- Document the new SSL verification option in CHANGELOG.md

Tests:
- Add tests for constructor input validation and SSL flag in transport sessions