### PR TITLE
Hotfix: Microsoft EntraId GraphAPI Session Issue (1052)

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-10-30 - 2.10.3
+
+### Fixed
+
+- Fix the problem of early closed async loop
+
 ## 2025-10-20 - 2.10.2
 
 ### Fixed

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftEntraID/tests/conftest.py
+++ b/MicrosoftEntraID/tests/conftest.py
@@ -137,6 +137,7 @@ def graph_api_client(session_faker: Faker) -> GraphApi:
     dir_audits.with_url.return_value.get = AsyncMock()
     client_mock.audit_logs.directory_audits = dir_audits
 
+    client._credentials = MagicMock()
     client._client = client_mock
 
     return client

--- a/MicrosoftEntraID/tests/test_account_validator.py
+++ b/MicrosoftEntraID/tests/test_account_validator.py
@@ -41,6 +41,7 @@ def test_validate_success(mock_get_event_loop, test_azure_ad_account_validator):
     mock_users = Mock()
     mock_users.get = AsyncMock()
     mock_client.users = mock_users
+    test_azure_ad_account_validator._credentials = MagicMock()
     test_azure_ad_account_validator._client = mock_client
 
     # Act
@@ -64,6 +65,7 @@ def test_validate_failure_connection_error(mock_get_event_loop, test_azure_ad_ac
     mock_users = Mock()
     mock_users.get = AsyncMock(side_effect=Exception("Connection failed"))
     mock_client.users = mock_users
+    test_azure_ad_account_validator._credentials = MagicMock()
     test_azure_ad_account_validator._client = mock_client
 
     # Configure run_until_complete to raise the exception
@@ -91,6 +93,7 @@ def test_validate_failure_authentication_error(mock_get_event_loop, test_azure_a
     mock_users = Mock()
     mock_users.get = AsyncMock(side_effect=Exception("Invalid credentials"))
     mock_client.users = mock_users
+    test_azure_ad_account_validator._credentials = MagicMock()
     test_azure_ad_account_validator._client = mock_client
 
     # Configure run_until_complete to raise the exception
@@ -118,6 +121,7 @@ def test_validate_failure_network_error(mock_get_event_loop, test_azure_ad_accou
     mock_users = Mock()
     mock_users.get = AsyncMock(side_effect=Exception("Network timeout"))
     mock_client.users = mock_users
+    test_azure_ad_account_validator._credentials = MagicMock()
     test_azure_ad_account_validator._client = mock_client
 
     # Configure run_until_complete to raise the exception
@@ -147,6 +151,7 @@ def test_validate_uses_cached_client(mock_get_event_loop, test_azure_ad_account_
     mock_client.users = mock_users
 
     # Set the cached client directly
+    test_azure_ad_account_validator._credentials = MagicMock()
     test_azure_ad_account_validator._client = mock_client
 
     # Act


### PR DESCRIPTION
Relates to [1052](https://github.com/SekoiaLab/integration/issues/1052)

## Summary by Sourcery

Reset Graph API clients and credentials on session or transport closure, enforce client re-creation, ensure proper cleanup, update tests, and bump version accordingly

Bug Fixes:
- Reset the Graph API client when HTTP transport closes to avoid using a closed session
- Ensure the asynchronous loops do not fail early due to closed transports by clearing the client

Enhancements:
- Convert cached_property usage for client instances to property to support credential resets
- Force re-creation of clients when credentials are refreshed and clear credentials on close

Build:
- Bump manifest version to 2.10.3

Documentation:
- Update CHANGELOG with version 2.10.3 and note the async loop closure fix

Tests:
- Add credentials mocks to account validator tests to align with new credential handling
- Initialize credentials in the graph_api_client fixture for consistent test setup