### PR TITLE
Feature: MicrosoftEntraId Parsed Properties (1394)

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-03-30 - 2.11.0
+
+### Added
+
+- Parse `oldValue` and `newValue` JSON strings in `modifiedProperties` of directory audit events into structured objects for easier detection rule development (e.g., Conditional Access Policy updates)
+
 ## 2026-02-20 - 2.10.17
 
 ### Changed

--- a/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
+++ b/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
@@ -16,11 +16,7 @@ from msgraph.generated.users.users_request_builder import UsersRequestBuilder
 from sekoia_automation.asset_connector import AsyncAssetConnector
 from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product
 from sekoia_automation.asset_connector.models.ocsf.organization import Organization
-from sekoia_automation.asset_connector.models.ocsf.user import (
-    Account,
-    AccountTypeId,
-    AccountTypeStr,
-)
+from sekoia_automation.asset_connector.models.ocsf.user import Account, AccountTypeId, AccountTypeStr
 from sekoia_automation.asset_connector.models.ocsf.user import Group as UserOCSFGroup
 from sekoia_automation.asset_connector.models.ocsf.user import User as UserOCSF
 from sekoia_automation.asset_connector.models.ocsf.user import (

--- a/MicrosoftEntraID/graph_api/client.py
+++ b/MicrosoftEntraID/graph_api/client.py
@@ -1,5 +1,6 @@
+import json
 from datetime import datetime, timezone
-from typing import AsyncGenerator, Iterable
+from typing import Any, AsyncGenerator, Iterable
 
 from azure.identity.aio import ClientSecretCredential
 from kiota_abstractions.base_request_configuration import RequestConfiguration
@@ -126,8 +127,20 @@ class GraphApi(object):
     def encode_log(value: Parsable) -> str:
         writer = _factory.get_serialization_writer("application/json")
         writer.write_object_value(None, value)
+        raw = writer.get_serialized_content().decode("utf-8")
 
-        return writer.get_serialized_content().decode("utf-8")
+        parsed = json.loads(raw)
+        for resource in parsed.get("targetResources") or []:
+            for prop in resource.get("modifiedProperties") or []:
+                for key in ("oldValue", "newValue"):
+                    val = prop.get(key)
+                    if isinstance(val, str):
+                        try:
+                            prop[key] = json.loads(val)
+                        except (json.JSONDecodeError, ValueError):
+                            pass
+
+        return json.dumps(parsed)
 
     async def close(self) -> None:  # pragma: no cover
         if self._client:

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.10.17",
+  "version": "2.11.0",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftEntraID/tests/conftest.py
+++ b/MicrosoftEntraID/tests/conftest.py
@@ -12,8 +12,10 @@ import pytest
 from faker import Faker
 from msgraph.generated.models.audit_activity_initiator import AuditActivityInitiator
 from msgraph.generated.models.directory_audit import DirectoryAudit
+from msgraph.generated.models.modified_property import ModifiedProperty
 from msgraph.generated.models.sign_in import SignIn
 from msgraph.generated.models.sign_in_status import SignInStatus
+from msgraph.generated.models.target_resource import TargetResource
 from msgraph.generated.models.user_identity import UserIdentity
 from sekoia_automation import constants
 
@@ -219,4 +221,40 @@ def directory_audits_page_2() -> SimpleNamespace:
             ),
         ],
         odata_next_link=None,
+    )
+
+
+@pytest.fixture
+def directory_audit_with_modified_properties() -> DirectoryAudit:
+    """DirectoryAudit event simulating a Conditional Access Policy update."""
+    import json
+
+    return DirectoryAudit(
+        id="ca-policy-1",
+        activity_date_time=datetime.fromisoformat("2025-09-01T00:00:00Z"),
+        activity_display_name="Update conditional access policy",
+        initiated_by=AuditActivityInitiator(user=UserIdentity(display_name="Admin")),
+        target_resources=[
+            TargetResource(
+                id="policy-id-123",
+                display_name="Block Legacy Auth",
+                type="Policy",
+                modified_properties=[
+                    ModifiedProperty(
+                        display_name="ConditionalAccessPolicy",
+                        old_value=json.dumps(
+                            {"State": "Disabled", "Conditions": {"Applications": {"IncludeApplications": ["All"]}}}
+                        ),
+                        new_value=json.dumps(
+                            {"State": "Enabled", "Conditions": {"Applications": {"IncludeApplications": ["All"]}}}
+                        ),
+                    ),
+                    ModifiedProperty(
+                        display_name="DisplayName",
+                        old_value='"Old Policy Name"',
+                        new_value='"New Policy Name"',
+                    ),
+                ],
+            )
+        ],
     )

--- a/MicrosoftEntraID/tests/graph_api/test_client.py
+++ b/MicrosoftEntraID/tests/graph_api/test_client.py
@@ -1,6 +1,8 @@
+import json
 from datetime import datetime, timezone
 
 import pytest
+from msgraph.generated.models.directory_audit import DirectoryAudit
 
 from graph_api.client import GraphApi
 
@@ -101,3 +103,34 @@ async def test_client_get_directory_audits_empty_1(graph_api_client: GraphApi, d
 
     assert [i.id for i in items] == ["3"]
     assert items[0].activity_display_name == "Add user"
+
+
+def test_encode_log_parses_modified_properties(
+    directory_audit_with_modified_properties: DirectoryAudit,
+) -> None:
+    result = json.loads(GraphApi.encode_log(directory_audit_with_modified_properties))
+
+    modified_props = result["targetResources"][0]["modifiedProperties"]
+
+    # ConditionalAccessPolicy: oldValue/newValue should be parsed into dicts
+    ca_prop = modified_props[0]
+    assert ca_prop["displayName"] == "ConditionalAccessPolicy"
+    assert isinstance(ca_prop["oldValue"], dict)
+    assert ca_prop["oldValue"]["State"] == "Disabled"
+    assert isinstance(ca_prop["newValue"], dict)
+    assert ca_prop["newValue"]["State"] == "Enabled"
+
+    # DisplayName: simple quoted strings should be parsed into plain strings
+    name_prop = modified_props[1]
+    assert name_prop["oldValue"] == "Old Policy Name"
+    assert name_prop["newValue"] == "New Policy Name"
+
+
+def test_encode_log_leaves_non_json_values_as_strings(
+    directory_audits_page_1: object,
+) -> None:
+    """Events without modifiedProperties should serialize without errors."""
+    audit = directory_audits_page_1.value[0]  # type: ignore[attr-defined]
+    result = json.loads(GraphApi.encode_log(audit))
+
+    assert result["activityDisplayName"] == "Add user"


### PR DESCRIPTION
Relates to [1394](https://github.com/SekoiaLab/integration/issues/1394)

## Summary by Sourcery

Parse directory audit log modifiedProperties JSON string fields into structured objects when encoding Microsoft Entra ID logs.

New Features:
- Convert JSON string oldValue and newValue fields in modifiedProperties of directory audit target resources into structured objects during log encoding.

Build:
- Bump Microsoft Entra ID integration version to 2.11.0 in the manifest.

Documentation:
- Document the modifiedProperties parsing behavior for directory audit events in the changelog.

Tests:
- Add fixtures and tests to validate parsing of modifiedProperties JSON strings and ensure events without modifiedProperties still serialize correctly.