### PR TITLE
Sekoia.io: Improve Get Events action

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-09-08 - 2.68.5
+
+### Changed
+
+- Increase the backoff factor when getting events
+- Change the way to wait the completion of an event search job
+
 ## 2025-06-03 - 2.68.4
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.68.4",
+  "version": "2.68.5",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/base_get_event.py
+++ b/Sekoia.io/sekoiaio/operation_center/base_get_event.py
@@ -96,7 +96,7 @@ class BaseGetEvents(Action):
 
             # If we exceed the timeout, raise an error
             if time.time() - start_wait > timeout:
-                raise TimeoutError(f"Event search job took more than {timeout}s to {action}")
+                raise TimeoutError(f"Event search job {event_search_job_uuid} took more than {timeout}s to {action}")
 
     def wait_for_search_job_execution(self, event_search_job_uuid: str) -> None:
         # Wait for job to start (20 min)

--- a/Sekoia.io/sekoiaio/operation_center/base_get_event.py
+++ b/Sekoia.io/sekoiaio/operation_center/base_get_event.py
@@ -1,4 +1,5 @@
 import time
+from typing import Callable
 from posixpath import join as urljoin
 
 import requests
@@ -65,22 +66,53 @@ class BaseGetEvents(Action):
 
         return response_start.json()["uuid"]
 
-    def wait_for_search_job_execution(self, event_search_job_uuid: str) -> None:
-        # wait at most 300 sec for the event search job to conclude
-        max_wait_search = 300
+    def _wait_for_search_job_step(
+        self, event_search_job_uuid: str, should_we_wait: Callable[[int], bool], error: str, timeout: int = 300
+    ) -> None:
+        """
+        Wait for a step in the search job execution
+
+        :param event_search_job_uuid: The UUID of the event search job
+        :param should_we_wait: A function that takes the current status and returns True if we should keep waiting
+        :param error: The error message to raise if the timeout is reached
+        :param timeout: The maximum time to wait in seconds
+        """
         start_wait = time.time()
 
+        # Initial status check
         response_get = self.http_session.get(f"{self.events_api_path}/search/jobs/{event_search_job_uuid}", timeout=20)
         response_get.raise_for_status()
 
-        while response_get.json()["status"] != 2:
+        # Wait for the condition to be met
+        while should_we_wait(response_get.json()["status"]):
+            # Wait one second before polling again
             time.sleep(1)
+
+            # Poll the job status
             response_get = self.http_session.get(
                 f"{self.events_api_path}/search/jobs/{event_search_job_uuid}", timeout=20
             )
             response_get.raise_for_status()
-            if time.time() - start_wait > max_wait_search:
-                raise TimeoutError(f"Event search job took more than {max_wait_search}s to conclude")
+
+            # If we exceed the timeout, raise an error
+            if time.time() - start_wait > timeout:
+                raise TimeoutError(error.format(timeout=timeout))
+
+    def wait_for_search_job_execution(self, event_search_job_uuid: str) -> None:
+        # Wait for job to start (20 min)
+        self._wait_for_search_job_step(
+            event_search_job_uuid,
+            lambda status: status == 0,  # Wait for status to change from 0 (not started)
+            "Event search job took more than {timeout}s to start",
+            1200,
+        )
+        # Wait for job to complete (30 min)
+        self._wait_for_search_job_step(
+            event_search_job_uuid,
+            lambda status: status == 1,  # Wait for status to change from 1 (in progress)
+            "Event search job took more than {timeout}s to complete",
+            1800,
+        )
 
     def run(self, arguments: dict):
         raise NotImplementedError()

