### PR TITLE
Hotfix: CrowdStrike Queue Configuration Issue

### DIFF
--- a/CrowdStrike/CHANGELOG.md
+++ b/CrowdStrike/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.12.1 - 2025-10-22
+
+### Fixed
+
+- Crowdstrike SQS Configuration
+
 ## 1.12.0 - 2025-09-23
 
 ### Changed

--- a/CrowdStrike/manifest.json
+++ b/CrowdStrike/manifest.json
@@ -29,7 +29,7 @@
   "name": "CrowdStrike",
   "uuid": "4ffe6bd9-6693-414d-ade0-5ec9fb1b8b2c",
   "slug": "crowdstrike",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "categories": [
     "Endpoint"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Hotfix the CrowdStrike telemetry connector by correcting its SQS queue configuration and releasing version 1.12.1

Bug Fixes:
- Implement sqs_wrapper to properly configure and instantiate the SQS queue wrapper using connector settings

Enhancements:
- Switch CrowdStrikeTelemetryConnector to use the dedicated CrowdStrikeTelemetryConnectorConfig type instead of the generic AwsS3QueuedConfiguration

Chores:
- Bump integration version to 1.12.1 and update the changelog accordingly