### PR TITLE
TheHiveV5: upstream to production branch

### DIFF
--- a/TheHiveV5/CHANGELOG.md
+++ b/TheHiveV5/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-12-22 - 1.0.9
+
+### Fixed
+
+- Fix action identifiers in the metadata file
+
 ## 2025-12-19 - 1.0.8
 
 ### Fixed

--- a/TheHiveV5/action_add_comment.json
+++ b/TheHiveV5/action_add_comment.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "f936765f-4b37-46c8-9801-701fc11385ea",
+  "uuid": "006931ed-34d7-4959-a6ee-92d83f17b501",
   "name": "Add a comment in The Hive v5",
   "description": "Action to add a comment in The Hive v5",
   "docker_parameters": "thehive_add_comment",

--- a/TheHiveV5/action_add_observable.json
+++ b/TheHiveV5/action_add_observable.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "3b3ab2df-8b4f-49ce-ae69-560722b1b14a",
+  "uuid": "5d651e49-b0b8-44c8-aaef-8f02cb833a82",
   "name": "Add observables in The Hive v5",
   "description": "Action to add a list of observables in The Hive v5",
   "docker_parameters": "thehive_add_observable",

--- a/TheHiveV5/action_upload_logs.json
+++ b/TheHiveV5/action_upload_logs.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "42724f7a-36d1-4265-8a29-e209090dbfa3",
+  "uuid": "4b5db174-6e63-4ba9-89c6-d7ffe6df89f4",
   "name": "Upload logs to an alert in The Hive v5",
   "description": "",
   "docker_parameters": "thehive_upload_logs",

--- a/TheHiveV5/manifest.json
+++ b/TheHiveV5/manifest.json
@@ -36,7 +36,7 @@
   "name": "The Hive V5",
   "uuid": "d6c96586-707c-451f-b9f6-d31b3291f87d",
   "slug": "thehivev5",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "categories": [
     "Collaboration Tools"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Update TheHiveV5 integration to version 1.0.9 and document the release.

Bug Fixes:
- Correct action identifiers in TheHiveV5 metadata/actions configuration.

Build:
- Bump TheHiveV5 manifest version from 1.0.8 to 1.0.9.

Documentation:
- Add 1.0.9 release entry to TheHiveV5 changelog describing the fixed action identifiers.