### PR TITLE
Fix: Aws Cloudtrail delay (1193)

### DIFF
--- a/AWS/asset_connector/device_assets.py
+++ b/AWS/asset_connector/device_assets.py
@@ -29,6 +29,7 @@ from sekoia_automation.asset_connector.models.ocsf.device import (
 from sekoia_automation.asset_connector.models.ocsf.group import Group
 from sekoia_automation.asset_connector.models.ocsf.organization import Organization
 from sekoia_automation.storage import PersistentJSON
+
 from aws_helpers.base import AWSModule
 
 

--- a/AWS/asset_connector/users_assets.py
+++ b/AWS/asset_connector/users_assets.py
@@ -26,6 +26,7 @@ from sekoia_automation.asset_connector.models.ocsf.user import (
     UserTypeStr,
 )
 from sekoia_automation.storage import PersistentJSON
+
 from aws_helpers.base import AWSModule
 
 

--- a/AWS/aws_helpers/account_validator.py
+++ b/AWS/aws_helpers/account_validator.py
@@ -1,5 +1,6 @@
 import boto3
 from sekoia_automation.account_validator import AccountValidator
+
 from aws_helpers.base import AWSModule
 
 

--- a/AWS/aws_helpers/s3_wrapper.py
+++ b/AWS/aws_helpers/s3_wrapper.py
@@ -11,7 +11,7 @@ from loguru import logger
 from pydantic.v1 import Field
 from sekoia_automation.aio.helpers.aws.client import AwsClient, AwsConfiguration
 
-from aws_helpers.utils import is_gzip_compressed, async_gzip_open, AsyncReader
+from aws_helpers.utils import AsyncReader, async_gzip_open, is_gzip_compressed
 
 
 class S3Configuration(AwsConfiguration):

--- a/AWS/aws_helpers/utils.py
+++ b/AWS/aws_helpers/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import io
 import gzip
 from abc import abstractmethod
 from concurrent.futures import Executor

--- a/AWS/connectors/s3/__init__.py
+++ b/AWS/connectors/s3/__init__.py
@@ -11,7 +11,7 @@ import orjson
 
 from aws_helpers.s3_wrapper import S3Configuration, S3Wrapper
 from aws_helpers.sqs_wrapper import SqsConfiguration, SqsWrapper
-from aws_helpers.utils import normalize_s3_key, AsyncReader
+from aws_helpers.utils import AsyncReader, normalize_s3_key
 from connectors import AbstractAwsConnector, AbstractAwsConnectorConfiguration
 from connectors.metrics import INCOMING_EVENTS
 

--- a/AWS/connectors/s3/logs/base.py
+++ b/AWS/connectors/s3/logs/base.py
@@ -331,7 +331,7 @@ class AwsS3FetcherTrigger(AWSConnector, metaclass=ABCMeta):  # pragma: no cover
         try:
             while True:
                 self.manage_workers()
-                time.sleep(900)
+                # time.sleep(900) TODO: Check if this is necessary
         finally:
             self.log(message=f"Stopping {self.name} Trigger", level="info")
 

--- a/AWS/main.py
+++ b/AWS/main.py
@@ -2,6 +2,9 @@
 
 from sekoia_automation.loguru.config import init_logging
 
+from asset_connector.device_assets import AwsDeviceAssetConnector
+from asset_connector.users_assets import AwsUsersAssetConnector
+from aws_helpers.account_validator import AwsAccountValidator
 from connectors import AwsModule
 from connectors.s3.logs.trigger_cloudtrail_logs import CloudTrailLogsTrigger
 from connectors.s3.logs.trigger_flowlog_records import FlowlogRecordsTrigger
@@ -12,9 +15,6 @@ from connectors.s3.trigger_s3_logs import AwsS3LogsTrigger
 from connectors.s3.trigger_s3_ocsf_parquet import AwsS3OcsfTrigger
 from connectors.s3.trigger_s3_records import AwsS3RecordsTrigger
 from connectors.trigger_sqs_messages import AwsSqsMessagesTrigger
-from asset_connector.device_assets import AwsDeviceAssetConnector
-from asset_connector.users_assets import AwsUsersAssetConnector
-from aws_helpers.account_validator import AwsAccountValidator
 
 if __name__ == "__main__":
     init_logging()

--- a/AWS/tests/asset_connector/test_account_validator.py
+++ b/AWS/tests/asset_connector/test_account_validator.py
@@ -1,7 +1,9 @@
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
+
 from aws_helpers.account_validator import AwsAccountValidator
-from aws_helpers.base import AWSModule, AWSConfiguration
+from aws_helpers.base import AWSConfiguration, AWSModule
 
 
 class TestAwsAccountValidator:

--- a/AWS/tests/asset_connector/test_device_assets.py
+++ b/AWS/tests/asset_connector/test_device_assets.py
@@ -1,27 +1,28 @@
-import pytest
-from unittest import mock
 from datetime import datetime
+from unittest import mock
+
+import pytest
 import pytz
 from botocore.exceptions import ClientError, NoCredentialsError
+from dateutil.parser import isoparse
 from sekoia_automation.asset_connector.models.ocsf.device import (
     Device,
     DeviceOCSFModel,
-    OperatingSystem,
-    OSTypeId,
-    OSTypeStr,
-    DeviceTypeStr,
     DeviceTypeId,
+    DeviceTypeStr,
     NetworkInterface,
     NetworkInterfaceTypeId,
     NetworkInterfaceTypeStr,
+    OperatingSystem,
+    OSTypeId,
+    OSTypeStr,
 )
 from sekoia_automation.asset_connector.models.ocsf.group import Group
 from sekoia_automation.asset_connector.models.ocsf.organization import Organization
 from sekoia_automation.module import Module
-from dateutil.parser import isoparse
 
+from asset_connector.device_assets import AwsDevice, AwsDeviceAssetConnector
 from connectors import AwsModule, AwsModuleConfiguration
-from asset_connector.device_assets import AwsDeviceAssetConnector, AwsDevice
 
 
 @pytest.fixture

--- a/AWS/tests/asset_connector/test_users_assets.py
+++ b/AWS/tests/asset_connector/test_users_assets.py
@@ -1,12 +1,13 @@
-import pytest
 from unittest import mock
+
+import pytest
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+from dateutil.parser import isoparse
 from sekoia_automation.asset_connector.models.ocsf.user import UserOCSFModel
 from sekoia_automation.module import Module
-from dateutil.parser import isoparse
-from botocore.exceptions import NoCredentialsError, ClientError, BotoCoreError
 
+from asset_connector.users_assets import AwsUser, AwsUsersAssetConnector
 from connectors import AwsModule, AwsModuleConfiguration
-from asset_connector.users_assets import AwsUsersAssetConnector, AwsUser
 
 
 @pytest.fixture
@@ -199,8 +200,9 @@ def test_update_checkpoint_integration(test_aws_users_asset_connector):
 # Test AwsUser class
 def test_aws_user_initialization():
     """Test AwsUser class initialization."""
-    from sekoia_automation.asset_connector.models.ocsf.user import User, Account, AccountTypeStr, AccountTypeId
     from datetime import datetime
+
+    from sekoia_automation.asset_connector.models.ocsf.user import Account, AccountTypeId, AccountTypeStr, User
 
     # Create a test user
     account = Account(

--- a/AWS/tests/connectors/s3/test_abstract_aws_s3_queued_connector.py
+++ b/AWS/tests/connectors/s3/test_abstract_aws_s3_queued_connector.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import BinaryIO
 from unittest.mock import AsyncMock, MagicMock
 
-import io
 import orjson
 import pytest
 from faker import Faker


### PR DESCRIPTION
Relates to [1193](https://github.com/SekoiaLab/integration/issues/1193)

## Summary by Sourcery

Adjust S3 log forwarding to be rate-aware by tracking and returning the number of forwarded CloudTrail records per run and sleeping only when no records are processed.

Bug Fixes:
- Prevent unnecessary polling delays for AWS CloudTrail logs by skipping the frequency sleep when records were forwarded in the current cycle.

Enhancements:
- Optimize event chunking by using a simple counter to decide when to emit chunks instead of relying on len() calls.
- Extend the S3 logs worker to return the total number of processed records, enabling more controlled scheduling behavior.

Tests:
- Update CloudTrail logs worker tests to assert the total number of forwarded events and align expectations with the new return value.

Chores:
- Clean up and reorder imports in various AWS modules and tests, and remove unused asset connector imports from the main entrypoint.