### PR TITLE
CI: Update build-module workflow

### DIFF
--- a/.github/actions/test-with-poetry/action.yaml
+++ b/.github/actions/test-with-poetry/action.yaml
@@ -1,0 +1,40 @@
+name: Test with poetry
+description: Test an automation module with Poetry project manager
+
+inputs:
+  module:
+    description: "The module to test"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Poetry
+      run: |
+        pip install poetry
+        poetry config virtualenvs.in-project true
+
+    - name: Install Dependencies
+      id: install-dependencies
+      run: |
+        poetry install
+      working-directory: ${{ inputs.module }}
+
+    - name: Execute Black
+      uses: psf/black@stable
+      with:
+        options: "--check --verbose"
+        src: ./"${{ inputs.module }}"
+
+    - name: Execute Mypy
+      run: |
+        poetry run pip install mypy
+        mkdir -p .mypy_cache
+        poetry run mypy  --install-types --non-interactive --ignore-missing-imports --show-column-numbers --hide-error-context .
+      working-directory: "${{ inputs.module }}"
+
+    - name: Execute Python tests
+      id: execute-tests
+      run: |
+        poetry run python -m pytest --junit-xml=junit.xml --cov-report term --cov-report xml:coverage.xml --cov . --cov-config pyproject.toml
+      working-directory: "${{ inputs.module }}"

--- a/.github/actions/test-with-poetry/action.yaml
+++ b/.github/actions/test-with-poetry/action.yaml
@@ -10,12 +10,14 @@ runs:
   using: "composite"
   steps:
     - name: Install Poetry
+      shell: bash
       run: |
         pip install poetry
         poetry config virtualenvs.in-project true
 
     - name: Install Dependencies
       id: install-dependencies
+      shell: bash
       run: |
         poetry install
       working-directory: ${{ inputs.module }}
@@ -27,6 +29,7 @@ runs:
         src: ./"${{ inputs.module }}"
 
     - name: Execute Mypy
+      shell: bash
       run: |
         poetry run pip install mypy
         mkdir -p .mypy_cache
@@ -35,6 +38,7 @@ runs:
 
     - name: Execute Python tests
       id: execute-tests
+      shell: bash
       run: |
         poetry run python -m pytest --junit-xml=junit.xml --cov-report term --cov-report xml:coverage.xml --cov . --cov-config pyproject.toml
       working-directory: "${{ inputs.module }}"

--- a/.github/actions/test-with-uv/action.yaml
+++ b/.github/actions/test-with-uv/action.yaml
@@ -1,0 +1,44 @@
+name: Test with uv
+description: Test an automation module with uv project manager
+
+inputs:
+  module:
+    description: "The module to test"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        activate-environment: true
+
+    - name: Install Dependencies
+      id: install-dependencies
+      shell: bash
+      run: |
+        uv sync
+      working-directory: ${{ inputs.module }}
+
+    - name: Execute Black
+      uses: psf/black@stable
+      with:
+        options: "--check --verbose"
+        src: ./"${{ inputs.module }}"
+
+    - name: Execute Mypy
+      shell: bash
+      run: |
+        uv pip install mypy
+        mkdir -p .mypy_cache
+        uv run mypy --install-types --non-interactive --ignore-missing-imports --show-column-numbers --hide-error-context .
+      working-directory: ${{ inputs.module }}
+
+    - name: Execute Python tests
+      id: execute-tests
+      shell: bash
+      run: |
+        uv run pytest --junit-xml=junit.xml --cov-report term --cov-report xml:coverage.xml --cov . --cov-config pyproject.toml
+      working-directory: ${{ inputs.module }}

--- a/.github/actions/test-with-uv/action.yaml
+++ b/.github/actions/test-with-uv/action.yaml
@@ -19,7 +19,7 @@ runs:
       id: install-dependencies
       shell: bash
       run: |
