### PR TITLE
ci: Harden GitHub Actions workflows

### DIFF
--- a/.github/actions/test-with-poetry/action.yaml
+++ b/.github/actions/test-with-poetry/action.yaml
@@ -23,7 +23,7 @@ runs:
       working-directory: ${{ inputs.module }}
 
     - name: Execute Black
-      uses: psf/black@stable
+      uses: psf/black@35ea67920b7f6ac8e09be1c47278752b1e827f76 # 26.3.0
       with:
         options: "--check --verbose"
         src: ./"${{ inputs.module }}"

--- a/.github/actions/test-with-poetry/action.yaml
+++ b/.github/actions/test-with-poetry/action.yaml
@@ -23,7 +23,7 @@ runs:
       working-directory: ${{ inputs.module }}
 
     - name: Execute Black
-      uses: psf/black@35ea67920b7f6ac8e09be1c47278752b1e827f76 # 26.3.0
+      uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # 26.3.1
       with:
         options: "--check --verbose"
         src: ./"${{ inputs.module }}"

--- a/.github/actions/test-with-uv/action.yaml
+++ b/.github/actions/test-with-uv/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@6ee6290f1cbc4156c0bdd66691b2c144ef8df19a # v7.4.0
       with:
         enable-cache: true
         activate-environment: true
@@ -23,7 +23,7 @@ runs:
       working-directory: ${{ inputs.module }}
 
     - name: Execute Black
-      uses: psf/black@stable
+      uses: psf/black@35ea67920b7f6ac8e09be1c47278752b1e827f76 # 26.3.0
       with:
         options: "--check --verbose"
         src: ./"${{ inputs.module }}"

--- a/.github/actions/test-with-uv/action.yaml
+++ b/.github/actions/test-with-uv/action.yaml
@@ -23,7 +23,7 @@ runs:
       working-directory: ${{ inputs.module }}
 
     - name: Execute Black
-      uses: psf/black@35ea67920b7f6ac8e09be1c47278752b1e827f76 # 26.3.0
+      uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # 26.3.1
       with:
         options: "--check --verbose"
         src: ./"${{ inputs.module }}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Cooldown applies only to version updates, not security updates
+    cooldown:
+      default-days: 14
+    groups:
+      # Group all version updates into a single PR; security updates remain ungrouped
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     # Cooldown applies only to version updates, not security updates

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -145,7 +145,6 @@ jobs:
           content="${content//$'\r'/''}"
           # end of optional handling for multi line json
           echo "$content"
-          echo "$content"
           echo "manifest=$content" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_MODULE: ${{ matrix.module }}

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -14,8 +14,12 @@ env:
   SECONDARY_REGISTRY: registry.sekoia.io
   IMAGE_PREFIX_NAME: sekoia-io
 
+permissions: {}
+
 jobs:
   find-modules:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     name: Find modules in repo
     runs-on: ubuntu-latest
     outputs:
@@ -42,6 +46,8 @@ jobs:
           echo "matrix=$(comm -12  <(cut -d "/" -f1 <<< "$(git diff --name-only -r $start $end)" | sort | uniq) <(cut -d "/" -f1 <<< "$(ls -a */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   test:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     name: Test module ${{ matrix.module }}
     runs-on: ubuntu-latest
     needs: find-modules
@@ -113,6 +119,9 @@ jobs:
           fail_ci_if_error: true
 
   build-docker:
+    permissions:
+      contents: read  # for docker/build-push-action to access repository contents
+      packages: write  # for docker/login-action to push images to GHCR
     name: Build ${{ matrix.module }} docker image
     runs-on: ubuntu-latest
     needs: find-modules

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -70,10 +70,10 @@ jobs:
         id: detect-pm
         run: |
           if [ -f "${MODULE_PATH}/uv.lock" ]; then
-            echo "package_manager=uv" >> $GITHUB_OUTPUT
+            echo "package_manager=uv" >> "$GITHUB_OUTPUT"
             echo "Detected uv project"
           else
-            echo "package_manager=poetry" >> $GITHUB_OUTPUT
+            echo "package_manager=poetry" >> "$GITHUB_OUTPUT"
             echo "Defaulting to Poetry"
           fi
         env:
@@ -152,7 +152,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -160,7 +160,7 @@ jobs:
 
       - name: Log in to the secondary Container registry
         if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.SECONDARY_REGISTRY }}
           username: ${{ secrets.SECONDARY_REGISTRY_USERNAME }}

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -33,7 +33,7 @@ jobs:
         name: List modules having changed files
         run: |
           if ${{ github.event_name == 'workflow_dispatch' }}; then
