### PR TITLE
JIRA - fix new actions

### DIFF
--- a/JIRA/CHANGELOG.md
+++ b/JIRA/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-12-17 - 1.4.1
+
+### Fixed
+
+- Fix return from list to dict
+
 ## 2025-12-01 - 1.4.0
 
 ### Added

--- a/JIRA/jira_modules/action_base.py
+++ b/JIRA/jira_modules/action_base.py
@@ -54,7 +54,7 @@ class JIRAAction(Action):
 
         return result
 
-    def post_paginated_results(self, path: str, result_field: str, payload: dict | None = None) -> list:
+    def post_paginated_results(self, path: str, result_field: str, payload: dict | None = None) -> dict:
         # pagination with next token
         if payload is None:
             payload = {}
@@ -65,11 +65,11 @@ class JIRAAction(Action):
         response = self.post_json(path, json=payload)
         is_last = response.get("isLast") if type(response) == dict else False
         if is_last:
-            return response.get(result_field) if result_field else response
+            return {result_field: response.get(result_field)}
 
         result = []
         while True:
-            items = response.get(result_field) if result_field else response
+            items = response.get(result_field, [])
 
             if len(items) == 0:
                 break
@@ -84,7 +84,7 @@ class JIRAAction(Action):
 
             response = self.post_json(path=path, json=payload)
 
-        return result
+        return {result_field: result}
 
     def _handle_response_error(self, response: requests.Response):
         if not response.ok:

--- a/JIRA/jira_modules/action_search_issues.py
+++ b/JIRA/jira_modules/action_search_issues.py
@@ -30,7 +30,7 @@ class JIRASearchIssues(JIRAAction):
     description = "Find issues using provided filters"
     module: JIRAModule
 
-    def run(self, arguments: JIRASearchIssuesArguments) -> list[Any]:
+    def run(self, arguments: JIRASearchIssuesArguments) -> dict:
         return self.post_paginated_results(
             path="search/jql",
             result_field="issues",

--- a/JIRA/manifest.json
+++ b/JIRA/manifest.json
@@ -2,7 +2,7 @@
   "uuid": "d1445e5e-8e3b-417f-ae19-bca67a10affd",
   "name": "Atlassian JIRA",
   "slug": "atlassian-jira",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Atlassian JIRA is a popular project management and issue-tracking software designed to help teams plan, track, and manage agile software development projects efficiently. It offers customizable workflows and integrates seamlessly with other Atlassian products.",
   "configuration": {
     "title": "JIRA",


### PR DESCRIPTION
## Summary by Sourcery

Align JIRA search issue actions with paginated POST response structure and bump the JIRA integration version.

Bug Fixes:
- Standardize post-based paginated JIRA responses to return a dictionary keyed by the result field instead of a bare list.
- Update the search issues action to match the new paginated response structure.

Chores:
- Increment the Atlassian JIRA manifest version to 1.4.1.