### PR TITLE
CI: add worflow to review upstream PRs

### DIFF
--- a/.github/workflows/release_auto_approve.yml
+++ b/.github/workflows/release_auto_approve.yml
@@ -1,0 +1,22 @@
+name: Integration release auto-approve
+
+# Controls when the action will run.
+on:
+  pull_request:
+    branches: [production]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: |
+      github.event.pull_request.user.login == 'integration-release-to-production' &&
+      github.event.pull_request.user.type == 'Bot'
+    steps:
+      - name: Approve a PR
+        run: gh pr review --repo "${{ github.repository }}" --approve "$PR_NUMBER"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a Github workflow to approve PRs from 'integration-release-to-production'

## Summary by Sourcery

CI:
- Introduce a workflow that auto-approves pull requests created by the 'integration-release-to-production' bot when they target the production branch.