### PR TITLE
Fix/okta asset connector

### DIFF
--- a/Okta/CHANGELOG.md
+++ b/Okta/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-02-18 - 2.8.15
+
+### Fixed
+
+- Fix async implementation of update_checkpoint method in asset connectors
+
 ## 2026-02-11 - 2.8.14
 
 ### Added

--- a/Okta/manifest.json
+++ b/Okta/manifest.json
@@ -26,7 +26,7 @@
   "name": "Okta",
   "uuid": "4ef895d1-3f21-4678-8d0a-5c39c37210fe",
   "slug": "okta",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "categories": [
     "IAM"
   ],

--- a/Okta/okta_modules/asset_connector/device_assets.py
+++ b/Okta/okta_modules/asset_connector/device_assets.py
@@ -101,7 +101,7 @@ class OktaDeviceAssetConnector(AsyncAssetConnector):
 
         return result
 
-    def update_checkpoint(self) -> None:
+    async def update_checkpoint(self) -> None:
         """Update the checkpoint with the most recent date seen.
 
         Raises:

--- a/Okta/okta_modules/asset_connector/user_assets.py
+++ b/Okta/okta_modules/asset_connector/user_assets.py
@@ -63,7 +63,7 @@ class OktaUserAssetConnector(AsyncAssetConnector):
 
         return result
 
-    def update_checkpoint(self) -> None:
+    async def update_checkpoint(self) -> None:
         """Update the checkpoint with the most recent date seen.
 
         Raises:

--- a/Okta/tests/asset_connector/test_user_assets.py
+++ b/Okta/tests/asset_connector/test_user_assets.py
@@ -438,7 +438,8 @@ class TestOktaUserAssetConnector:
         # Verify
         assert result is None
 
-    def test_update_checkpoint_success(self, mock_connector):
+    @pytest.mark.asyncio
+    async def test_update_checkpoint_success(self, mock_connector):
         """Test successful checkpoint update."""
         # Setup
         mock_connector.new_most_recent_date = "2023-01-01T00:00:00.000Z"
@@ -446,26 +447,28 @@ class TestOktaUserAssetConnector:
         mock_connector.context.__enter__.return_value = mock_cache
 
         # Execute
-        mock_connector.update_checkpoint()
+        await mock_connector.update_checkpoint()
 
         # Verify
         assert mock_cache["most_recent_date_seen"] == "2023-01-01T00:00:00.000Z"
         mock_connector.log.assert_called_with("Checkpoint updated with date: 2023-01-01T00:00:00.000Z", level="info")
 
-    def test_update_checkpoint_none_date(self, mock_connector):
+    @pytest.mark.asyncio
+    async def test_update_checkpoint_none_date(self, mock_connector):
         """Test checkpoint update when new_most_recent_date is None."""
         # Setup
         mock_connector.new_most_recent_date = None
 
         # Execute
-        mock_connector.update_checkpoint()
+        await mock_connector.update_checkpoint()
 
         # Verify
         mock_connector.log.assert_called_with(
             "Warning: new_most_recent_date is None, skipping checkpoint update", level="warning"
         )
 
-    def test_update_checkpoint_error(self, mock_connector):
+    @pytest.mark.asyncio
+    async def test_update_checkpoint_error(self, mock_connector):
         """Test checkpoint update with error."""
         # Setup
         mock_connector.new_most_recent_date = "2023-01-01T00:00:00.000Z"
@@ -474,7 +477,7 @@ class TestOktaUserAssetConnector:
         mock_connector.log_exception = MagicMock()  # Mock log_exception method
 
         # Execute
-        mock_connector.update_checkpoint()
+        await mock_connector.update_checkpoint()
 
         # Verify
         # Check that log was called with the error message


### PR DESCRIPTION
## Summary by Sourcery

Update Okta asset connectors to correct the async checkpoint update implementation and bump the integration version.

Bug Fixes:
- Fix the async implementation of the update_checkpoint method in device and user asset connectors.

Build:
- Bump Okta integration manifest version from 2.8.14 to 2.8.15.

Documentation:
- Add changelog entry for version 2.8.15 describing the checkpoint update fix.