### PR TITLE
O365: deprecated old message traceconnectors

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-03-19 - 2.20.1
+
+### Changed
+
+- Deprecate old Office 365 Message Trace connectors
+
 ## 2026-03-05 - 2.20.0
 
 ### Added

--- a/Office365/connector_office365_messagetrace_oauth.json
+++ b/Office365/connector_office365_messagetrace_oauth.json
@@ -1,7 +1,7 @@
 {
   "description": "Fetch events for MessageTrace API (OAuth)",
   "docker_parameters": "office365_messagetrace_trigger_oauth",
-  "name": "Fetch events from MessageTrace API (OAuth)",
+  "name": "Fetch events from MessageTrace API (OAuth; deprecated)",
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "categories": [
     "Email"
   ]

--- a/Office365/trigger_office365_messagetrace_oauth.json
+++ b/Office365/trigger_office365_messagetrace_oauth.json
@@ -1,7 +1,7 @@
 {
   "description": "Fetch events for MessageTrace API (OAuth)",
   "docker_parameters": "office365_messagetrace_trigger_oauth",
-  "name": "Fetch events from MessageTrace API (OAuth)",
+  "name": "Fetch events from MessageTrace API (OAuth; deprecated)",
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {


### PR DESCRIPTION
## Summary by Sourcery

Deprecate legacy Office 365 Message Trace connectors and bump the Office365 integration version.

Enhancements:
- Deprecate the old Office 365 Message Trace connectors in favor of newer alternatives.

Build:
- Bump Office365 integration manifest version from 2.20.0 to 2.20.1.

Documentation:
- Add changelog entry for version 2.20.1 describing the deprecation of old Office 365 Message Trace connectors.