### PR TITLE
CI: add the develop branch in the GitHub workflows

### DIFF
--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - develop
   workflow_dispatch:
 
 env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,9 +4,9 @@ name: Check Automation Modules
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/generate-modules-list.yml
+++ b/.github/workflows/generate-modules-list.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 jobs:
   generate-modules-list:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Extend checks, build, and module list generation workflows to trigger on pushes and pull requests targeting the develop branch.