### PR TITLE
Prodaft: fix identifiers

### DIFF
--- a/USTA/CHANGELOG.md
+++ b/USTA/CHANGELOG.md
@@ -3,10 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## Unreleased
 
+## 2026-02-18 - 1.0.1
+
+### Fixed
+
+- Fix identifiers
+
 ## 2025-12-12 - 1.0.0
+
 ### Added 
+
 - `UstaAtpConnector` added to fetch account takeover prevention events from USTA platform. 
+
 ### Changed
+
 - Refactor the module

--- a/USTA/connector_ustaatpconnector.json
+++ b/USTA/connector_ustaatpconnector.json
@@ -1,7 +1,7 @@
 {
   "name": "UstaAtpConnector",
   "description": "UstaAtpConnector",
-  "uuid": "122f2747-b303-531a-84b8-a2a5d9502c36",
+  "uuid": "3299e7bc-3ff1-4b2b-a021-d97c8b802d7a",
   "docker_parameters": "UstaAtpConnector",
   "arguments": {
     "title": "UstaATPConnectorConfiguration",

--- a/USTA/manifest.json
+++ b/USTA/manifest.json
@@ -21,5 +21,5 @@
     "Threat Intelligence"
   ],
   "uuid": "46ff3d14-82d0-4cb4-98dd-8d6b9a932c9d",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/USTA/manifest.json
+++ b/USTA/manifest.json
@@ -20,6 +20,6 @@
   "categories": [
     "Threat Intelligence"
   ],
-  "uuid": "85b0e92e-14b3-4d61-a259-829e82e736a7",
+  "uuid": "46ff3d14-82d0-4cb4-98dd-8d6b9a932c9d",
   "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary by Sourcery

Release patch version 1.0.1 for the USTA connector with corrected identifiers and updated metadata.

Bug Fixes:
- Correct identifiers used by the USTA connector.

Build:
- Bump USTA connector manifest version to 1.0.1 and update its UUID in the manifest.

Documentation:
- Update CHANGELOG with a 1.0.1 release entry describing the identifier fix.