### PR TITLE
Delinea: fix categorization

### DIFF
--- a/Delinea/CHANGELOG.md
+++ b/Delinea/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-01-07 - 1.0.3
+
+### Fixed
+
+- Fix categorization of the module
+
 ## 2025-12-22 - 1.0.2
 
 ### Fixed

--- a/Delinea/manifest.json
+++ b/Delinea/manifest.json
@@ -29,7 +29,7 @@
   "name": "Delinea",
   "uuid": "04473922-fd88-40d5-a001-c2a859d208d6",
   "slug": "delinea",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "categories": [
     "IAM"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Update the Delinea module release to correctly categorize it and bump the version.

Bug Fixes:
- Correct the Delinea module categorization from Network to IAM.

Build:
- Bump Delinea module version from 1.0.2 to 1.0.3 and record the change in the changelog.