### PR TITLE
Fix: Okta SecretString Issue (1086)

### DIFF
--- a/Okta/CHANGELOG.md
+++ b/Okta/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-11-25 - 2.8.5
+
+### Added
+
+- Fix the issue when work with SecretString
+
 ## 2025-11-12 - 2.8.4
 
 ### Added

--- a/Okta/manifest.json
+++ b/Okta/manifest.json
@@ -26,7 +26,7 @@
   "name": "Okta",
   "uuid": "4ef895d1-3f21-4678-8d0a-5c39c37210fe",
   "slug": "okta",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "categories": [
     "IAM"
   ],

--- a/Okta/okta_modules/system_log_trigger.py
+++ b/Okta/okta_modules/system_log_trigger.py
@@ -109,7 +109,7 @@ class SystemLogConnector(Connector):
     @cached_property
     def client(self) -> ApiClient:
         return ApiClient(
-            apikey=self.module.configuration.apikey.get_secret_value(),
+            apikey=self.module.configuration.apikey,  # type: ignore
             ratelimit_per_minute=self.configuration.ratelimit_per_minute,
         )
 


### PR DESCRIPTION
Relates to [1086](https://github.com/SekoiaLab/integration/issues/1086)

## Summary by Sourcery

Fix Okta integration authentication handling for SecretString API keys and bump the integration version.

Bug Fixes:
- Resolve incorrect handling of SecretString API keys when initializing the Okta system log client.

Chores:
- Update Okta integration version and changelog entry to 2.8.5 for the SecretString fix.