### PR TITLE
Okta: bump version number

### DIFF
--- a/Okta/CHANGELOG.md
+++ b/Okta/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-11-12 - 2.8.4
+
+### Added
+
+- Add events cache to deduplicate events
+
 ## 2025-10-06 - 2.8.3
 
 ### Changed

--- a/Okta/manifest.json
+++ b/Okta/manifest.json
@@ -26,7 +26,7 @@
   "name": "Okta",
   "uuid": "4ef895d1-3f21-4678-8d0a-5c39c37210fe",
   "slug": "okta",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "categories": [
     "IAM"
   ],


### PR DESCRIPTION
Bump the version number according to the last changes done by @vg-svitla

## Summary by Sourcery

Release Okta version 2.8.4 with a new events cache to deduplicate events

New Features:
- Add events cache to deduplicate events

Enhancements:
- Bump Okta integration version to 2.8.4

Documentation:
- Add 2.8.4 entry in CHANGELOG