### PR TITLE
NewRelic: fix category

### DIFF
--- a/NewRelic/CHANGELOG.md
+++ b/NewRelic/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.0.1] - 2025-12-08
+
+### Fixed
+
+- Change the category of the module
+
 ## [1.0.0] - 2025-11-26
 
 ### Added

--- a/NewRelic/manifest.json
+++ b/NewRelic/manifest.json
@@ -32,5 +32,5 @@
     "Applicative"
   ],
   "uuid": "e44114c6-4c81-47b9-9298-3fe268b30f84",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
## Summary by Sourcery

Update the New Relic integration metadata to release a patch version with a corrected module category.

Bug Fixes:
- Correct the New Relic module category from Network to Applicative in the manifest.

Build:
- Bump the New Relic integration version from 1.0.0 to 1.0.1 in the manifest.

Documentation:
- Add a 1.0.1 changelog entry documenting the category fix.