### PR TITLE
Azure: add the ability to set log level for any loggers in the EventHub connector

### DIFF
--- a/Azure/CHANGELOG.md
+++ b/Azure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-02-13 - 2.9.3
+
+### Added
+
+- Add the ability to set log level for any loggers in the Azure EventHub connector
+
 ## 2025-12-10 - 2.9.2
 
 ### Fixed

--- a/Azure/connectors/azure_eventhub.py
+++ b/Azure/connectors/azure_eventhub.py
@@ -14,7 +14,11 @@ from azure.storage.blob.aio import BlobServiceClient
 from sekoia_automation.aio.connector import AsyncConnector
 from sekoia_automation.connector import Connector, DefaultConnectorConfiguration
 
+from .logging import set_log_level_from_env
 from .metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, INCOMING_MESSAGES, MESSAGES_AGE, OUTCOMING_EVENTS
+
+# Initialize log level from environment variables
+set_log_level_from_env()
 
 
 class AzureEventsHubConfiguration(DefaultConnectorConfiguration):

--- a/Azure/connectors/logging.py
+++ b/Azure/connectors/logging.py
@@ -1,0 +1,38 @@
+import logging
+import os
+
+
+def set_log_level(loggers: set[str], log_level: int) -> None:
+    """
+    Set the log level for the specified loggers.
+
+    :param loggers: A set of logger names to set the log level for.
+    :param log_level: The log level to set for the specified loggers.
+    """
+    for logger in loggers:
+        logging.getLogger(logger.strip()).setLevel(log_level)
+
+
+def set_log_level_from_env() -> None:
+    """
+    Set the log level for the specified loggers based on the AZURE_LOG_LEVEL and AZURE_LOGGERS environment variables.
+
+    AZURE_LOG_LEVEL should be set to the desired log level (e.g., 10 for DEBUG, 20 for INFO, etc.).
+    AZURE_LOGGERS should be a comma-separated list of logger names to set the log level for. If AZURE_LOGGERS is not set, the log level will be set for all loggers.
+    """
+    # If AZURE_LOG_LEVEL is not set, do not change the log level for any loggers.
+    if os.environ.get("AZURE_LOG_LEVEL") is None:
+        return
+
+    loggers = None
+
+    # If AZURE_LOGGERS is set, use the specified loggers. Otherwise, use all loggers.
+    if os.environ.get("AZURE_LOGGERS") is not None:
+        loggers = set(os.environ.get("AZURE_LOGGERS").split(","))
+
+    # If AZURE_LOGGERS is not set, use all loggers.
+    if loggers is None:
+        loggers = set(logging.root.manager.loggerDict.keys())
+
+    # Set the log level for the specified loggers.
+    set_log_level(loggers, int(os.environ.get("AZURE_LOG_LEVEL")))

--- a/Azure/connectors/logging.py
+++ b/Azure/connectors/logging.py
@@ -28,11 +28,11 @@ def set_log_level_from_env() -> None:
 
     # If AZURE_LOGGERS is set, use the specified loggers. Otherwise, use all loggers.
     if os.environ.get("AZURE_LOGGERS") is not None:
-        loggers = set(os.environ.get("AZURE_LOGGERS").split(","))
+        loggers = set(os.environ["AZURE_LOGGERS"].split(","))
 
     # If AZURE_LOGGERS is not set, use all loggers.
     if loggers is None:
         loggers = set(logging.root.manager.loggerDict.keys())
 
     # Set the log level for the specified loggers.
-    set_log_level(loggers, int(os.environ.get("AZURE_LOG_LEVEL")))
+    set_log_level(loggers, int(os.environ["AZURE_LOG_LEVEL"]))

--- a/Azure/manifest.json
+++ b/Azure/manifest.json
@@ -8,8 +8,6 @@
   "name": "Microsoft Azure",
   "uuid": "525eecc0-9eee-484d-92bd-039117cf4dac",
   "slug": "azure",
-  "version": "2.9.2",
-  "categories": [
-    "Cloud Providers"
-  ]
+  "version": "2.9.3",
+  "categories": ["Cloud Providers"]
 }


### PR DESCRIPTION
Add the ability to set log level for any loggers in the Azure EventHub connector with some environment variables.

## Summary by Sourcery

Allow configuring Azure EventHub connector logging levels via environment variables and bump the Azure integration version.

New Features:
- Support configuring log levels for selected or all loggers in the Azure EventHub connector using environment variables.

Enhancements:
- Introduce a shared logging helper to apply log levels from environment variables across specified loggers.

Build:
- Bump the Azure integration manifest version to 2.9.3.

Documentation:
- Document the new logging configuration capability in the Azure changelog.