### PR TITLE
CrowdStrike: Fix module due to changes in AWS

### DIFF
--- a/CrowdStrike/CHANGELOG.md
+++ b/CrowdStrike/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.12.5 - 2026-04-10
+
+### Fixed
+
+- Fix the autimation module following changes in the AWS automation module
+
 ## 1.12.4 - 2026-02-18
 
 ### Changed

--- a/CrowdStrike/crowdstrike_telemetry/__init__.py
+++ b/CrowdStrike/crowdstrike_telemetry/__init__.py
@@ -1,13 +1,16 @@
 """CrowdStrike Telemetry Module."""
 
-from connectors import AwsModule, AwsModuleConfiguration
-from pydantic.v1 import Field
+from connectors import AwsModule
+from pydantic.v1 import BaseModel, Field
 
 
-class CrowdStrikeTelemetryModuleConfig(AwsModuleConfiguration):
+class CrowdStrikeTelemetryModuleConfig(BaseModel):
     """Module Configuration."""
 
     aws_access_key: str = Field(alias="aws_access_key_id", description="The identifier of the access key")
+    aws_secret_access_key: str = Field(
+        secret=True, default=None, description="The secret associated to the access key"
+    )
     aws_region_name: str = Field(alias="aws_region", description="The area hosting the AWS resources")
 
 

--- a/CrowdStrike/manifest.json
+++ b/CrowdStrike/manifest.json
@@ -29,7 +29,7 @@
   "name": "CrowdStrike",
   "uuid": "4ffe6bd9-6693-414d-ade0-5ec9fb1b8b2c",
   "slug": "crowdstrike",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "categories": [
     "Endpoint"
   ]

--- a/CrowdStrike/tests/crowdstrike_telemetry/test_crowdstrike.py
+++ b/CrowdStrike/tests/crowdstrike_telemetry/test_crowdstrike.py
@@ -7,7 +7,7 @@ from concurrent.futures import Executor
 from contextlib import asynccontextmanager
 from functools import partial
 from typing import Any, AsyncIterable
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import aiofiles
 import orjson
@@ -161,14 +161,18 @@ async def test_crowdstrike_next_batch(
 
     connector.limit_of_events_to_push = 1  # to test multiple iterations of the loop
 
-    connector.sqs_wrapper = MagicMock()
-    connector.sqs_wrapper.receive_messages = MagicMock()
-    connector.sqs_wrapper.receive_messages.return_value.__aenter__.return_value = messages
+    mock_sqs = MagicMock()
+    mock_sqs.receive_messages = MagicMock()
+    mock_sqs.receive_messages.return_value.__aenter__.return_value = messages
 
-    connector.s3_wrapper = MagicMock()
-    connector.s3_wrapper.read_key = MagicMock()
-    connector.s3_wrapper.read_key.return_value.__aenter__.side_effect = read_key
+    mock_s3 = MagicMock()
+    mock_s3.read_key = MagicMock()
+    mock_s3.read_key.return_value.__aenter__.side_effect = read_key
 
-    total_events, times_to_log = await connector.next_batch()
+    with (
+        patch.object(CrowdStrikeTelemetryConnector, "sqs_wrapper", new_callable=PropertyMock, return_value=mock_sqs),
+        patch.object(CrowdStrikeTelemetryConnector, "s3_wrapper", new_callable=PropertyMock, return_value=mock_s3),
+    ):
+        total_events, times_to_log = await connector.next_batch()
 
     assert total_events == amount_of_messages * 2  # 2 events in test_data


### PR DESCRIPTION
Fix the autimation module following changes in the AWS automation module

## Summary by Sourcery

Update the CrowdStrike telemetry module configuration and tests to align with recent AWS automation changes and release a new patch version.

Bug Fixes:
- Adjust CrowdStrike telemetry configuration to explicitly handle AWS secret access keys after AWS module changes.
- Update telemetry tests to correctly mock SQS and S3 wrappers using property-based patching.

Build:
- Bump CrowdStrike integration version from 1.12.4 to 1.12.5 in the manifest.

Documentation:
- Add changelog entry documenting the AWS automation compatibility fix for version 1.12.5.