### PR TITLE
Fix: Aws Additional Filters (1431)

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-03-17 - 1.34.0
+
+### Added
+
+- Add optional `prefix_filter` parameter to all SQS-based S3 connectors. When set, only S3 objects whose key starts with the given prefix are processed. This allows filtering events when a single S3 bucket contains multiple log types (e.g. CloudTrail + other logs).
+
 ## 2026-02-24 - 1.33.17
 
 ### Changed

--- a/AWS/connectors/s3/__init__.py
+++ b/AWS/connectors/s3/__init__.py
@@ -21,6 +21,7 @@ class AwsS3QueuedConfiguration(AbstractAwsConnectorConfiguration):
     chunk_size: int = 10000
     delete_consumed_messages: bool = True
     queue_name: str
+    prefix_filter: str | None = None
 
 
 class AwsS3LogsBaseConfiguration(BaseModel):
@@ -127,6 +128,16 @@ class AbstractAwsS3QueuedConnector(AbstractAwsConnector, metaclass=ABCMeta):
                             raise ValueError("Key is undefined", record)
 
                         normalized_key = normalize_s3_key(s3_key)
+
+                        if self.configuration.prefix_filter and not normalized_key.startswith(
+                            self.configuration.prefix_filter
+                        ):
+                            self.log(
+                                message=f"Skipping S3 object {normalized_key}: does not match prefix filter "
+                                f"'{self.configuration.prefix_filter}'",
+                                level="debug",
+                            )
+                            continue
 
                         stream: AsyncReader
                         async with (

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -23,7 +23,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.33.17",
+  "version": "1.34.0",
   "categories": ["Cloud Providers"],
   "supports_validation": true
 }

--- a/AWS/tests/connectors/s3/test_abstract_aws_s3_queued_connector.py
+++ b/AWS/tests/connectors/s3/test_abstract_aws_s3_queued_connector.py
@@ -294,3 +294,131 @@ async def test_abstract_aws_s3_queued_connector_next_batch_with_empty_data_in_s3
     result = await abstract_queued_connector.next_batch()
 
     assert result == (0, [message[1] for message in valid_messages])
