### PR TITLE
Google PubSub - add universe_domain field

### DIFF
--- a/Google/CHANGELOG.md
+++ b/Google/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-01-09 - 1.22.0
+
+### Added
+
+- Added university domain field
+
 ## 2025-08-05 - 1.21.6
 
 ### Changed

--- a/Google/google_module/base.py
+++ b/Google/google_module/base.py
@@ -19,6 +19,10 @@ class GoogleBase(ModuleItem):
         Save the credentials in a file so they can be used by the Google client
         """
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(self.CREDENTIALS_PATH)
+        os.environ["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] = self.module.configuration["credentials"].get(
+            "universe_domain", "googleapis.com"
+        )
+
         with self.CREDENTIALS_PATH.open("w") as fp:
             json.dump(self.module.configuration["credentials"], fp)
 

--- a/Google/manifest.json
+++ b/Google/manifest.json
@@ -19,10 +19,7 @@
           "auth_provider_x509_cert_url",
           "client_x509_cert_url"
         ],
-        "secrets": [
-          "private_key_id",
-          "private_key"
-        ],
+        "secrets": ["private_key_id", "private_key"],
         "properties": {
           "type": {
             "type": "string"
@@ -55,20 +52,20 @@
           "client_x509_cert_url": {
             "type": "string",
             "format": "uri"
+          },
+          "universe_domain": {
+            "type": "string",
+            "default": "googleapis.com"
           }
         }
       }
     },
-    "required": [
-      "credentials"
-    ]
+    "required": ["credentials"]
   },
   "description": "Google Cloud is a suite of cloud computing services that offers infrastructure as a service, platform as a service, and serverless computing. It provides tools for storage, machine learning, data analytics, and app development, leveraging Google's infrastructure.",
   "name": "Google Cloud",
   "uuid": "4f682a9e-9a25-43a5-8a48-cd9bd7fade7e",
   "slug": "google",
-  "version": "1.21.6",
-  "categories": [
-    "Cloud Providers"
-  ]
+  "version": "1.22.0",
+  "categories": ["Cloud Providers"]
 }


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1187

## Summary by Sourcery

Add support for configuring Google Cloud universe domain and expose it to the runtime environment.

New Features:
- Allow specifying a universe_domain field in Google Cloud credentials with a default of googleapis.com.
- Export the configured universe domain via the GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variable.

Enhancements:
- Bump the Google Cloud integration version to 1.22.0 and update its changelog entry accordingly.