### PR TITLE
CI: disable some GitHub job for PRs created by dependabot

### DIFF
--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -127,7 +127,7 @@ jobs:
     name: Build ${{ matrix.module }} docker image
     runs-on: ubuntu-latest
     needs: find-modules
-    if: needs.find-modules.outputs.matrix != '[]' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: needs.find-modules.outputs.matrix != '[]' && github.actor != 'dependabot[bot]'
     strategy:
       matrix:
         module: ${{fromJSON(needs.find-modules.outputs.matrix)}}
@@ -210,7 +210,7 @@ jobs:
     name: Deploy modules
     runs-on: ubuntu-latest
     needs: [find-modules, build-docker]
-    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.find-modules.outputs.matrix != '[]' && github.event.pull_request.user.login != 'dependabot[bot]'}}
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.find-modules.outputs.matrix != '[]' }}
     strategy:
       matrix:
         module: ${{fromJSON(needs.find-modules.outputs.matrix)}}

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -127,7 +127,7 @@ jobs:
     name: Build ${{ matrix.module }} docker image
     runs-on: ubuntu-latest
     needs: find-modules
-    if: needs.find-modules.outputs.matrix != '[]'
+    if: needs.find-modules.outputs.matrix != '[]' && github.event.pull_request.user.login != 'dependabot[bot]'
     strategy:
       matrix:
         module: ${{fromJSON(needs.find-modules.outputs.matrix)}}
@@ -210,7 +210,7 @@ jobs:
     name: Deploy modules
     runs-on: ubuntu-latest
     needs: [find-modules, build-docker]
-    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.find-modules.outputs.matrix != '[]' }}
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.find-modules.outputs.matrix != '[]' && github.event.pull_request.user.login != 'dependabot[bot]'}}
     strategy:
       matrix:
         module: ${{fromJSON(needs.find-modules.outputs.matrix)}}

--- a/.github/workflows/generate-modules-list.yml
+++ b/.github/workflows/generate-modules-list.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/generate-modules-list.yml
+++ b/.github/workflows/generate-modules-list.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
I propose to bypass some jobs in Github workflows for PRs created by dependabot

## Summary by Sourcery

Update CI workflows to skip selected jobs for pull requests opened by Dependabot.

CI:
- Prevent the module image build job from running on Dependabot pull requests.
- Prevent the module deployment job from running on Dependabot pull requests.
- Skip the generate-modules-list workflow job when the pull request author is Dependabot.