### PR TITLE
Wiz: Add the ability to set the timeout

### DIFF
--- a/Wiz/CHANGELOG.md
+++ b/Wiz/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-02-19 - 1.4.1
+
+### Fixed
+
+- Add the ability to set the timeout on GraphQL queries
+
 ## 2026-02-04 - 1.4.0
 
 ### Added

--- a/Wiz/manifest.json
+++ b/Wiz/manifest.json
@@ -29,7 +29,7 @@
   "name": "Wiz",
   "uuid": "860eaa8b-ecb1-43dc-8a3d-6ec10144e6e9",
   "slug": "wiz",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "categories": [
     "Network"
   ]

--- a/Wiz/wiz/__init__.py
+++ b/Wiz/wiz/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import time
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
@@ -74,10 +75,13 @@ class WizConnector(AsyncConnector, ABC):
         if self._wiz_gql_client is not None:
             return self._wiz_gql_client
 
+        timeout = int(os.environ.get("WIZ_CLIENT_TIMEOUT", 60))
+
         self._wiz_gql_client = WizGqlClient.create(
             client_id=self.module.configuration.client_id,
             client_secret=self.module.configuration.client_secret,
             tenant_url=self.module.configuration.tenant_url,
+            timeout=timeout,
         )
 
         return self._wiz_gql_client

--- a/Wiz/wiz/client/gql_client.py
+++ b/Wiz/wiz/client/gql_client.py
@@ -96,11 +96,11 @@ class WizGqlClient(object):
         self.timeout = timeout or 60  # default to 60s
 
     @classmethod
-    def create(cls, client_id: str, client_secret: str, tenant_url: str) -> "WizGqlClient":
+    def create(cls, client_id: str, client_secret: str, tenant_url: str, timeout: int | None = None) -> "WizGqlClient":
         auth_url = WizTokenRefresher.create_url_from_tenant(tenant_url)
         token_refresher = WizTokenRefresher(client_id, client_secret, auth_url)
 
-        return cls(client_id, client_secret, tenant_url, token_refresher)
+        return cls(client_id, client_secret, tenant_url, token_refresher, timeout)
 
     async def close(self) -> None:
         if self.token_refresher is not None:

--- a/Wiz/wiz/client/gql_client.py
+++ b/Wiz/wiz/client/gql_client.py
@@ -87,11 +87,13 @@ class WizGqlClient(object):
         client_secret: str,
         tenant_url: str,
         token_refresher: WizTokenRefresher,
+        timeout: int | None = None,
     ) -> None:
         self.client_id = client_id
         self.client_secret = client_secret
         self.tenant_url = tenant_url
         self.token_refresher = token_refresher
+        self.timeout = timeout or 60  # default to 60s
 
     @classmethod
     def create(cls, client_id: str, client_secret: str, tenant_url: str) -> "WizGqlClient":
@@ -118,7 +120,7 @@ class WizGqlClient(object):
                     headers={"Authorization": f"Bearer {token.access_token}"},
                 )
 
-                yield Client(transport=transport)
+                yield Client(transport=transport, execute_timeout=self.timeout)
 
     async def request(self, query: str, variable_values: dict[str, str | None] | None = None) -> dict[str, Any]:
         async with self._session() as session:

--- a/Wiz/wiz/client/gql_client.py
+++ b/Wiz/wiz/client/gql_client.py
@@ -93,7 +93,7 @@ class WizGqlClient(object):
         self.client_secret = client_secret
         self.tenant_url = tenant_url
         self.token_refresher = token_refresher
-        self.timeout = timeout or 60  # default to 60s
+        self.timeout = 60 if timeout is None else timeout  # default to 60s, preserve explicit falsy values
 
     @classmethod
     def create(cls, client_id: str, client_secret: str, tenant_url: str, timeout: int | None = None) -> "WizGqlClient":


### PR DESCRIPTION
- Add the ability to set the timeout
- Set the default timeout to 60s

## Summary by Sourcery

Allow configuring a timeout for Wiz GraphQL client requests and set a sensible default.

New Features:
- Support configuring the Wiz GraphQL client timeout via constructor and environment variable.

Bug Fixes:
- Ensure GraphQL queries honor a configurable execution timeout instead of relying on the library default.

Enhancements:
- Set a default GraphQL client timeout of 60 seconds to improve reliability of long-running requests.

Build:
- Bump Wiz integration version to 1.4.1 in the manifest.

Documentation:
- Document the new timeout capability and release in the changelog.