### PR TITLE
update main file

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2025-12-23 - 2.68.21
+
+### Fixed
+
+- Fixed missing import in main
+
 ## 2025-12-23 - 2.68.20
 
 ### Added

--- a/Sekoia.io/main.py
+++ b/Sekoia.io/main.py
@@ -64,6 +64,7 @@ from sekoiaio.operation_center.update_asset import UpdateAsset
 from sekoiaio.triggers.alerts import (
     AlertCommentCreatedTrigger,
     AlertCreatedTrigger,
+    AlertEventsThresholdTrigger,
     AlertStatusChangedTrigger,
     AlertUpdatedTrigger,
     SecurityAlertsTrigger,
@@ -138,6 +139,7 @@ if __name__ == "__main__":
     module.register(AlertUpdatedTrigger, "alert_updated_trigger")
     module.register(AlertStatusChangedTrigger, "alert_status_changed_trigger")
     module.register(AlertCommentCreatedTrigger, "alert_comment_created_trigger")
+    module.register(AlertEventsThresholdTrigger, "alert_events_threshold_trigger")
     module.register(CaseCreatedTrigger, "case_created_trigger")
     module.register(CaseUpdatedTrigger, "case_updated_trigger")
     module.register(CaseAlertsUpdatedTrigger, "case_alerts_updated_trigger")

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.68.20",
+  "version": "2.68.21",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Bump the Sekoia.io integration version and register the new alert events threshold trigger in the main module.

Bug Fixes:
- Document and fix the previously missing registration for the alert events threshold trigger.

Build:
- Update manifest version to 2.68.21 to reflect the new patch release.

Documentation:
- Add a 2.68.21 changelog entry describing the fixed missing import in main.