-            echo "matrix=$(cut -d "/" -f1 <<< "$(ls -a */manifest.json)" | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+            echo "matrix=$(cut -d "/" -f1 <<< "$(ls -a -- */manifest.json)" | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ${{ github.event_name == 'pull_request' }}; then
@@ -43,7 +43,7 @@ jobs:
             start=${{ github.event.before }}
             end=${{ github.event.after }}
           fi
-          echo "matrix=$(comm -12  <(cut -d "/" -f1 <<< "$(git diff --name-only -r $start $end)" | sort | uniq) <(cut -d "/" -f1 <<< "$(ls -a */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo "matrix=$(comm -12  <(cut -d "/" -f1 <<< "$(git diff --name-only -r "$start" "$end")" | sort | uniq) <(cut -d "/" -f1 <<< "$(ls -a -- */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
 
   test:
     permissions:
@@ -108,7 +108,7 @@ jobs:
         run: |
           FLAG="${MATRIX_MODULE}"
           FLAG=${FLAG// } # replace spaces
-          echo FLAG=${FLAG} >> $GITHUB_ENV # update GitHub ENV vars
+          echo "FLAG=${FLAG}" >> "$GITHUB_ENV" # update GitHub ENV vars
         env:
           MATRIX_MODULE: ${{ matrix.module }}
 
@@ -139,14 +139,14 @@ jobs:
       - name: Read Module Manifest
         id: read-module-manifest
         run: |
-          content=`cat "${MATRIX_MODULE}/manifest.json"`
+          content=$(cat "${MATRIX_MODULE}/manifest.json")
           # the following lines are only required for multi line json
           content="${content//$'\n'/''}"
           content="${content//$'\r'/''}"
           # end of optional handling for multi line json
-          echo $content
           echo "$content"
-          echo "manifest=$content" >> $GITHUB_OUTPUT
+          echo "$content"
+          echo "manifest=$content" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_MODULE: ${{ matrix.module }}
 

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -106,9 +106,11 @@ jobs:
 
       - name: Code Coverage Flag
         run: |
-          FLAG="${{ matrix.module }}"
+          FLAG="${MATRIX_MODULE}"
           FLAG=${FLAG// } # replace spaces
           echo FLAG=${FLAG} >> $GITHUB_ENV # update GitHub ENV vars
+        env:
+          MATRIX_MODULE: ${{ matrix.module }}
 
       - name: Code Coverage
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
@@ -137,7 +139,7 @@ jobs:
       - name: Read Module Manifest
         id: read-module-manifest
         run: |
-          content=`cat "${{ matrix.module }}/manifest.json"`
+          content=`cat "${MATRIX_MODULE}/manifest.json"`
           # the following lines are only required for multi line json
           content="${content//$'\n'/''}"
           content="${content//$'\r'/''}"
@@ -145,6 +147,8 @@ jobs:
           echo $content
           echo "$content"
           echo "manifest=$content" >> $GITHUB_OUTPUT
+        env:
+          MATRIX_MODULE: ${{ matrix.module }}
 
       - name: Log in to the Container registry
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -22,7 +22,7 @@ jobs:
       matrix: ${{ steps.list-modules.outputs.matrix }}
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
       - id: list-modules
@@ -52,10 +52,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.11"
@@ -86,14 +86,14 @@ jobs:
           module: ${{ matrix.module }}
 
       - name: Upload Event
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: Event File (${{ matrix.module }})
           path: ${{ github.event_path }}
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: Unit Test Results (${{ matrix.module }})
           path: "${{ matrix.module }}/junit.xml"
@@ -105,7 +105,7 @@ jobs:
           echo FLAG=${FLAG} >> $GITHUB_ENV # update GitHub ENV vars
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.module }}/coverage.xml
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Read Module Manifest
         id: read-module-manifest
@@ -139,7 +139,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: Log in to the secondary Container registry
         if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.SECONDARY_REGISTRY }}
           username: ${{ secrets.SECONDARY_REGISTRY_USERNAME }}
@@ -156,7 +156,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         if: ${{ github.event_name == 'push' }}
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX_NAME }}/automation-module-${{fromJson(steps.read-module-manifest.outputs.manifest).slug}}
@@ -169,10 +169,10 @@ jobs:
             type=pep440,pattern={{version}},value=${{fromJson(steps.read-module-manifest.outputs.manifest).version}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           push: ${{ github.event_name == 'push' }}
           context: ${{ matrix.Module }}
@@ -206,13 +206,13 @@ jobs:
     steps:
       - name: my-app-install token
         id: my-app
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.my-app.outputs.token }}
           event-type: publish-automation-modules

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.10"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,8 +15,12 @@ defaults:
   run:
     working-directory: _utils
 
