### PR TITLE
HarfangLab - add option

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-03-26 - 1.29.6
+
+### Added
+
+- Add option to update security events statuses along with a threat status
+
 ## 2026-02-23 - 1.29.5
 
 ### Changed

--- a/HarfangLab/action_harfanglab_update_threat_status.json
+++ b/HarfangLab/action_harfanglab_update_threat_status.json
@@ -18,24 +18,19 @@
       "new_status": {
         "description": "New status",
         "type": "string",
-        "enum": [
-          "closed",
-          "false_positive",
-          "investigating",
-          "new"
-        ]
+        "enum": ["closed", "false_positive", "investigating", "new"]
       },
       "update_by_query": {
         "description": "Update by query",
         "type": "boolean"
+      },
+      "tag_security_events": {
+        "description": "Tag security events",
+        "type": "boolean"
       }
     },
-    "required": [
-      "threat_ids",
-      "new_status",
-      "update_by_query"
-    ]
-},
+    "required": ["threat_ids", "new_status"]
+  },
   "results": {},
   "slug": "update_threat_status"
 }

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.29.5",
+  "version": "1.29.6",
   "categories": [
     "Endpoint"
   ],


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1463

## Summary by Sourcery

Add a configurable option related to threat status updates and release a new HarfangLab connector version.

New Features:
- Add an option to update security event statuses in conjunction with a threat status change.

Enhancements:
- Bump HarfangLab integration version to 1.29.6 and document the release in the changelog.