### PR TITLE
Ubika - setup auth retries

### DIFF
--- a/Ubika/CHANGELOG.md
+++ b/Ubika/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-01-30 - 1.0.6
+
+### Changed
+
+- Update token sooner (60s instead of 30s)
+- Use retries for authentication timeout
+
 ## 2026-01-07 - 1.0.5
 
 ### Changed

--- a/Ubika/manifest.json
+++ b/Ubika/manifest.json
@@ -11,7 +11,7 @@
   "name": "Ubika",
   "uuid": "0c82ee9b-f645-47f9-8e16-a689cfc246c4",
   "slug": "ubika",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "categories": [
     "Network"
   ]

--- a/Ubika/tests/test_ubika_cloud_protector_alerts.py
+++ b/Ubika/tests/test_ubika_cloud_protector_alerts.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
 import httpx
+import pytest
 from respx import MockRouter
 
 from ubika_modules import UbikaModule

--- a/Ubika/tests/test_ubika_cloud_protector_traffic.py
+++ b/Ubika/tests/test_ubika_cloud_protector_traffic.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
 import httpx
+import pytest
 from respx import MockRouter
 from sekoia_automation.storage import PersistentJSON
 

--- a/Ubika/ubika_modules/client/auth.py
+++ b/Ubika/ubika_modules/client/auth.py
@@ -29,11 +29,7 @@ class UbikaCloudProtectorNextGenCredentials:
 
 
 class UbikaCloudProtectorNextGenAuthentication(Auth):
-    def __init__(
-        self,
-        refresh_token: str,
-        ratelimit_per_minute: int = 20,
-    ) -> None:
+    def __init__(self, refresh_token: str, transport: httpx.BaseTransport) -> None:
         self.__authorization_url = "https://login.ubika.io/auth/realms/main/protocol/openid-connect/token"
         self.__refresh_token = refresh_token
         self.__api_credentials: UbikaCloudProtectorNextGenCredentials | None = None
@@ -41,16 +37,14 @@ class UbikaCloudProtectorNextGenAuthentication(Auth):
         # Configure HTTPX client with rate limiting and http2 support
         self.__http_client = httpx.Client(
             http2=True,
-            transport=LimiterTransport(
-                per_minute=ratelimit_per_minute,
-            ),
+            transport=transport,
             timeout=300.0,
         )
 
     def get_credentials(self) -> UbikaCloudProtectorNextGenCredentials:
         current_dt = datetime.utcnow()
 
-        if self.__api_credentials is None or current_dt + timedelta(seconds=30) >= self.__api_credentials.expires_at:
+        if self.__api_credentials is None or current_dt + timedelta(seconds=60) >= self.__api_credentials.expires_at:
             response: Response | None = None
             try:
                 response = self.__http_client.post(
@@ -64,12 +58,13 @@ class UbikaCloudProtectorNextGenAuthentication(Auth):
                         "Content-Type": "application/x-www-form-urlencoded",
                     },
                 )
-
                 response.raise_for_status()
+
             except httpx.TimeoutException as timeout_exc:
                 raise AuthorizationError(
                     "timeout_error", "The request to obtain a new access token timed out."
                 ) from timeout_exc
+
             except httpx.HTTPStatusError as e:
                 if response is None:
                     raise AuthorizationError(
@@ -77,6 +72,7 @@ class UbikaCloudProtectorNextGenAuthentication(Auth):
                     ) from e
                 raw = response.json()
                 raise AuthorizationError(raw["error"], raw["error_description"]) from e
+
             except httpx.RequestError as e:
                 raise AuthorizationError(
                     "request_error", f"An error occurred while requesting a new access token : {e}"

--- a/Ubika/ubika_modules/client/retry.py
+++ b/Ubika/ubika_modules/client/retry.py
@@ -4,15 +4,14 @@ import httpx
 from tenacity import (
     Retrying,
     TryAgain,
-    wait_random,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
+    wait_random,
 )
 
 
 class ExponentialBackoffTransport(httpx.BaseTransport):
-
     def __init__(
         self,
         transport: httpx.BaseTransport,

--- a/Ubika/ubika_modules/connector_ubika_cloud_protector_base.py
+++ b/Ubika/ubika_modules/connector_ubika_cloud_protector_base.py
@@ -6,8 +6,8 @@ from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from threading import Event
 
-import orjson
 import httpx
+import orjson
 from dateutil.parser import isoparse
 from pydantic.v1 import Field
 from sekoia_automation.connector import Connector, DefaultConnectorConfiguration

--- a/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen.py
+++ b/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen.py
@@ -3,8 +3,8 @@ from collections.abc import Generator
 from datetime import timedelta
 from functools import cached_property
 
-import orjson
 import httpx
+import orjson
 from cachetools import Cache, LRUCache
 from pydantic.v1 import Field
 from sekoia_automation.checkpoint import CheckpointTimestamp, TimeUnit


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1292

## Summary by Sourcery

Add retry support and adjusted token refresh timing for Ubika Cloud Protector Next Gen authentication, wiring the auth client through the shared retrying transport and updating version metadata.

Bug Fixes:
- Ensure authentication HTTP and timeout errors are retried via the shared exponential backoff transport instead of bypassing retries.

Enhancements:
- Refresh access tokens earlier by increasing the pre-expiry buffer from 30 to 60 seconds.
- Refactor Ubika authentication to accept an injected HTTP transport, aligning it with the client’s retry and rate-limiting stack.

Documentation:
- Document authentication behavior changes and earlier token refresh in the changelog.

Tests:
- Expand authentication tests to cover non-retriable HTTP errors, retriable HTTP errors with multiple attempts, and timeout retries for token acquisition.

Chores:
- Bump Ubika integration version to 1.0.6 in the manifest.