### PR TITLE
feat(sekoiaio): add custom status and verdict to trigger and action o…

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-03-17 - 2.71.0
+
+### Added
+
+- Add custom status and verdict triggers and actions for alert
+
 ## 2026-02-25 - 2.70.0
 
 ### Added

--- a/Sekoia.io/action_get_an_alert.json
+++ b/Sekoia.io/action_get_an_alert.json
@@ -574,6 +574,48 @@
           }
         }
       },
+      "custom_status_uuid": {
+        "type": "string",
+        "format": "uuid",
+        "x-nullable": true,
+        "description": "UUID of the custom status associated to the alert"
+      },
+      "custom_status": {
+        "x-nullable": true,
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "stage": {
+            "type": "string"
+          }
+        }
+      },
+      "verdict": {
+        "x-nullable": true,
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "stage": {
+            "type": "string"
+          }
+        }
+      },
       "created_by": {
         "type": "string"
       },

--- a/Sekoia.io/action_patch_an_alert.json
+++ b/Sekoia.io/action_patch_an_alert.json
@@ -48,6 +48,16 @@
         "maxLength": 10000,
         "description": "Title of the alert",
         "in": "body"
+      },
+      "verdict_uuid": {
+        "description": "Verdict of the alert",
+        "type": "string",
+        "in": "body"
+      },
+      "custom_status_uuid": {
+        "description": "Custom status of the alert",
+        "type": "string",
+        "in": "body"
       }
     },
     "required": [
@@ -137,6 +147,60 @@
             "type": "string"
           }
         }
+      },
+       "custom_status_uuid": {
+        "type": "string",
+        "format": "uuid",
+        "x-nullable": true,
+        "description": "UUID of the custom status associated to the alert"
+      },
+      "custom_status": {
+        "x-nullable": true,
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "stage": {
+            "type": "string"
+          }
+        }
+      },
+      "verdict_uuid": {
+        "type": "string",
+        "format": "uuid",
+        "x-nullable": true,
+        "description": "UUID of the verdict associated to the alert"
+      },
+      "verdict": {
+        "x-nullable": true,
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "stage": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "label",
+          "level",
+          "stage"
+        ]
       },
       "created_by": {
         "type": "string"

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.70.0",
+  "version": "2.71.0",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/triggers/alerts.py
+++ b/Sekoia.io/sekoiaio/triggers/alerts.py
@@ -82,6 +82,14 @@ class SecurityAlertsTrigger(_SEKOIANotificationBaseTrigger):
                 "name": alert.get("status", {}).get("name"),
                 "uuid": alert.get("status", {}).get("uuid"),
             },
+            "custom_status": {
+                "name": alert.get("custom_status", {}).get("label"),
+                "uuid": alert.get("custom_status", {}).get("uuid"),
+            },
+            "verdict": {
+                "name": alert.get("verdict", {}).get("label"),
+                "uuid": alert.get("verdict", {}).get("uuid"),
+            },
             "created_at": alert.get("created_at"),
             "urgency": alert.get("urgency", {}).get("current_value"),
             "entity": alert.get("entity", {}),


### PR DESCRIPTION
add custom status and verdict properties to trigger and action of the alert

## Summary by Sourcery

New Features:
- Include alert custom_status and verdict metadata in the alert trigger payload and alert actions responses/requests.