### PR TITLE
CI: add instructions for the PR reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,20 +6,20 @@ The organization of this repository is described in `docs/README.md`. Please ref
 
 ## Pull Request Reviews
 
-### Module Identifier Changes
+### Component Identifier Changes
 
-When reviewing pull requests, pay special attention to changes in module identifiers:
+When reviewing pull requests, pay special attention to changes in component identifiers for modules, actions, connectors, and triggers:
 
-- **Always comment** when a module's identifier (ID/UUID) is modified in any configuration file, manifest, or module definition
-- Highlight that changing a module identifier is a breaking change that may affect:
+- **Always comment** when a component's identifier (ID/UUID) is modified in any configuration file, manifest, or component definition
+- Highlight that changing a component identifier is a breaking change that may affect:
   - Existing deployments and installations
-  - Module dependencies and references
+  - Component dependencies and references
   - Historical data and configurations
   - Integration with other systems
 
 ### Review Checklist
 
-When a module identifier change is detected:
+When a component identifier change is detected:
 1. Ask if this change is intentional
 2. Request confirmation that the impact has been assessed
 3. Suggest adding a migration guide or changelog entry


### PR DESCRIPTION
Add instructions for Github Copilot agent for PR reviews

## Summary by Sourcery

Add a Copilot instructions file to guide automated PR reviews with special emphasis on module identifier changes and a structured review checklist

Documentation:
- Introduce .github/copilot-instructions.md with guidelines for GitHub Copilot during PR reviews
- Outline the importance of module identifier changes as breaking changes and list affected areas
- Provide a step-by-step review checklist for assessing module identifier updates