-        uv sync
+        uv sync --frozen
       working-directory: ${{ inputs.module }}
 
     - name: Execute Black

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -59,37 +59,12 @@ jobs:
         uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
-      - name: Install Poetry
-        run: |
-          pip install poetry
-          poetry config virtualenvs.in-project true
-
-      - name: Install Dependencies
-        id: install-dependencies
-        run: |
-          poetry install
-        working-directory: ${{ matrix.module }}
-
-      - name: Execute Black
-        uses: psf/black@stable
+      - name: Test with Poetry
+        uses: ./.github/actions/test-with-poetry
         with:
-          options: "--check --verbose"
-          src: ./"${{ matrix.module }}"
-
-      - name: Execute Mypy
-        run: |
-          poetry run pip install mypy
-          mkdir -p .mypy_cache
-          poetry run mypy  --install-types --non-interactive --ignore-missing-imports --show-column-numbers --hide-error-context .
-        working-directory: "${{ matrix.module }}"
-
-      - name: Execute Python tests
-        id: execute-tests
-        run: |
-          poetry run python -m pytest --junit-xml=junit.xml --cov-report term --cov-report xml:coverage.xml --cov . --cov-config pyproject.toml
-        working-directory: "${{ matrix.module }}"
+          module: ${{ matrix.module }}
 
       - name: Upload Event
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -2,7 +2,7 @@ name: Build Modules
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
@@ -15,7 +15,6 @@ env:
   IMAGE_PREFIX_NAME: sekoia-io
 
 jobs:
-
   find-modules:
     name: Find modules in repo
     runs-on: ubuntu-latest
@@ -167,13 +166,13 @@ jobs:
     if: always()
 
     steps:
-    - name: Success
-      if: ${{ !(contains(needs.*.result, 'failure')) || needs.find-modules.outputs.matrix == '[]' }}
-      run: exit 0
-    - name: Failure
-      if: ${{ contains(needs.*.result, 'failure') && needs.find-modules.outputs.matrix != '[]' }}
-      run: |
-        exit 1
+      - name: Success
+        if: ${{ !(contains(needs.*.result, 'failure')) || needs.find-modules.outputs.matrix == '[]' }}
+        run: exit 0
+      - name: Failure
+        if: ${{ contains(needs.*.result, 'failure') && needs.find-modules.outputs.matrix != '[]' }}
+        run: |
+          exit 1
 
   deploy-module:
     name: Deploy modules

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -60,8 +60,28 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Detect package manager
+        id: detect-pm
+        run: |
+          if [ -f "${MODULE_PATH}/uv.lock" ]; then
+            echo "package_manager=uv" >> $GITHUB_OUTPUT
+            echo "Detected uv project"
+          else
+            echo "package_manager=poetry" >> $GITHUB_OUTPUT
+            echo "Defaulting to Poetry"
+          fi
+        env:
+          MODULE_PATH: ${{ matrix.module }}
+
       - name: Test with Poetry
+        if: steps.detect-pm.outputs.package_manager == 'poetry'
         uses: ./.github/actions/test-with-poetry
+        with:
+          module: ${{ matrix.module }}
+
+      - name: Test with uv
+        if: steps.detect-pm.outputs.package_manager == 'uv'
+        uses: ./.github/actions/test-with-uv
         with:
           module: ${{ matrix.module }}
 


### PR DESCRIPTION
Update the build-module workflow:
- Outsource poetry commands inside a dedicated GitHub action
- Create the equivalent one for uv
- Update the workflow to detect the package manager and use the corresponding action.

## Summary by Sourcery

Update the module build workflow to support both Poetry and uv via reusable composite actions for testing modules.

CI:
- Refactor the build-modules workflow to detect the package manager (Poetry or uv) and invoke the appropriate testing action.
- Adjust workflow syntax and job steps formatting for consistency.

Tests:
- Extract module test logic into reusable composite actions for Poetry and uv, including dependency installation, formatting checks, type checks, and pytest runs.