+
+
+@pytest.mark.asyncio
+async def test_abstract_aws_s3_queued_connector_next_batch_with_prefix_filter(
+    session_faker: Faker,
+    aws_module: AwsModule,
+    symphony_storage: Path,
+    mock_push_data_to_intakes: AsyncMock,
+):
+    """
+    Test that prefix_filter skips S3 objects whose key does not match the prefix.
+    """
+    prefix = "AWSLogs/123456789/CloudTrail/"
+    matching_key = f"{prefix}eu-west-3/2026/03/12/log.json.gz"
+    non_matching_key = "AWSLogs/123456789/OtherLogs/some-file.log"
+
+    config = AwsS3QueuedConfiguration(
+        intake_key=session_faker.word(),
+        queue_name=session_faker.word(),
+        prefix_filter=prefix,
+    )
+
+    klass = type("TestConnector", (AbstractAwsS3QueuedConnector, AwsAccountProvider), {})
+    connector = klass(module=aws_module, data_path=symphony_storage)
+    connector.configuration = config
+    connector.push_data_to_intakes = mock_push_data_to_intakes
+
+    data_content = session_faker.word()
+
+    async def _parse_content(stream: BinaryIO) -> AsyncGenerator[str, None]:
+        content = await stream.read()
+        result = content.decode("utf-8")
+        if result:
+            yield result
+
+    connector._parse_content = MagicMock(side_effect=_parse_content)
+    connector.log = MagicMock()
+    connector.log_exception = MagicMock()
+
+    test_bucket = session_faker.word()
+    matching_message = orjson.dumps(
+        {
+            "Records": [
+                {
+                    "s3": {
+                        "bucket": {"name": test_bucket},
+                        "object": {"key": matching_key},
+                    }
+                }
+            ]
+        }
+    ).decode("utf-8")
+    non_matching_message = orjson.dumps(
+        {
+            "Records": [
+                {
+                    "s3": {
+                        "bucket": {"name": test_bucket},
+                        "object": {"key": non_matching_key},
+                    }
+                }
+            ]
+        }
+    ).decode("utf-8")
+
+    timestamp = session_faker.pyint(min_value=1, max_value=1000)
+    sqs_messages = [
+        (matching_message, timestamp),
+        (non_matching_message, timestamp),
+    ]
+
+    connector.sqs_wrapper = MagicMock()
+    connector.sqs_wrapper.receive_messages = MagicMock()
+    connector.sqs_wrapper.receive_messages.return_value.__aenter__.return_value = sqs_messages
+
+    async def read_key():
+        return await async_bytesIO(data_content.encode("utf-8"))
+
+    connector.s3_wrapper = MagicMock()
+    connector.s3_wrapper.read_key = MagicMock()
+    connector.s3_wrapper.read_key.return_value.__aenter__.side_effect = read_key
+
+    result = await connector.next_batch()
+
+    # Only 1 message should be processed (the matching one)
+    assert result[0] == 1
+    # s3_wrapper.read_key should have been called only once (for the matching key)
+    assert connector.s3_wrapper.read_key.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_abstract_aws_s3_queued_connector_next_batch_without_prefix_filter(
+    session_faker: Faker, abstract_queued_connector: AbstractAwsS3QueuedConnector
+):
+    """
+    Test that when prefix_filter is None (default), all S3 objects are processed.
+    """
+    test_bucket = session_faker.word()
+    key1 = "AWSLogs/CloudTrail/log1.json.gz"
+    key2 = "OtherLogs/something.log"
+
+    message1 = orjson.dumps({"Records": [{"s3": {"bucket": {"name": test_bucket}, "object": {"key": key1}}}]}).decode(
+        "utf-8"
+    )
+    message2 = orjson.dumps({"Records": [{"s3": {"bucket": {"name": test_bucket}, "object": {"key": key2}}}]}).decode(
+        "utf-8"
+    )
+
+    timestamp = session_faker.pyint(min_value=1, max_value=1000)
+    sqs_messages = [(message1, timestamp), (message2, timestamp)]
+
+    data_content = session_faker.word()
+
+    async def read_key():
+        return await async_bytesIO(data_content.encode("utf-8"))
+
+    abstract_queued_connector.sqs_wrapper = MagicMock()
+    abstract_queued_connector.sqs_wrapper.receive_messages = MagicMock()
+    abstract_queued_connector.sqs_wrapper.receive_messages.return_value.__aenter__.return_value = sqs_messages
+
+    abstract_queued_connector.s3_wrapper = MagicMock()
+    abstract_queued_connector.s3_wrapper.read_key = MagicMock()
+    abstract_queued_connector.s3_wrapper.read_key.return_value.__aenter__.side_effect = read_key
+
+    result = await abstract_queued_connector.next_batch()
+
+    # Both messages should be processed
+    assert result[0] == 2

--- a/AWS/trigger_s3_cloudfront.json
+++ b/AWS/trigger_s3_cloudfront.json
@@ -37,6 +37,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/trigger_s3_flowlogs.json
+++ b/AWS/trigger_s3_flowlogs.json
@@ -42,6 +42,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/trigger_s3_flowlogs_parquet.json
+++ b/AWS/trigger_s3_flowlogs_parquet.json
@@ -27,6 +27,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/trigger_s3_logs.json
+++ b/AWS/trigger_s3_logs.json
@@ -42,6 +42,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/trigger_s3_ocsf.json
+++ b/AWS/trigger_s3_ocsf.json
@@ -27,6 +27,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/trigger_s3_records.json
+++ b/AWS/trigger_s3_records.json
@@ -27,6 +27,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones (e.g. 'AWSLogs/123456789/CloudTrail/')",
+        "type": "string",
+        "default": null
       }
     },
     "required": [


### PR DESCRIPTION
Relates to [1431](https://github.com/SekoiaLab/integration/issues/1431)

## Summary by Sourcery

Add optional S3 object key prefix filtering to SQS-based S3 queued connectors and bump the AWS integration version.

New Features:
- Introduce an optional prefix_filter configuration on S3 queued connectors to only process S3 objects whose keys start with a specified prefix.

Enhancements:
- Skip non-matching S3 objects based on the configured key prefix while logging debug information about skipped objects.

Build:
- Update AWS integration manifest version to 1.34.0.

Documentation:
- Document the new prefix_filter option and its use case in the AWS connector changelog.

Tests:
- Add tests verifying that S3 queued connectors process only messages whose object keys match the configured prefix and that all messages are processed when no prefix_filter is set.