### PR TITLE
Zscaler: bump version number

### DIFF
--- a/Zscaler/CHANGELOG.md
+++ b/Zscaler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-08-12 - 1.0.4
+
+### Changed
+
+- Replace the previous Zscaler client by an API Client and the authentication mechanism
+
 ## 2025-08-06 - 1.0.3
 
 ### Fixed

--- a/Zscaler/manifest.json
+++ b/Zscaler/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zscaler",
   "slug": "zscaler",
   "description": "Zscaler is a cloud security company providing secure internet access and zero trust network access to protect enterprise data and applications. Its platform offers scalable, cloud-native solutions for secure browsing, data protection, and threat prevention.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {


### PR DESCRIPTION
The changelog and the manifest were not updated in the previous PR: https://github.com/SEKOIA-IO/automation-library/pull/1457.

Bump the version number.

## Summary by Sourcery

Bump Zscaler integration version to 1.0.4 and update the changelog.

Enhancements:
- Replace the previous Zscaler client with an API client and update the authentication mechanism

Documentation:
- Add 1.0.4 release entry in the changelog

Chores:
- Update manifest.json to set version to 1.0.4