### PR TITLE
SentinelOne: clean the hostname

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-09-04 - 1.20.13
+
+### Fixed
+
+- Clean the hostname to remove protocol scheme and url path, in the module configuration
+
 ## 2025-08-28 - 1.20.12
 
 ### Fixed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -5,7 +5,7 @@
     "properties": {
       "hostname": {
         "title": "Hostname",
-        "description": "The domain-name to the SentinelOne instance",
+        "description": "The domain-name to the SentinelOne instance (e.g., <region>.sentinelone.com)",
         "type": "string",
 	"pattern": "^[A-Za-z0-9][A-Za-z0-9.-]+(:\\d+)?$"
       },

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -27,7 +27,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.20.12",
+  "version": "1.20.13",
   "categories": [
     "Endpoint"
   ]

--- a/SentinelOne/sentinelone_module/base.py
+++ b/SentinelOne/sentinelone_module/base.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel, Field
 from sekoia_automation.action import Action
 from sekoia_automation.module import Module
 
+from sentinelone_module.helpers import clean_hostname
+
 
 class SentinelOneConfiguration(BaseModel):
     hostname: str = Field(..., description="The url to the SentinelOne instance")
@@ -21,6 +23,6 @@ class SentinelOneAction(Action):
     @cached_property
     def client(self):
         return Management(
-            hostname=self.module.configuration.hostname,
+            hostname=clean_hostname(self.module.configuration.hostname),
             api_token=self.module.configuration.api_token,
         )

--- a/SentinelOne/sentinelone_module/helpers.py
+++ b/SentinelOne/sentinelone_module/helpers.py
@@ -105,3 +105,14 @@ def filter_collected_events(events: Sequence, getter: Callable, cache: Cache) ->
         selected_events.append(event)
 
     return selected_events
+
+
+def clean_hostname(hostname: str) -> str:
+    """
+    Removes any extra information from a hostname string, such as protocol prefixes (http://, https://) or url paths.
+    """
+    if "://" in hostname:
+        hostname = hostname.split("://")[1]
+    if "/" in hostname:
+        hostname = hostname.split("/")[0]
+    return hostname

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -18,7 +18,7 @@ from sekoia_automation.connector import Connector
 
 from sentinelone_module.base import SentinelOneModule
 from sentinelone_module.exceptions import SENTINEL_ONE_EMPTY_RESPONSE, SentinelOneManagementResponseError
-from sentinelone_module.helpers import filter_collected_events
+from sentinelone_module.helpers import clean_hostname, filter_collected_events
 from sentinelone_module.logging import get_logger
 from sentinelone_module.logs.configuration import SentinelOneLogsConnectorConfiguration
 from sentinelone_module.logs.helpers import get_latest_event_timestamp
@@ -96,7 +96,9 @@ class SentinelOneLogsConsumer(Thread):
         Returns:
             Management: SentinelOne client instance
         """
-        return Management(hostname=self.module.configuration.hostname, api_token=self.module.configuration.api_token)
+        return Management(
+            hostname=clean_hostname(self.module.configuration.hostname), api_token=self.module.configuration.api_token
+        )
 
     def load_events_cache(self) -> Cache:
         events_cache: LRUCache = LRUCache(maxsize=10000)

--- a/SentinelOne/tests/conftest.py
+++ b/SentinelOne/tests/conftest.py
@@ -38,7 +38,7 @@ def sentinelone_hostname():
 @pytest.fixture(scope="session")
 def sentinelone_module(sentinelone_hostname):
     module = SentinelOneModule()
-    module.configuration = {"hostname": sentinelone_hostname, "api_token": "1234567890"}
+    module.configuration = {"hostname": f"https://{sentinelone_hostname}/a/path/", "api_token": "1234567890"}
     return module
 
 

--- a/SentinelOne/tests/test_helpers.py
+++ b/SentinelOne/tests/test_helpers.py
@@ -4,6 +4,7 @@ import pytest
 from cachetools import LRUCache
 
 from sentinelone_module.helpers import (
+    clean_hostname,
     filter_collected_events,
     generate_password,
     is_a_supported_stix_indicator,
@@ -95,3 +96,21 @@ def test_stix_to_indicators():
 )
 def test_filter_collected_events(events, getter, cache, expected_list):
     assert filter_collected_events(events, getter, cache) == expected_list
+
+
+@pytest.mark.parametrize(
+    "hostname,expected_hostname",
+    [
+        ("example.com", "example.com"),
+        ("http://example.com", "example.com"),
+        ("https://example.com", "example.com"),
+        ("http://example.com/path/to/resource", "example.com"),
+        ("https://example.com/path/to/resource", "example.com"),
+        ("ftp://example.com/resource", "example.com"),
+        ("example.com/path/to/resource", "example.com"),
+        ("http://subdomain.example.com", "subdomain.example.com"),
+        ("https://subdomain.example.com/path", "subdomain.example.com"),
+    ],
+)
+def test_clean_hostname(hostname, expected_hostname):
+    assert clean_hostname(hostname) == expected_hostname


### PR DESCRIPTION
Remove protocol scheme or url path from the hostname configured in the configuration.

## Summary by Sourcery

Introduce a clean_hostname helper to remove protocol prefixes and URL paths from the configured hostname and apply it when creating the SentinelOne Management client

Enhancements:
- Sanitize configured hostname by stripping protocol schemes and URL paths before initializing the Management client

Build:
- Bump manifest version to 1.20.13

Documentation:
- Update CHANGELOG with hostname cleaning fix and new version

Tests:
- Add parametrized tests for clean_hostname helper and update hostname fixture to include protocol and path