### PR TITLE
Hotfix: Update Salesforce Encode Params

### DIFF
--- a/Salesforce/CHANGELOG.md
+++ b/Salesforce/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-02-06 - 1.8.1
+
+### Fixed
+
+- Update encode params
+
 ## 2026-02-02 - 1.8.0
 
 ### Added

--- a/Salesforce/client/http_client.py
+++ b/Salesforce/client/http_client.py
@@ -195,7 +195,7 @@ class SalesforceHttpClient(object):
         }
 
         return URL("{0}/services/data/v58.0/query".format(self.base_url)).with_query(
-            urlencode(params, safe=">+,'=:", encoding="utf-8")
+            urlencode(params, safe=">+,'=:<", encoding="utf-8")
         )
 
     async def _request_headers(self) -> Dict[str, str]:

--- a/Salesforce/manifest.json
+++ b/Salesforce/manifest.json
@@ -39,7 +39,7 @@
   "name": "Salesforce",
   "uuid": "f811e134-2548-11ee-be56-0242ac120002",
   "slug": "salesforce",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "categories": [
     "Applicative"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Update Salesforce HTTP client query parameter encoding and bump connector version.

Bug Fixes:
- Adjust Salesforce query URL parameter encoding to allow '<' characters without percent-encoding.

Build:
- Bump Salesforce connector version to 1.8.1 in the manifest.

Documentation:
- Add 1.8.1 release entry to the Salesforce changelog describing the encode params fix.