### PR TITLE
HTTP: Improve Request URL action

### DIFF
--- a/HTTP/CHANGELOG.md
+++ b/HTTP/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-10-03 - 1.119.5
+
+### Changed
+
+- Allow to supply a dictionary in the params argument
+
 ## 2025-06-30 - 1.119.4
 
 ### Fixed

--- a/HTTP/action_request.json
+++ b/HTTP/action_request.json
@@ -33,7 +33,14 @@
       },
       "params": {
         "description": "Query string parameters to append to the URL",
-        "type": "string"
+	"anyOf": [
+	  {
+	    "type": "object"
+	  },
+	  {
+	    "type": "string"
+	  }
+	],
       },
       "fail_on_http_error": {
         "description": "Fail when the HTTP query returns in error. Default to true.",

--- a/HTTP/manifest.json
+++ b/HTTP/manifest.json
@@ -9,7 +9,7 @@
   "name": "HTTP",
   "uuid": "5894985f-91eb-46db-9306-cc5ac6463d3d",
   "slug": "http",
-  "version": "1.119.4",
+  "version": "1.119.5",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
Allow to supply a dictionary in the `params` arguments.
Currently, only a string was allowed