### PR TITLE
fix(AWS): update pydantic model

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix seperator parameter issue
+- Fix separator parameter issue
 
 ## 2026-01-29 - 1.33.11
 

--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-02-05 - 1.33.12
+
+### Fixed
+
+- Fix seperator parameter issue
+
 ## 2026-01-29 - 1.33.11
 
 ### Changed

--- a/AWS/connectors/s3/trigger_s3_cloudfront.py
+++ b/AWS/connectors/s3/trigger_s3_cloudfront.py
@@ -17,7 +17,7 @@ class AwsS3CloudFrontConfiguration(AwsS3QueuedConfiguration):
     """AwsS3CloudFrontTrigger configuration."""
 
     skip_first: int = 0
-    separator: str
+    separator: str = "\n"
 
 
 class AwsS3CloudFrontTrigger(AbstractAwsS3QueuedConnector):

--- a/AWS/connectors/s3/trigger_s3_flowlogs.py
+++ b/AWS/connectors/s3/trigger_s3_flowlogs.py
@@ -14,7 +14,7 @@ class AwsS3FlowLogsConfiguration(AwsS3QueuedConfiguration):
 
     ignore_comments: bool = False
     skip_first: int = 0
-    separator: str
+    separator: str = "\n"
 
 
 class AwsS3FlowLogsTrigger(AbstractAwsS3QueuedConnector):

--- a/AWS/connectors/s3/trigger_s3_logs.py
+++ b/AWS/connectors/s3/trigger_s3_logs.py
@@ -12,7 +12,7 @@ class AwsS3LogsConfiguration(AwsS3QueuedConfiguration):
 
     ignore_comments: bool = False
     skip_first: int = 0
-    separator: str
+    separator: str = "\n"
 
 
 class AwsS3LogsTrigger(AbstractAwsS3QueuedConnector):

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -29,7 +29,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.33.11",
+  "version": "1.33.12",
   "categories": [
     "Cloud Providers"
   ],


### PR DESCRIPTION
## Summary by Sourcery

Update AWS connector configuration defaults and bump package version.

Bug Fixes:
- Set a default newline separator for AwsS3LogsConfiguration to resolve missing separator issues.

Documentation:
- Add changelog entry for version 1.33.12 describing the separator parameter fix.

Chores:
- Bump AWS manifest version from 1.33.11 to 1.33.12.