### PR TITLE
feat(sekoiaio): add custom_status option to retrieve custom status an…

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-03-23 - 2.71.1
+
+### Fixed
+
+- Add `custom_status` option to `_retrieve_alert_from_alertapi` to retrieve custom status and verdict information for alert
+
 ## 2026-03-17 - 2.71.0
 
 ### Added

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.71.0",
+  "version": "2.71.1",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/triggers/alerts.py
+++ b/Sekoia.io/sekoiaio/triggers/alerts.py
@@ -84,10 +84,14 @@ class SecurityAlertsTrigger(_SEKOIANotificationBaseTrigger):
             },
             "custom_status": {
                 "name": alert.get("custom_status", {}).get("label"),
+                "level": alert.get("custom_status", {}).get("level"),
+                "stage": alert.get("custom_status", {}).get("stage"),
                 "uuid": alert.get("custom_status", {}).get("uuid"),
             },
             "verdict": {
                 "name": alert.get("verdict", {}).get("label"),
+                "level": alert.get("verdict", {}).get("level"),
+                "stage": alert.get("verdict", {}).get("stage"),
                 "uuid": alert.get("verdict", {}).get("uuid"),
             },
             "created_at": alert.get("created_at"),
@@ -129,6 +133,7 @@ class SecurityAlertsTrigger(_SEKOIANotificationBaseTrigger):
                 "comments": False,
                 "countermeasures": False,
                 "history": False,
+                "custom_status": True,
             },
         )
 


### PR DESCRIPTION
add custom_status option to retrieve custom status and verdict for alert

## Summary by Sourcery

Add support for retrieving and exposing custom status and verdict metadata on alerts, and bump the Sekoia.io integration version.

New Features:
- Expose custom_status level, stage, and uuid, as well as verdict level, stage, and uuid, in alert trigger payloads.
- Enable retrieval of custom_status data from the alert API when fetching an alert.

Build:
- Bump the Sekoia.io integration manifest version from 2.71.0 to 2.72.0.

Documentation:
- Document the new custom_status option and retrieved fields in the changelog for version 2.72.0.