### PR TITLE
HTTP: return relative path for downloaded file

### DIFF
--- a/HTTP/CHANGELOG.md
+++ b/HTTP/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-01-22 - 1.120.1
+
+### Changed
+
+- Return relative path for downloaded file
+
 ## 2026-01-13 - 1.120.0
 
 ### Added

--- a/HTTP/http_module/download_file_action.py
+++ b/HTTP/http_module/download_file_action.py
@@ -56,14 +56,15 @@ class DownloadFileAction(Action):
         Save the requests's response in a file.
         """
         filename = self._get_file_name(response)
-        file_path = self._data_path / str(uuid4()) / filename
+        file_path = self.data_path / str(uuid4()) / filename
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
         with file_path.open("wb") as f:
             response.raw.decode_content = True  # Force decoding content
             f.write(response.raw.read())
 
-        return {"file_path": str(file_path)}
+        result_path = file_path.relative_to(self.data_path)
+        return {"file_path": str(result_path)}
 
     @staticmethod
     def _get_file_name(response: Response) -> str:

--- a/HTTP/manifest.json
+++ b/HTTP/manifest.json
@@ -9,7 +9,7 @@
   "name": "HTTP",
   "uuid": "5894985f-91eb-46db-9306-cc5ac6463d3d",
   "slug": "http",
-  "version": "1.120.0",
+  "version": "1.120.1",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Return a relative path for downloaded HTTP files and bump the module version.

Bug Fixes:
- Adjust the download file action to return a path relative to the data directory instead of an absolute path.

Documentation:
- Add changelog entry documenting the change to return a relative path for downloaded files.