--- a/Sekoia.io/sekoiaio/operation_center/base_get_event.py
+++ b/Sekoia.io/sekoiaio/operation_center/base_get_event.py
@@ -27,9 +27,11 @@ class BaseGetEvents(Action):
         # Configure http with retry strategy
         retry_strategy = Retry(
             total=10,
+            status=10,
             status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=["HEAD", "GET", "OPTIONS"],
-            backoff_factor=0.2,
+            backoff_factor=1,
+            backoff_max=120,
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.http_session = requests.Session()

--- a/Sekoia.io/tests/operation_center_action/test_get_events.py
+++ b/Sekoia.io/tests/operation_center_action/test_get_events.py
@@ -180,3 +180,162 @@ def test_not_events_found_but_total(requests_mock):
     assert results["events"] == []
     assert len(action._logs) == 1
     assert action._logs[0]["level"] == "error"
+
+
+def test_get_events_with_retries(requests_mock):
+    action = GetEvents()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+
+    arguments = {
+        "query": 'source.ip:"127.0.0.1" OR destination.ip:"127.0.0.1"',
+        "earliest_time": "-1d",
+        "latest_time": "now",
+        "fields": "event.dialect,action.outcome,action.id",
+        "limit": 6,
+    }
+
+    requests_mock.post(
+        "https://fake.url/api/v1/sic/conf/events/search/jobs",
+        json={"uuid": "483d36a5-8538-49c4-be19-49b669f90bf8"},
+    )
+
+    status_mock = requests_mock.get(
+        "https://fake.url/api/v1/sic/conf/events/search/jobs/483d36a5-8538-49c4-be19-49b669f90bf8",
+        [
+            # The job is pending
+            {
+                "json": {
+                    "canceled_by_type": None,
+                    "view_uuid": None,
+                    "term": arguments["query"],
+                    "expired": False,
+                    "earliest_time": arguments["earliest_time"],
+                    "results_ttl": 600,
+                    "created_by": "99671aa8-857f-49be-85b4-bcf1bc4df398",
+                    "started_at": None,
+                    "total": 0,
+                    "canceled_by": None,
+                    "created_at": "2021-05-26T09:19:57.469271+00:00",
+                    "created_by_type": "avatar",
+                    "canceled_at": None,
+                    "ended_at": None,
+                    "latest_time": arguments["latest_time"],
+                    "status": 0,
+                    "uuid": "483d36a5-8538-49c4-be19-49b669f90bf8",
+                    "term_lang": "dork",
+                },
+                "status_code": 200,
+            },
+            # The job is running
+            {
+                "json": {
+                    "canceled_by_type": None,
+                    "view_uuid": None,
+                    "term": arguments["query"],
+                    "expired": False,
+                    "earliest_time": arguments["earliest_time"],
+                    "results_ttl": 600,
+                    "created_by": "99671aa8-857f-49be-85b4-bcf1bc4df398",
+                    "started_at": "2021-05-26T09:19:58.469271+00:00",
+                    "total": 3,
+                    "canceled_by": None,
+                    "created_at": "2021-05-26T09:19:57.469271+00:00",
+                    "created_by_type": "avatar",
+                    "canceled_at": None,
+                    "ended_at": None,
+                    "latest_time": arguments["latest_time"],
+                    "status": 1,
+                    "uuid": "483d36a5-8538-49c4-be19-49b669f90bf8",
+                    "term_lang": "dork",
+                },
+                "status_code": 200,
+            },
+            # The job is done
+            {
+                "json": {
+                    "canceled_by_type": None,
+                    "view_uuid": None,
+                    "term": arguments["query"],
+                    "expired": False,
+                    "earliest_time": arguments["earliest_time"],
+                    "results_ttl": 600,
+                    "created_by": "99671aa8-857f-49be-85b4-bcf1bc4df398",
+                    "started_at": "2021-05-26T09:19:58.469271+00:00",
+                    "total": 3,
+                    "canceled_by": None,
+                    "created_at": "2021-05-26T09:19:57.469271+00:00",
+                    "created_by_type": "avatar",
+                    "canceled_at": None,
+                    "ended_at": "2021-05-26T09:19:59.469271+00:00",
+                    "latest_time": arguments["latest_time"],
+                    "status": 2,
+                    "uuid": "483d36a5-8538-49c4-be19-49b669f90bf8",
+                    "term_lang": "dork",
+                },
+                "status_code": 200,
+            },
+        ],
+    )
+
+    events = [
+        {
+            "name": "action.id",
+            "value_type": "number",
+            "description": "Identifier of the action",
+            "display_name": "action.id",
+            "most_common_values": [],
+        },
+        {
+            "display_name": "event.dialect",
+            "description": "Dialect of the event",
+            "most_common_values": [{"value": 100.0, "name": "openssh"}],
+            "value_type": "string",
+            "name": "event.dialect",
+        },
+        {
+            "name": "action.outcome",
+            "value_type": "string",
+            "description": "Result of the action",
+            "display_name": "action.outcome",
+            "most_common_values": [
+                {"value": 50.0, "name": "False"},
+                {"value": 50.0, "name": "True"},
+            ],
+        },
+        {
+            "name": "action.outcome_reason",
+            "value_type": "string",
+            "description": "The reason of the failure/success",
+            "display_name": "action.outcome_reason",
+        },
+        {
+            "name": "action.properties.AccessList",
+            "value_type": "string",
+            "description": "",
+            "display_name": "action.properties.AccessList",
+            "most_common_values": [
+                {"value": 50.0, "name": "val1"},
+                {"value": 50.0, "name": "val2"},
+            ],
+        },
+        {
+            "name": "action.properties.AccessMask",
+            "value_type": "string",
+            "description": "",
+            "display_name": "action.properties.AccessMask",
+        },
+    ]
+    requests_mock.get(
+        (
+            "https://fake.url/api/v1/sic/conf/events/search/jobs/"
+            "483d36a5-8538-49c4-be19-49b669f90bf8/events?limit=6&offset=0"
+        ),
+        json={
+            "items": events,
+            "total": 6,
+        },
+    )
+
+    results: dict = action.run(arguments)
+    assert results["events"] == events
+    assert status_mock.call_count == 3


### PR DESCRIPTION
- Increase the backoff factor when getting events
- Change the way to wait the completion of an event search job

## Summary by Sourcery

Improve the Get Events action's reliability by enhancing the HTTP retry strategy, refactoring the event search job polling into separate start and completion phases, and adding tests for retry behavior

Enhancements:
- Increase HTTP session retry backoff factor and configure a maximum backoff time
- Refactor wait_for_search_job_execution into distinct start and completion polling steps with extended timeouts

Tests:
- Add test to verify retry logic and status polling across an event search job lifecycle

Chores:
- Bump version to 2.68.5 and update the changelog