### PR TITLE
fix/thehiveV5/issue_with_user_name_observable

### DIFF
--- a/TheHiveV5/CHANGELOG.md
+++ b/TheHiveV5/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-12-18 - 1.0.7
+
+### Fixed
+
+- Fixed "user.name" issue when not mapped to thehive hostname
+
 ## 2025-12-17 - 1.0.6
 
 ### Fixed

--- a/TheHiveV5/manifest.json
+++ b/TheHiveV5/manifest.json
@@ -36,7 +36,7 @@
   "name": "The Hive V5",
   "uuid": "d6c96586-707c-451f-b9f6-d31b3291f87d",
   "slug": "thehivev5",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "categories": [
     "Collaboration Tools"
   ]

--- a/TheHiveV5/thehive/thehiveconnector.py
+++ b/TheHiveV5/thehive/thehiveconnector.py
@@ -86,8 +86,6 @@ SEKOIA_FIELDS = [
     "url.full",
     "url.original",
     "user_agent.original",
-    # suggestions:
-    "file.path",
     "user.name",
 ]
 
@@ -128,6 +126,7 @@ SEKOIA_TO_THEHIVE = {
     "user_agent.original": "user-agent",
     "host.hostname": "hostname",
     "host.name": "hostname",
+    "user.name": "hostname",
     "source.ip": "ip",
     "destination.ip": "ip",
     "destination.nat.ip": "ip",


### PR DESCRIPTION
## Summary by Sourcery

Fix handling of TheHive V5 user name observables and bump the integration version.

Bug Fixes:
- Ensure TheHive V5 "user.name" observables are correctly mapped when not previously associated with the host name.

Documentation:
- Document the fix for the "user.name" observable mapping issue in the changelog.