### PR TITLE
fix(AlertEventsThresholdTrigger): Fix time threshold triggering on ev…

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-01-20 - 2.68.29
+
+### Fixed
+
+- AlertEventsThresholdTrigger: Fix time-based threshold triggering incorrectly on every notification. The time threshold now correctly waits for the configured `time_window_hours` to elapse before triggering:
+  - Time threshold evaluation is now handled exclusively by the background thread, not on each Kafka notification
+  - First occurrence no longer triggers immediately unless volume threshold is met
+  - Properly tracks reference time (last trigger or first event) to determine when time window elapses
+
+### Changed
+
+- AlertStateManager: `get_alerts_pending_time_check()` now correctly checks if `time_window_hours` has elapsed since last trigger (or first event), instead of just checking if events are "recent"
+
+### Added
+
+- AlertEventsThresholdTrigger: Update tests to reflect new time threshold behavior (time-based triggering via background thread only)
+
 ## 2026-01-16 - 2.68.28
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.68.28",
+  "version": "2.68.29",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
…ery notification

## Summary by Sourcery

Correct time-based alert threshold evaluation to trigger only after the configured time window elapses, while keeping volume-based triggering immediate when event thresholds are met.

Bug Fixes:
- Prevent time-based thresholds from triggering on every Kafka notification by deferring their evaluation to the background thread and enforcing the configured time window.
- Ensure alerts without new events or with failed event count lookups do not trigger erroneously.
- Fix calculation of pending time-based alerts so only alerts with pending events and an elapsed time window are considered, skipping invalid or incomplete timestamps.

Enhancements:
- Refine first-occurrence behavior so alerts only trigger immediately when the volume threshold is met, recording state for time-based triggering otherwise.
- Improve state manager time-window logic to use last trigger time, creation time, or last event time as appropriate when determining readiness for time-based triggering.
- Expand and adjust tests for AlertEventsThresholdTrigger and AlertStateManager to cover new volume and time threshold interactions and race-condition scenarios more accurately.

Documentation:
- Document the corrected AlertEventsThresholdTrigger time-window behavior and state-manager time check semantics in the changelog.

Tests:
- Update and extend unit tests for alert threshold evaluation, Kafka notification handling, time-window logic, and batch notification scenarios to validate the new triggering behavior.

Chores:
- Bump integration manifest version from 2.68.28 to 2.68.29.