+permissions: {}
+
 jobs:
   check_modules:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/generate-modules-list.yml
+++ b/.github/workflows/generate-modules-list.yml
@@ -21,7 +21,7 @@ jobs:
       - id: list-modules
         name: List modules
         run: |
-          echo "modules=$((cut -d "/" -f1 <<< "$(ls -a */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_ENV
+          echo "modules=$( (cut -d "/" -f1 <<< "$(ls -a -- */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_ENV"
 
       - name: my-app-install token
         id: my-app

--- a/.github/workflows/generate-modules-list.yml
+++ b/.github/workflows/generate-modules-list.yml
@@ -7,8 +7,12 @@ on:
       - main
       - develop
 
+permissions: {}
+
 jobs:
   generate-modules-list:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE

--- a/.github/workflows/generate-modules-list.yml
+++ b/.github/workflows/generate-modules-list.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: list-modules
         name: List modules
@@ -21,13 +21,13 @@ jobs:
 
       - name: my-app-install token
         id: my-app
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.my-app.outputs.token }}
           event-type: refresh-automation-modules-list

--- a/.github/workflows/release_auto_approve.yml
+++ b/.github/workflows/release_auto_approve.yml
@@ -6,11 +6,13 @@ on:
     branches: [production]
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   auto-approve:
-    runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      pull-requests: write  # for run step (declared via comment)
+    runs-on: ubuntu-latest
     if: |
       github.event.pull_request.user.login == 'integration-release-to-production' &&
       github.event.pull_request.user.type == 'Bot'
@@ -19,4 +21,4 @@ jobs:
         run: gh pr review --repo "${{ github.repository }}" --approve "$PR_NUMBER"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # gha-perms:permissions=pull-requests:write

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -6,12 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.10"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run
         working-directory: .

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -1,8 +1,12 @@
 name: Check linting
 on: push
 
+permissions: {}
+
 jobs:
   linter:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.10

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -14,8 +14,7 @@ jobs:
       actions: read  # for dawidd6/action-download-artifact to query and download artifacts
       checks: write  # for EnricoMi/publish-unit-test-result-action to create and update check runs
       contents: read  # for EnricoMi/publish-unit-test-result-action to read commits and compare branches
-      issues: write  # for EnricoMi/publish-unit-test-result-action to post and update PR comments
-      pull-requests: read  # for EnricoMi/publish-unit-test-result-action to list PRs associated with a commit
+      pull-requests: write  # for EnricoMi/publish-unit-test-result-action to post and update PR comments
     name: Unit Test Results
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Download Test Report
-        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # v16
+        uses: dawidd6/action-download-artifact@09b07ec687d10771279a426c79925ee415c12906 # v17
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -6,12 +6,16 @@ on:
     types:
       - completed
 
-permissions:
-  checks: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   unit-test-results:
+    permissions:
+      actions: read  # for dawidd6/action-download-artifact to query and download artifacts
+      checks: write  # for EnricoMi/publish-unit-test-result-action to create and update check runs
+      contents: read  # for EnricoMi/publish-unit-test-result-action to read commits and compare branches
+      issues: write  # for EnricoMi/publish-unit-test-result-action to post and update PR comments
+      pull-requests: read  # for EnricoMi/publish-unit-test-result-action to list PRs associated with a commit
     name: Unit Test Results
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Download Test Report
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # v16
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File (*)/event.json


### PR DESCRIPTION
## Summary

- Configure Dependabot for GitHub Actions (weekly, 14-day cooldown, grouped version updates)
- Pin actions to commit SHAs (14-day minimum age)
- Least-privilege `permissions` (deny-all at workflow level, minimal job-level grants)
- Fix zizmor template injection findings (env var indirection)
- Fix actionlint/shellcheck findings (quoting, backtick-to-`$()`, glob safety)

## Summary by Sourcery

Harden GitHub Actions workflows by tightening permissions, pinning third-party actions to specific commit SHAs, and introducing automated dependency updates for workflow actions.

Build:
- Add Dependabot configuration to manage GitHub Actions updates on a weekly schedule with a cooldown and grouped version updates.
- Pin all GitHub Actions and related third-party actions in workflows to specific commit SHAs and refresh them to current major versions.
- Refine workflow job permissions to follow a deny-by-default model with minimal, purpose-specific grants for each job.
- Improve workflow shell steps for safety and linters by adding proper quoting, safer globbing, and environment variable indirection where needed.

CI:
- Harden CI workflows for building modules, generating module lists, publishing test results, linting, and release auto-approval using pinned actions and least-privilege permissions.