### PR TITLE
Withsecure: fix payload

### DIFF
--- a/WithSecure/CHANGELOG.md
+++ b/WithSecure/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## 2025-10-20 - 2.16.4
+
+### Fixed
+
+- Fix the serialisation of arrays in the form of a URL-encoded payload
+
 ## 2025-10-20 - 2.16.3
 
 ### Fixed

--- a/WithSecure/manifest.json
+++ b/WithSecure/manifest.json
@@ -25,7 +25,7 @@
   "name": "WithSecure",
   "uuid": "8aa9f86c-f360-4ae7-84f5-b61c6917cf01",
   "slug": "withsecure",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "categories": [
     "Endpoint"
   ]

--- a/WithSecure/tests/test_security_event_connector.py
+++ b/WithSecure/tests/test_security_event_connector.py
@@ -313,3 +313,40 @@ def test_load_recent_date_seen(trigger):
         c["most_recent_date_seen"] = (datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
 
     assert trigger.most_recent_date_seen < datetime.now(timezone.utc) - timedelta(days=3)
+
+
+def test_next_batch_with_form_urlencoded_format(trigger, message1, message2):
+    """Test that engineGroup parameters are correctly repeated in form-urlencoded format"""
+
+    def custom_matcher(request: requests.PreparedRequest):
+        if request.url == API_AUTHENTICATION_URL:
+            resp = requests.Response()
+            resp._content = json.dumps(
+                {
+                    "access_token": "dummy-test-token",
+                    "token_type": "Bearer",
+                    "expires_in": 1799,
+                }
+            ).encode()
+            resp.status_code = 200
+            return resp
+        elif request.url.startswith(API_SECURITY_EVENTS_URL):
+            # Verify that engineGroup is repeated in the request body
+            assert "engineGroup=epp" in request.body
+            assert "engineGroup=edr" in request.body
+            assert "engineGroup=ecp" in request.body
+            assert "Content-Type" in request.headers
+            assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+
+            resp = requests.Response()
+            resp._content = json.dumps({"items": [message1, message2]}).encode()
+            resp.status_code = 200
+            return resp
+        return None
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.add_matcher(custom_matcher)
+        trigger.next_batch()
+        assert len(trigger.push_events_to_intakes.mock_calls) == 1
+        assert len(trigger.push_events_to_intakes.mock_calls[0][2]["events"]) == 2
+

--- a/WithSecure/tests/test_security_event_connector.py
+++ b/WithSecure/tests/test_security_event_connector.py
@@ -349,4 +349,3 @@ def test_next_batch_with_form_urlencoded_format(trigger, message1, message2):
         trigger.next_batch()
         assert len(trigger.push_events_to_intakes.mock_calls) == 1
         assert len(trigger.push_events_to_intakes.mock_calls[0][2]["events"]) == 2
-

--- a/WithSecure/withsecure/security_events_connector.py
+++ b/WithSecure/withsecure/security_events_connector.py
@@ -3,7 +3,6 @@ from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from typing import Any, Optional
-from urllib.parse import urlencode
 
 import orjson
 import requests
@@ -84,6 +83,16 @@ class SecurityEventsConnector(Connector):
 
         return response
 
+    def __flatten_form_data(self, data: dict[str, Any]) -> list[tuple[str, Any]]:
+        flattened_data = []
+        for key, value in data.items():
+            if isinstance(value, list):
+                for item in value:
+                    flattened_data.append((key, item))
+            else:
+                flattened_data.append((key, value))
+        return flattened_data
+
     def __fetch_next_events(self, from_date: datetime) -> Generator[list[dict[str, Any]], None, None]:
         """
         Fetch all the events that occurred after the specified from date
@@ -102,16 +111,8 @@ class SecurityEventsConnector(Connector):
 
         headers = {"Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded"}
 
-        # Flatten engineGroup array for form-urlencoded format
-        flattened_data = []
-        for key, value in data.items():
-            if isinstance(value, list):
-                for item in value:
-                    flattened_data.append((key, item))
-            else:
-                flattened_data.append((key, value))
-
         try:
+            flattened_data = self.__flatten_form_data(data)
             response = self.__get_events(data=flattened_data, headers=headers)
             response.raise_for_status()
 
@@ -146,7 +147,8 @@ class SecurityEventsConnector(Connector):
                 return
             data["anchor"] = anchor
             try:
-                response = self.__get_events(data=data, headers=headers)
+                flattened_data = self.__flatten_form_data(data)
+                response = self.__get_events(data=flattened_data, headers=headers)
                 response.raise_for_status()
                 payload = response.json()
             except Exception as any_exception:

--- a/WithSecure/withsecure/security_events_connector.py
+++ b/WithSecure/withsecure/security_events_connector.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from typing import Any, Optional
+from urllib.parse import urlencode
 
 import orjson
 import requests
@@ -70,7 +71,7 @@ class SecurityEventsConnector(Connector):
             log_cb=self.log,
         )
 
-    def __get_events(self, data: dict[str, Any], headers: dict[str, str]) -> requests.Response:
+    def __get_events(self, data: list[tuple[str, Any]], headers: dict[str, str]) -> requests.Response:
         for attempt in Retrying(
             stop=stop_after_attempt(5),
             wait=wait_exponential(multiplier=1, min=1, max=10),
@@ -101,8 +102,17 @@ class SecurityEventsConnector(Connector):
 
         headers = {"Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded"}
 
+        # Flatten engineGroup array for form-urlencoded format
+        flattened_data = []
+        for key, value in data.items():
+            if isinstance(value, list):
+                for item in value:
+                    flattened_data.append((key, item))
+            else:
+                flattened_data.append((key, value))
+
         try:
-            response = self.__get_events(data=data, headers=headers)
+            response = self.__get_events(data=flattened_data, headers=headers)
             response.raise_for_status()
 
             # Remove null bytes if any


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/integration/issues/1383)

## Summary by Sourcery

Ensure WithSecure security event connector sends engineGroup filters correctly using form-urlencoded requests and is covered by tests.

Bug Fixes:
- Fix security events API request payload to repeat engineGroup parameters in application/x-www-form-urlencoded format instead of sending a list structure.

Tests:
- Add integration-style test to verify engineGroup parameters are repeated in the request body and that the correct form-urlencoded Content-Type header is used when fetching events.