### PR TITLE
BitDefender: fix automation module

### DIFF
--- a/BitDefender GravityZone/CHANGELOG.md
+++ b/BitDefender GravityZone/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-08-26 - [1.0.6]
+
+### Fixed
+- Change the identifier of the automation module
+
 ## 2025-08-11 - [1.0.5]
 ### Fixed
 - Change key name to correspond with the API.

--- a/BitDefender GravityZone/manifest.json
+++ b/BitDefender GravityZone/manifest.json
@@ -22,7 +22,7 @@
   "description": "Bitdefender is a global cybersecurity company renowned for its advanced antivirus software, providing comprehensive security solutions and threat intelligence for individuals and enterprises, safeguarding against evolving cyber threats.",
   "name": "Bitdefender GravityZone",
   "uuid": "26277889-b91b-46d0-8bac-7f6b2f6fb9a3",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "slug": "bitdefender_gravityzone",
   "categories": [
     "Endpoint"

--- a/BitDefender GravityZone/manifest.json
+++ b/BitDefender GravityZone/manifest.json
@@ -21,7 +21,7 @@
   },
   "description": "Bitdefender is a global cybersecurity company renowned for its advanced antivirus software, providing comprehensive security solutions and threat intelligence for individuals and enterprises, safeguarding against evolving cyber threats.",
   "name": "Bitdefender GravityZone",
-  "uuid": "4d874ec5-0927-4f8a-9a47-61d0b8b995b1",
+  "uuid": "26277889-b91b-46d0-8bac-7f6b2f6fb9a3",
   "version": "1.0.5",
   "slug": "bitdefender_gravityzone",
   "categories": [


### PR DESCRIPTION
Put back the original identifier of the BitDefender automation module.

## Summary by Sourcery

Restore the original UUID for the BitDefender automation module, bump the version to 1.0.6, and update the changelog accordingly

Bug Fixes:
- Restore original identifier for the BitDefender automation module

Enhancements:
- Bump version to 1.0.6 and update module UUID in manifest

Documentation:
- Add 1.0.6 release entry to CHANGELOG.md