### PR TITLE
O365 : Update changelog

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-12-19 - 2.19.1
+
+### Changed
+
+- Skip expired events using their `ExpirationTime` field
+
+
 ## 2025-12-01 - 2.19.0
 
 ### Changed

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "categories": [
     "Email"
   ]


### PR DESCRIPTION
Related PR : [PR](https://github.com/SEKOIA-IO/automation-library/pull/1724)

## Summary by Sourcery

Document the new 2.19.1 Office365 connector release that skips expired events and bump the connector version accordingly.

Build:
- Bump Office365 connector manifest version from 2.19.0 to 2.19.1.

Documentation:
- Add changelog entry for Office365 2.19.1 describing skipping of expired events.