### PR TITLE
AWS S3 logs - fix configurations

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-03-25 - 1.34.1
+
+### Fixed
+
+- Add `prefix_filter` to connector configuration
+
 ## 2026-03-17 - 1.34.0
 
 ### Added

--- a/AWS/connector_s3_cloudfront.json
+++ b/AWS/connector_s3_cloudfront.json
@@ -26,7 +26,7 @@
       },
       "skip_first": {
         "type": "integer",
-        "description": "The number of records to skip at the begining of each S3 object (default: 0)",
+        "description": "The number of records to skip at the beginning of each S3 object (default: 0)",
         "default": 0
       },
       "intake_server": {
@@ -37,6 +37,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/connector_s3_flowlogs.json
+++ b/AWS/connector_s3_flowlogs.json
@@ -26,7 +26,7 @@
       },
       "skip_first": {
         "type": "integer",
-        "description": "The number of records to skip at the begining of each S3 object (default: 0)",
+        "description": "The number of records to skip at the beginning of each S3 object (default: 0)",
         "default": 1
       },
       "ignore_comments": {
@@ -42,6 +42,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/connector_s3_flowlogs_parquet.json
+++ b/AWS/connector_s3_flowlogs_parquet.json
@@ -27,6 +27,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/connector_s3_logs.json
+++ b/AWS/connector_s3_logs.json
@@ -26,7 +26,7 @@
       },
       "skip_first": {
         "type": "integer",
-        "description": "The number of records to skip at the begining of each S3 object (default: 0)",
+        "description": "The number of records to skip at the beginning of each S3 object (default: 0)",
         "default": 0
       },
       "ignore_comments": {
@@ -42,6 +42,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/connector_s3_ocsf.json
+++ b/AWS/connector_s3_ocsf.json
@@ -27,6 +27,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/connector_s3_records.json
+++ b/AWS/connector_s3_records.json
@@ -27,6 +27,11 @@
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"
+      },
+      "prefix_filter": {
+        "description": "If set, only S3 objects whose key starts with this prefix will be processed. Use this when the S3 bucket contains multiple log types and you want to collect only specific ones (e.g. 'AWSLogs/123456789/CloudTrail/')",
+        "type": "string",
+        "default": null
       }
     },
     "required": [

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -23,7 +23,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "categories": ["Cloud Providers"],
   "supports_validation": true
 }

--- a/AWS/trigger_s3_cloudfront.json
+++ b/AWS/trigger_s3_cloudfront.json
@@ -22,11 +22,11 @@
       "separator": {
         "type": "string",
         "description": "The separator used between each records (default: the linefeed character '\\n')",
-        "default": "\n"
+        "default": "\\n"
       },
       "skip_first": {
         "type": "integer",
-        "description": "The number of records to skip at the begining of each S3 object (default: 0)",
+        "description": "The number of records to skip at the beginning of each S3 object (default: 0)",
         "default": 0
       },
       "intake_server": {

--- a/AWS/trigger_s3_flowlogs.json
+++ b/AWS/trigger_s3_flowlogs.json
@@ -22,11 +22,11 @@
       "separator": {
         "type": "string",
         "description": "The separator used between each records (default: the linefeed character '\\n')",
-        "default": "\n"
+        "default": "\\n"
       },
       "skip_first": {
         "type": "integer",
-        "description": "The number of records to skip at the begining of each S3 object (default: 0)",
+        "description": "The number of records to skip at the beginning of each S3 object (default: 0)",
         "default": 1
       },
       "ignore_comments": {

--- a/AWS/trigger_s3_logs.json
+++ b/AWS/trigger_s3_logs.json
@@ -22,11 +22,11 @@
       "separator": {
         "type": "string",
         "description": "The separator used between each records (default: the linefeed character '\\n')",
-        "default": "\n"
+        "default": "\\n"
       },
       "skip_first": {
         "type": "integer",
-        "description": "The number of records to skip at the begining of each S3 object (default: 0)",
+        "description": "The number of records to skip at the beginning of each S3 object (default: 0)",
         "default": 0
       },
       "ignore_comments": {


### PR DESCRIPTION
We added field to `trigger_` configurations, but didn't do that for `connector_` JSONs. Also, fixed a few other small typos and discrepancies.

https://github.com/SekoiaLab/integration/issues/1431

## Summary by Sourcery

Align AWS S3 connectors and triggers configuration by adding the missing prefix filter option and correcting minor configuration discrepancies.

Bug Fixes:
- Add the missing prefix_filter option to S3 connector configurations to match trigger settings and ensure consistent log collection behavior.

Documentation:
- Update AWS changelog with version 1.34.1 describing the S3 connector configuration fix.

Chores:
- Bump AWS integration manifest version from 1.34.0 to 1.34.1.