### PR TITLE
CI: Fix the Build modules GA for parallel jobs

### DIFF
--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Upload Event
         uses: actions/upload-artifact@v4
         with:
-          name: Event File
+          name: Event File (${{ matrix.module }})
           path: ${{ github.event_path }}
 
       - name: Upload Test Results

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -27,6 +27,6 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event File/event.json
+          event_file: artifacts/Event File (*)/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: "artifacts/**/*.xml"


### PR DESCRIPTION
When changing several modules in the same PR, the `Build modules` GA failed as the job try to push `Event Files` with the name (cf [failed job](https://github.com/SEKOIA-IO/automation-library/actions/runs/17859997791/job/50787975131)):

- Add the module name in the name of the artifact.

## Summary by Sourcery

Fix artifact naming and path resolution in CI workflows to prevent conflicts when running build modules in parallel

CI:
- Include module name in `Event File` artifact name in the build-modules workflow
- Update the `event_file` path in the test_results workflow to use a wildcard for module-specific artifact directories