### PR TITLE
SalesForce: Set Interval field only for Hourly fetch

### DIFF
--- a/Salesforce/CHANGELOG.md
+++ b/Salesforce/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-09-18 - 1.7.1
+
+### Changed
+
+- Change the way to compute the filters for the query
+
+### Fixed
+
+- Change the way to define the log type
+
 ## 2024-10-30 - 1.7.0
 
 ### Changed

--- a/Salesforce/client/http_client.py
+++ b/Salesforce/client/http_client.py
@@ -128,15 +128,22 @@ class SalesforceHttpClient(object):
         Returns:
             str:
         """
-        date_filter = "AND CreatedDate > {0}".format(start_from.strftime("%Y-%m-%dT%H:%M:%SZ")) if start_from else ""
-        result_log_type = log_type if log_type else LogType.HOURLY
+        # base query
+        query = "SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength FROM EventLogFile"
 
-        return """
-            SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength
-                FROM EventLogFile WHERE Interval = \'{0}\' {1}
-        """.format(
-            result_log_type.value, date_filter
-        )
+        # filters for the query
+        filters = []
+
+        if log_type:
+            filters.append("Interval = '{0}'".format(log_type.value))
+
+        if start_from:
+            filters.append("CreatedDate > {0}".format(start_from.strftime("%Y-%m-%dT%H:%M:%SZ")))
+
+        if filters:
+            query = "{0} WHERE {1}".format(query, " AND ".join(filters))
+
+        return query
 
     def _request_url_with_query(self, query: str) -> URL:
         """

--- a/Salesforce/manifest.json
+++ b/Salesforce/manifest.json
@@ -39,7 +39,7 @@
   "name": "Salesforce",
   "uuid": "f811e134-2548-11ee-be56-0242ac120002",
   "slug": "salesforce",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "categories": [
     "Applicative"
   ]

--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -25,9 +25,9 @@ class SalesforceConnectorConfig(DefaultConnectorConfiguration):
     fetch_daily_logs: bool = False
 
     @property
-    def log_type(self) -> LogType:
+    def log_type(self) -> LogType | None:
         """Get log type."""
-        return LogType.DAILY if self.fetch_daily_logs else LogType.HOURLY
+        return LogType.HOURLY if not self.fetch_daily_logs else None
 
 
 class SalesforceConnector(AsyncConnector):

--- a/Salesforce/tests/client/test_http_client.py
+++ b/Salesforce/tests/client/test_http_client.py
@@ -42,12 +42,9 @@ async def test_salesforce_http_client_log_files_query():
     """Test SalesforceHttpClient._log_files_query."""
     query = SalesforceHttpClient._log_files_query(None)
 
-    expected_query = """
-        SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength
-                FROM EventLogFile WHERE Interval = \'Hourly\'
-    """.strip()
+    expected_query = "SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength " "FROM EventLogFile"
 
-    assert query.strip() == expected_query
+    assert query == expected_query
 
 
 @pytest.mark.asyncio
@@ -57,12 +54,12 @@ async def test_salesforce_http_client_log_files_query_1():
         start_from=datetime.datetime.strptime("2023-01-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"),
     )
 
-    expected_query = """
-        SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength
-                FROM EventLogFile WHERE Interval = \'Hourly\' AND CreatedDate > 2023-01-01T00:00:00Z
-    """.strip()
+    expected_query = (
+        "SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength "
+        "FROM EventLogFile WHERE CreatedDate > 2023-01-01T00:00:00Z"
+    )
 
-    assert query.strip() == expected_query
+    assert query == expected_query
 
 
 @pytest.mark.asyncio
@@ -73,12 +70,12 @@ async def test_salesforce_http_client_log_files_query_2():
         log_type=LogType.DAILY,
     )
 
-    expected_query = """
-        SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength
-                FROM EventLogFile WHERE Interval = \'Daily\' AND CreatedDate > 2023-01-01T00:00:00Z
-    """.strip()
+    expected_query = (
+        "SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength "
+        "FROM EventLogFile WHERE Interval = 'Daily' AND CreatedDate > 2023-01-01T00:00:00Z"
+    )
 
-    assert query.strip() == expected_query
+    assert query == expected_query
 
 
 @pytest.mark.asyncio
@@ -89,12 +86,12 @@ async def test_salesforce_http_client_log_files_query_2():
         log_type=LogType.HOURLY,
     )
 
-    expected_query = """
-        SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength
-                FROM EventLogFile WHERE Interval = \'Hourly\' AND CreatedDate > 2023-01-01T00:00:00Z
-    """.strip()
+    expected_query = (
+        "SELECT Id, EventType, LogFile, LogDate, CreatedDate, LogFileLength "
+        "FROM EventLogFile WHERE Interval = 'Hourly' AND CreatedDate > 2023-01-01T00:00:00Z"
+    )
 
-    assert query.strip() == expected_query
+    assert query == expected_query
 
 
 @pytest.mark.asyncio

--- a/Salesforce/tests/salesforce/test_connector.py
+++ b/Salesforce/tests/salesforce/test_connector.py
@@ -254,7 +254,9 @@ async def test_salesforce_connector_get_salesforce_events(
             payload=token_data,
         )
 
-        query = connector.salesforce_client._log_files_query(connector.last_event_date)
+        query = connector.salesforce_client._log_files_query(
+            connector.last_event_date, connector.configuration.log_type
+        )
         get_log_files_url = connector.salesforce_client._request_url_with_query(query)
 
         log_file_response_dict = log_files_response_success.dict()
@@ -319,7 +321,9 @@ async def test_salesforce_connector_get_salesforce_events_1(
             payload=token_data,
         )
 
-        query = connector.salesforce_client._log_files_query(connector.last_event_date)
+        query = connector.salesforce_client._log_files_query(
+            connector.last_event_date, connector.configuration.log_type
+        )
         get_log_files_url = connector.salesforce_client._request_url_with_query(query)
 
         log_file_response_dict = log_files_response_success.dict()
@@ -389,7 +393,9 @@ async def test_salesforce_connector_get_salesforce_events_2(
             payload=token_data,
         )
 
-        query = connector.salesforce_client._log_files_query(connector.last_event_date, LogType.DAILY)
+        query = connector.salesforce_client._log_files_query(
+            connector.last_event_date, connector.configuration.log_type
+        )
         get_log_files_url = connector.salesforce_client._request_url_with_query(query)
 
         log_file_response_dict = log_files_response_success.dict()


### PR DESCRIPTION
According to [the documentation](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_eventlogfile.htm), the `Interval` field seems to be only available for `customers with hourly Event Log Files`.
For others, the use of this fields generates errors.