### PR TITLE
1Password: force the uri validation of the base url parameter

### DIFF
--- a/1Password/CHANGELOG.md
+++ b/1Password/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-09-16 - 1.0.2
+
+### Fixed
+
+- Force the URI validation on the `base_url` parameter in the configuration
+
 ## 2025-01-07 - 1.0.1
 
 ### Fixed

--- a/1Password/manifest.json
+++ b/1Password/manifest.json
@@ -7,7 +7,7 @@
       "base_url": {
         "description": "1Password base URL",
         "type": "string",
-	"format": "uri"
+        "format": "uri"
       },
       "api_token": {
         "description": "API token",

--- a/1Password/manifest.json
+++ b/1Password/manifest.json
@@ -26,7 +26,7 @@
   "name": "1Password",
   "uuid": "56f9e1f6-95ba-45ed-867b-44fb3183934d",
   "slug": "one-password",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "categories": [
     "Applicative"
   ]

--- a/1Password/manifest.json
+++ b/1Password/manifest.json
@@ -6,7 +6,8 @@
     "properties": {
       "base_url": {
         "description": "1Password base URL",
-        "type": "string"
+        "type": "string",
+	"format": "uri"
       },
       "api_token": {
         "description": "API token",


### PR DESCRIPTION
## Summary by Sourcery

Enforce URI validation on the base_url configuration parameter, bump the plugin version to 1.0.2, and update the changelog accordingly.

Enhancements:
- Require the base_url parameter to conform to URI format by adding "format": "uri" in the manifest

Chores:
- Bump 1Password integration version to 1.0.2
- Add changelog entry for version 1.0.2 highlighting the URI validation fix