### PR TITLE
WithSecure - ignore empty device objects

### DIFF
--- a/WithSecure/CHANGELOG.md
+++ b/WithSecure/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## 2025-10-15 - 2.16.2
+
+### Fixed
+
+- Ignore empty objects returned by list devices action
+
 ## 2024-11-22 - 2.16.1
 
 ### Changed

--- a/WithSecure/manifest.json
+++ b/WithSecure/manifest.json
@@ -25,7 +25,7 @@
   "name": "WithSecure",
   "uuid": "8aa9f86c-f360-4ae7-84f5-b61c6917cf01",
   "slug": "withsecure",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "categories": [
     "Endpoint"
   ]

--- a/WithSecure/withsecure/list_devices_action.py
+++ b/WithSecure/withsecure/list_devices_action.py
@@ -48,7 +48,8 @@ class ListDevicesAction(Action):
         response.raise_for_status()
         payload = response.json()
         for device in payload["items"]:
-            devices.append(self.build_device_details(device))
+            if device:
+                devices.append(self.build_device_details(device))
 
         while payload.get("nextAnchor"):
             params["anchor"] = payload["nextAnchor"]
@@ -57,7 +58,8 @@ class ListDevicesAction(Action):
             payload = response.json()
 
             for device in payload["items"]:
-                devices.append(self.build_device_details(device))
+                if device:
+                    devices.append(self.build_device_details(device))
 
         return ActionResults(devices=devices)
 


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1002

For some reason, there are empty dicts among correct objects. The fix allows to ignore them

## Summary by Sourcery

Ignore empty device objects in the WithSecure list_devices action to filter out invalid entries and bump the integration version.

Bug Fixes:
- Ignore empty device objects returned by list devices action to prevent processing invalid entries.

Chores:
- Bump WithSecure integration version to 2.16.2 and update changelog.