### PR TITLE
Sekoia: Add some tests

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a test to check if we can update asset with a list of tags
+- Add a test to check if we can update an asset with a list of tags
 
 ## 2026-02-10 - 2.69.0
 

--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-02-25 - 2.70.0
+
+### Added
+
+- Add a test to check if we can update asset with a list of tags
+
 ## 2026-02-10 - 2.69.0
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.69.0",
+  "version": "2.70.0",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/tests/operation_center_action/test_update_asset.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_asset.py
@@ -54,7 +54,7 @@ def test_update_asset_with_tags_as_list(requests_mock):
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
     asset_uuid = uuid.uuid4()
     tags_list = ["tag1", "tag2", "tag3"]
-    arguments = {"uuid": str(asset_uuid), "tags": tags_list}
+    arguments = {"uuid": str(asset_uuid), "tags": list(tags_list)}
     response = {
         "uuid": "00000000-0000-0000-0000-000000000123",
         "entity_uuid": "00000000-0000-0000-0000-000000000000",

--- a/Sekoia.io/tests/operation_center_action/test_update_asset.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_asset.py
@@ -47,3 +47,35 @@ def test_update_asset_by_uuid_returns_none_if_http_error(requests_mock):
 
     results: dict = action.run(arguments)
     assert results is None
+
+
+def test_update_asset_with_tags_as_list(requests_mock):
+    action = UpdateAsset()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    asset_uuid = uuid.uuid4()
+    tags_list = ["tag1", "tag2", "tag3"]
+    arguments = {"uuid": str(asset_uuid), "tags": tags_list}
+    response = {
+        "uuid": "00000000-0000-0000-0000-000000000123",
+        "entity_uuid": "00000000-0000-0000-0000-000000000000",
+        "name": "test get asset",
+        "type": "network",
+        "criticality": 10,
+        "atoms": {
+            "cidrv6": [],
+            "cidrv4": ["10.100.100.0/24"],
+        },
+        "props": {
+            "asn": "13336",
+        },
+        "tags": tags_list,
+        "revoked": False,
+        "reviewed": False,
+        "description": "test get asset action",
+        "pending_recommendations": [],
+    }
+    requests_mock.put(base_url + str(asset_uuid), json=response)
+
+    results: dict = action.run(arguments)
+    assert results == response
+    assert requests_mock.last_request.json()["tags"] == tags_list


### PR DESCRIPTION
Related issue : [issue](https://github.com/SekoiaLab/integration/issues/1376)

## Summary by Sourcery

Add coverage to ensure updating an asset supports a list of tags and bump the Sekoia.io integration version.

Build:
- Bump the Sekoia.io integration manifest version to 2.70.0.

Documentation:
- Document the new version and added tag list update test in the changelog.

Tests:
- Add a test verifying that updating an asset accepts tags provided as a list and returns the expected response.