### PR TITLE
AWS SQS Trigger

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-09-05 - 1.33.2
+
+### Fixed
+
+- Fix the SQS messages trigger to handle differently AWS notifications from raw messages
+
 ## 2025-04-07 - 1.33.1
 
 ### Added

--- a/AWS/aws_helpers/utils.py
+++ b/AWS/aws_helpers/utils.py
@@ -86,4 +86,4 @@ async def async_gzip_open(
         newline=newline,
     )
     f = await loop.run_in_executor(executor, cb)
-    return AsyncBufferedReader(f, loop=loop, executor=executor)
+    return AsyncBufferedReader(f, loop=loop, executor=executor)  # type: ignore[arg-type]

--- a/AWS/connectors/trigger_sqs_messages.py
+++ b/AWS/connectors/trigger_sqs_messages.py
@@ -85,8 +85,13 @@ class AwsSqsMessagesTrigger(AbstractAwsConnector):
 
                     timestamps_to_log.append(message_timestamp)
                     try:
-                        # Records is a list of strings
-                        records.extend(orjson.loads(message).get("Records", []))
+                        content = orjson.loads(message)
+                        if self.is_aws_notification(content):
+                            # The message is an AWS notification, we extract the Records field
+                            records.extend(content.get("Records", []))
+                        else:
+                            # The message is a raw message, we add it as is
+                            records.append(content)
                     except ValueError as e:
                         self.log_exception(e, message=f"Invalid JSON in message.\nInvalid message is: {message}")
 

--- a/AWS/connectors/trigger_sqs_messages.py
+++ b/AWS/connectors/trigger_sqs_messages.py
@@ -51,6 +51,17 @@ class AwsSqsMessagesTrigger(AbstractAwsConnector):
 
         return SqsWrapper(config)
 
+    def is_aws_notification(self, message: Any) -> bool:
+        """
+        Check if message is AWS notification.
+
+        Args:
+            message: dict
+        Returns:
+            bool: True if message is AWS notification
+        """
+        return isinstance(message, dict) and "Records" in message and isinstance(message["Records"], list)
+
     async def next_batch(self) -> tuple[int, list[int]]:
         """
         Get next batch of messages.

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,7 +29,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "categories": [
     "Cloud Providers"
   ]

--- a/AWS/poetry.lock
+++ b/AWS/poetry.lock
@@ -3521,14 +3521,14 @@ typing-extensions = ">=3.7.4.3"
 
 [[package]]
 name = "types-aiofiles"
-version = "23.2.0.20240623"
+version = "24.1.0.20250822"
 description = "Typing stubs for aiofiles"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "types-aiofiles-23.2.0.20240623.tar.gz", hash = "sha256:d515b2fa46bf894aff45a364a704f050de3898344fd6c5994d58dc8b59ab71e6"},
-    {file = "types_aiofiles-23.2.0.20240623-py3-none-any.whl", hash = "sha256:70597b29fc40c8583b6d755814b2cd5fcdb6785622e82d74ef499f9066316e08"},
+    {file = "types_aiofiles-24.1.0.20250822-py3-none-any.whl", hash = "sha256:0ec8f8909e1a85a5a79aed0573af7901f53120dd2a29771dd0b3ef48e12328b0"},
+    {file = "types_aiofiles-24.1.0.20250822.tar.gz", hash = "sha256:9ab90d8e0c307fe97a7cf09338301e3f01a163e39f3b529ace82466355c84a7b"},
 ]
 
 [[package]]
@@ -3918,4 +3918,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "a0122669e14353340e8a5afd1d33b1229fa0a483478ca2f35e456630eb49e22f"
+content-hash = "82c2ef4ba67f13ccb8cca13cbce14690b1b40bec3ea5c940730455c7fff9f2da"

--- a/AWS/pyproject.toml
+++ b/AWS/pyproject.toml
@@ -36,7 +36,7 @@ autoflake = "^1.4"
 isort = "^5.10.1"
 black = { version = "^24.3.0", extras = ["colorama"] }
 mypy = "^0.991"
-types-aiofiles = "^23.1.0.4"
+types-aiofiles = "^24.1.0.0"
 types-python-dateutil = "^2.8.19.13"
 poethepoet = { version = "^0.16.5", extras = ["poetry_plugin"] }
 poetry = "^1.5.1"

--- a/AWS/tests/connectors/test_trigger_sqs_messages.py
+++ b/AWS/tests/connectors/test_trigger_sqs_messages.py
@@ -184,6 +184,42 @@ async def test_trigger_sqs_messages_with_one_failed(
     assert await connector.next_batch() == expected_result
 
 
+@pytest.mark.asyncio
+async def test_trigger_sqs_with_custom_messages(
+    symphony_storage: Path, session_faker: Faker, connector: AwsSqsMessagesTrigger
+):
+    """
+    Test trigger AwsSqsMessagesTriggerConfiguration.
+
+    Args:
+        symphony_storage: Path,
+        session_faker: Faker
+        sqs_message: str
+        connector: AwsSqsMessagesTrigger
+    """
+    amount_of_messages = session_faker.pyint(min_value=5, max_value=100)
+    the_message = '{"message": "hello"}'
+
+    valid_messages = [
+        (the_message, session_faker.pyint(min_value=1, max_value=1000)) for _ in range(amount_of_messages)
+    ]
+    expected_messages = []
+    expected_timestamps = []
+    for data in valid_messages:
+        message, timestamp = data
+
+        expected_messages.extend([orjson.dumps(record).decode("utf-8") for record in orjson.loads(message)])
+        expected_timestamps.append(timestamp)
+
+    expected_result = len(expected_messages), expected_timestamps
+
+    connector.sqs_wrapper = MagicMock()
+    connector.sqs_wrapper.receive_messages = MagicMock()
+    connector.sqs_wrapper.receive_messages.return_value.__aenter__.return_value = valid_messages
+
+    assert await connector.next_batch() == expected_result
+
+
 @pytest.mark.parametrize(
     "message, expected",
     [

--- a/AWS/tests/connectors/test_trigger_sqs_messages.py
+++ b/AWS/tests/connectors/test_trigger_sqs_messages.py
@@ -182,3 +182,27 @@ async def test_trigger_sqs_messages_with_one_failed(
     ]
 
     assert await connector.next_batch() == expected_result
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        ({"Records": []}, True),
+        ({"Records": [{}]}, True),
+        ({}, False),
+        ({"message": []}, False),
+        ({"message": "hello"}, False),
+        ({"Records": "string"}, False),
+        ("string", False),
+    ],
+)
+def test_is_aws_notification(message: dict, expected: bool, connector: AwsSqsMessagesTrigger):
+    """
+    Test is_aws_notification method.
+
+    Args:
+        message: dict
+        expected: bool
+        connector: AwsSqsMessagesTrigger
+    """
+    assert connector.is_aws_notification(message) is expected


### PR DESCRIPTION
Fix the SQS messages trigger to handle differently AWS notifications from raw messages

## Summary by Sourcery

Refine the SQS messages trigger to correctly process AWS notification envelopes versus raw messages by adding a detection helper, adjusting parsing logic, adding targeted tests, and updating versioning and changelog.

Enhancements:
- Add is_aws_notification method to distinguish AWS notification messages
- Update next_batch logic to extract Records from notifications or include raw JSON messages

Build:
- Bump AWS provider version to 1.33.2 in manifest

Documentation:
- Update CHANGELOG with SQS trigger fix under version 1.33.2

Tests:
- Add test for handling custom raw messages in the SQS trigger
- Add parameterized tests for is_aws_notification behavior