### PR TITLE
Feature: Add Indicator To AddIOCtoIOCCollectionAction (1315, 1314)

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-02-10 - 2.69.1
+
+### Added
+
+- Add optional `indicator` field in `AddIOCtoIOCCollectionAction`
+
 ## 2026-02-10 - 2.69.0
 
 ### Fixed

--- a/Sekoia.io/action_add_ioc_to_ioc_collection.json
+++ b/Sekoia.io/action_add_ioc_to_ioc_collection.json
@@ -2,6 +2,10 @@
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
+      "indicator": {
+        "description": "Single indicator to add to an IOC collection.",
+        "type": "string"
+      },
       "indicators": {
         "description": "List of indicators to add to an IOC collection",
         "type": "array"
@@ -33,6 +37,11 @@
       }
     },
     "oneOf": [
+      {
+        "required": [
+          "indicator"
+        ]
+      },
       {
         "required": [
           "indicators"

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.69.0",
+  "version": "2.69.1",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/intelligence_center/add_ioc_to_ioc_collection.py
+++ b/Sekoia.io/sekoiaio/intelligence_center/add_ioc_to_ioc_collection.py
@@ -1,9 +1,11 @@
-import requests
 import ipaddress
 from datetime import datetime, timedelta
 
-from .base import InThreatBaseAction
+import requests
+
 from sekoiaio.utils import datetime_to_str
+
+from .base import InThreatBaseAction
 
 
 class AddIOCtoIOCCollectionAction(InThreatBaseAction):
@@ -50,18 +52,21 @@ class AddIOCtoIOCCollectionAction(InThreatBaseAction):
             "hash": "file.hashes",
         }
 
-        indicators = self.json_argument("indicators", arguments)
+        indicators = self.json_argument("indicators", arguments, required=False)
+        single_indicator = arguments.get("indicator")
         ioc_collection_id = arguments.get("ioc_collection_id")
         indicator_type = arguments.get("indicator_type")
         valid_for = int(arguments.get("valid_for", 0))
 
-        if str(indicator_type) == "IP address":
-            if not isinstance(indicators, list):
-                raise ValueError("Indicators should be list type")
+        result_indicators = indicators or [single_indicator]
 
-            self.add_IP_action(indicators, ioc_collection_id, valid_for)
+        if str(indicator_type) == "IP address":
+            if not isinstance(indicators, list) and not single_indicator:
+                raise ValueError("Indicators should be list type, or you should provide a single indicator value")
+
+            self.add_IP_action(result_indicators, ioc_collection_id, valid_for)
         else:
             if _type := indicator_type_mapping.get(str(indicator_type)):
-                self.perform_request(indicators, ioc_collection_id, _type, valid_for)
+                self.perform_request(result_indicators, ioc_collection_id, _type, valid_for)
             else:
                 self.error(f"Improper indicator type {indicator_type}")

--- a/Sekoia.io/tests/test_add_ioc_2_ioc_collection.py
+++ b/Sekoia.io/tests/test_add_ioc_2_ioc_collection.py
@@ -128,6 +128,132 @@ def test_add_ioc_incorrect_type(arguments_invalid_type):
     assert action._error is not None
 
 
+@pytest.fixture
+def arguments_single_indicator_ipv4():
+    return {
+        "indicator": "8.8.8.8",
+        "ioc_collection_id": "ioc-collection--00000000-0000-0000-0000-000000000000",
+        "indicator_type": "IP address",
+    }
+
+
+@pytest.fixture
+def arguments_single_indicator_ipv6():
+    return {
+        "indicator": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+        "ioc_collection_id": "ioc-collection--00000000-0000-0000-0000-000000000000",
+        "indicator_type": "IP address",
+    }
+
+
+@pytest.fixture
+def arguments_single_indicator_domain():
+    return {
+        "indicator": "www.sekoia.io",
+        "ioc_collection_id": "ioc-collection--00000000-0000-0000-0000-000000000000",
+        "indicator_type": "domain",
+    }
+
+
+@pytest.fixture
+def arguments_single_indicator_with_valid_for():
+    return {
+        "indicator": "8.8.8.8",
+        "ioc_collection_id": "ioc-collection--00000000-0000-0000-0000-000000000000",
+        "indicator_type": "IP address",
+        "valid_for": "30",
+    }
+
+
+@pytest.fixture
+def arguments_no_indicators():
+    return {
+        "ioc_collection_id": "ioc-collection--00000000-0000-0000-0000-000000000000",
+        "indicator_type": "IP address",
+    }
+
+
+def test_add_ioc_single_indicator_ipv4(arguments_single_indicator_ipv4):
+    action: AddIOCtoIOCCollectionAction = AddIOCtoIOCCollectionAction()
+    action.module.configuration = {"base_url": "http://fake.url/", "api_key": "fake_api_key"}
+
+    response = {"task_id": "00000000-0000-0000-0000-000000000000"}
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "http://fake.url/api/v2/inthreat/ioc-collections/ioc-collection--00000000-0000-0000-0000-000000000000/indicators/text",
+            json=response,
+        )
+        action.run(arguments_single_indicator_ipv4)
+
+        history = mock.request_history
+        assert mock.call_count == 1
+        assert history[0].method == "POST"
+        assert "8.8.8.8" in history[0].text
+
+
+def test_add_ioc_single_indicator_ipv6(arguments_single_indicator_ipv6):
+    action: AddIOCtoIOCCollectionAction = AddIOCtoIOCCollectionAction()
+    action.module.configuration = {"base_url": "http://fake.url/", "api_key": "fake_api_key"}
+
+    response = {"task_id": "00000000-0000-0000-0000-000000000000"}
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "http://fake.url/api/v2/inthreat/ioc-collections/ioc-collection--00000000-0000-0000-0000-000000000000/indicators/text",
+            json=response,
+        )
+        action.run(arguments_single_indicator_ipv6)
+
+        history = mock.request_history
+        assert mock.call_count == 1
+        assert history[0].method == "POST"
+        assert "2001:0db8:85a3:0000:0000:8a2e:0370:7334" in history[0].text
+
+
+def test_add_ioc_single_indicator_domain(arguments_single_indicator_domain):
+    action: AddIOCtoIOCCollectionAction = AddIOCtoIOCCollectionAction()
+    action.module.configuration = {"base_url": "http://fake.url/", "api_key": "fake_api_key"}
+
+    response = {"task_id": "00000000-0000-0000-0000-000000000000"}
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "http://fake.url/api/v2/inthreat/ioc-collections/ioc-collection--00000000-0000-0000-0000-000000000000/indicators/text",
+            json=response,
+        )
+        action.run(arguments_single_indicator_domain)
+
+        history = mock.request_history
+        assert mock.call_count == 1
+        assert history[0].method == "POST"
+
+
+def test_add_ioc_single_indicator_with_valid_for(arguments_single_indicator_with_valid_for):
+    action: AddIOCtoIOCCollectionAction = AddIOCtoIOCCollectionAction()
+    action.module.configuration = {"base_url": "http://fake.url/", "api_key": "fake_api_key"}
+
+    response = {"task_id": "00000000-0000-0000-0000-000000000000"}
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "http://fake.url/api/v2/inthreat/ioc-collections/ioc-collection--00000000-0000-0000-0000-000000000000/indicators/text",
+            json=response,
+        )
+        action.run(arguments_single_indicator_with_valid_for)
+
+        history = mock.request_history
+        assert mock.call_count == 1
+        assert history[0].method == "POST"
+        assert "valid_until" in history[0].text
+
+
+def test_add_ioc_no_indicators_raises_error(arguments_no_indicators):
+    action: AddIOCtoIOCCollectionAction = AddIOCtoIOCCollectionAction()
+    action.module.configuration = {"base_url": "http://fake.url/", "api_key": "fake_api_key"}
+
+    with pytest.raises(
+        ValueError, match="Indicators should be list type, or you should provide a single indicator value"
+    ):
+        action.run(arguments_no_indicators)
+
+
 def test_add_ioc_failed(arguments_http_error):
     action: AddIOCtoIOCCollectionAction = AddIOCtoIOCCollectionAction()
     action.module.configuration = {"base_url": "http://fake.url/", "api_key": "fake_api_key"}


### PR DESCRIPTION
Relates to 
* [1315](https://github.com/SekoiaLab/integration/issues/1315)
* [1314](https://github.com/SekoiaLab/integration/issues/1314)

## Summary by Sourcery

Allow adding a single indicator value to an IOC collection in addition to the existing list-based input and update metadata accordingly.

New Features:
- Support passing a single `indicator` field to AddIOCtoIOCCollectionAction alongside the existing `indicators` list parameter.

Enhancements:
- Extend AddIOCtoIOCCollectionAction to derive the indicator list from either the `indicators` array or a single `indicator` value and validate presence accordingly.

Documentation:
- Document the new optional `indicator` field for AddIOCtoIOCCollectionAction in the changelog.

Tests:
- Add tests covering single IPv4, IPv6, and domain indicators, handling of `valid_for`, and error behavior when no indicators are provided.

Chores:
- Bump the Sekoia.io integration manifest version to 2.69.1.