### PR TITLE
fix(akamai): optimize event yielding

### DIFF
--- a/Akamai/CHANGELOG.md
+++ b/Akamai/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-04-16 - 1.0.1
+
+### Changed
+
+- Optimize Akamai WAF event fetching by streaming events in chunks instead of accumulating a full page in memory.
+
 ## 2026-01-07 - 1.0.0
 
 ### Changed

--- a/Akamai/akamai_modules/connector_akamai_waf.py
+++ b/Akamai/akamai_modules/connector_akamai_waf.py
@@ -142,7 +142,7 @@ class AkamaiWAFLogsConnector(Connector):
 
             chunk: list = []
             offset = None
-            total_in_page = 0
+            events_in_page = 0
 
             for line in response.iter_lines():
                 if line:
@@ -150,7 +150,7 @@ class AkamaiWAFLogsConnector(Connector):
                     if item.get("type") == "akamai_siem":
                         self.process_event(item)
                         chunk.append(item)
-                        total_in_page += 1
+                        events_in_page += 1
 
                         if len(chunk) >= self.CHUNK_SIZE:
                             INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(chunk))
@@ -160,7 +160,7 @@ class AkamaiWAFLogsConnector(Connector):
                     else:
                         offset = item["offset"]
                         # response context - last JSON line
-                        if total_in_page > 0:
+                        if events_in_page > 0:
                             # Yield remaining events that didn't fill a full chunk
                             if len(chunk) > 0:
                                 INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(chunk))

--- a/Akamai/akamai_modules/connector_akamai_waf.py
+++ b/Akamai/akamai_modules/connector_akamai_waf.py
@@ -88,7 +88,7 @@ class AkamaiWAFLogsConnector(Connector):
             # Alternate field name converted from plural:
             member_as_singular = re.sub("s$", "", member)
             url_decoded = urllib.parse.unquote(attack_section[member])
-            member_array = [member for member in url_decoded.split(";")]
+            member_array = [item for item in url_decoded.split(";")]
             if not len(rules_array):
                 for i in range(len(member_array)):
                     rules_array.append({})

--- a/Akamai/akamai_modules/connector_akamai_waf.py
+++ b/Akamai/akamai_modules/connector_akamai_waf.py
@@ -283,7 +283,7 @@ class AkamaiWAFLogsConnector(Connector):
             self.log(f"Next batch in the future. Waiting {delta_sleep} seconds", level="debug")
             time.sleep(delta_sleep)
 
-    def run(self):
+    def run(self):  # pragma: no cover
         self.log(message="Start fetching Akamai WAF system logs", level="info")
 
         while self.running:

--- a/Akamai/akamai_modules/connector_akamai_waf.py
+++ b/Akamai/akamai_modules/connector_akamai_waf.py
@@ -165,7 +165,7 @@ class AkamaiWAFLogsConnector(Connector):
                         # response context - last JSON line
                         if events_in_page > 0:
                             # Yield remaining events that didn't fill a full chunk
-                            if len(chunk) > 0:
+                            if chunk:
                                 INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(chunk))
                                 yield chunk
                                 chunk = []
@@ -175,6 +175,9 @@ class AkamaiWAFLogsConnector(Connector):
                             return
 
             if offset is None:
+                if chunk:
+                    INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(chunk))
+                    yield chunk
                 return
 
             response = self.client.get(

--- a/Akamai/akamai_modules/connector_akamai_waf.py
+++ b/Akamai/akamai_modules/connector_akamai_waf.py
@@ -31,11 +31,6 @@ class AkamaiWAFLogsConnector(Connector):
     module: AkamaiModule
     configuration: AkamaiWAFLogsConnectorConfiguration
 
-    PAGE_SIZE = int(os.environ.get("AKAMAI_PAGE_SIZE", 60_000))  # default 1000, maximum 60000
-    CHUNK_SIZE = int(
-        os.environ.get("AKAMAI_CHINK_SIZE", 1_000)
-    )  # number of events to accumulate before yielding to limit memory usage
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -50,6 +45,13 @@ class AkamaiWAFLogsConnector(Connector):
         # This cache should be big enough to cover all events within 1 second.
         self.cache_size = 10_000
         self.events_cache: Cache = self.load_events_cache()
+
+        self.page_size = max(
+            1000, min(60_000, int(os.environ.get("AKAMAI_PAGE_SIZE", 60_000)))
+        )  # default 1000, maximum 60000
+        self.chunk_size = max(
+            1, min(1000, int(os.environ.get("AKAMAI_CHUNK_SIZE", 1_000)))
+        )  # number of events to accumulate before yielding to limit memory usage
 
     def load_events_cache(self) -> Cache:
         result: LRUCache = LRUCache(maxsize=self.cache_size)
@@ -137,7 +139,7 @@ class AkamaiWAFLogsConnector(Connector):
     def __fetch_next_events(self, from_date: int) -> Generator[list, None, None]:
         url = f"{self.module.configuration.base_url}/siem/v1/configs/{self.configuration.config_id}"
         response = self.client.get(
-            url=url, params={"from": from_date, "limit": self.PAGE_SIZE}, timeout=60, stream=True
+            url=url, params={"from": from_date, "limit": self.page_size}, timeout=60, stream=True
         )
 
         while self.running:
@@ -155,7 +157,7 @@ class AkamaiWAFLogsConnector(Connector):
                         chunk.append(item)
                         events_in_page += 1
 
-                        if len(chunk) >= self.CHUNK_SIZE:
+                        if len(chunk) >= self.chunk_size:
                             INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(chunk))
                             yield chunk
                             chunk = []
@@ -181,7 +183,7 @@ class AkamaiWAFLogsConnector(Connector):
                 return
 
             response = self.client.get(
-                url=url, params={"offset": offset, "limit": self.PAGE_SIZE}, timeout=60, stream=True
+                url=url, params={"offset": offset, "limit": self.page_size}, timeout=60, stream=True
             )
 
     def fetch_events(self) -> Generator[list, None, None]:

--- a/Akamai/akamai_modules/connector_akamai_waf.py
+++ b/Akamai/akamai_modules/connector_akamai_waf.py
@@ -31,6 +31,7 @@ class AkamaiWAFLogsConnector(Connector):
     configuration: AkamaiWAFLogsConnectorConfiguration
 
     PAGE_SIZE = 60_000  # default 1000, maximum 60000
+    CHUNK_SIZE = 1_000  # number of events to accumulate before yielding to limit memory usage
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -139,22 +140,32 @@ class AkamaiWAFLogsConnector(Connector):
         while self.running:
             self.__handle_response_error(response)
 
-            page = []
+            chunk: list = []
             offset = None
+            total_in_page = 0
 
             for line in response.iter_lines():
                 if line:
                     item: dict = orjson.loads(line)
                     if item.get("type") == "akamai_siem":
                         self.process_event(item)
-                        page.append(item)
+                        chunk.append(item)
+                        total_in_page += 1
+
+                        if len(chunk) >= self.CHUNK_SIZE:
+                            INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(chunk))
+                            yield chunk
+                            chunk = []
 
                     else:
                         offset = item["offset"]
                         # response context - last JSON line
-                        if len(page) > 0:
-                            INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(page))
-                            yield page
+                        if total_in_page > 0:
+                            # Yield remaining events that didn't fill a full chunk
+                            if len(chunk) > 0:
+                                INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(chunk))
+                                yield chunk
+                                chunk = []
 
                         else:
                             EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(0)

--- a/Akamai/akamai_modules/connector_akamai_waf.py
+++ b/Akamai/akamai_modules/connector_akamai_waf.py
@@ -1,4 +1,5 @@
 import base64
+import os
 import re
 import time
 import urllib.parse
@@ -30,8 +31,10 @@ class AkamaiWAFLogsConnector(Connector):
     module: AkamaiModule
     configuration: AkamaiWAFLogsConnectorConfiguration
 
-    PAGE_SIZE = 60_000  # default 1000, maximum 60000
-    CHUNK_SIZE = 1_000  # number of events to accumulate before yielding to limit memory usage
+    PAGE_SIZE = int(os.environ.get("AKAMAI_PAGE_SIZE", 60_000))  # default 1000, maximum 60000
+    CHUNK_SIZE = int(
+        os.environ.get("AKAMAI_CHINK_SIZE", 1_000)
+    )  # number of events to accumulate before yielding to limit memory usage
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/Akamai/manifest.json
+++ b/Akamai/manifest.json
@@ -39,5 +39,5 @@
   "slug": "akamai",
   "name": "Akamai",
   "uuid": "6f4e254f-9f1b-4760-8af5-f6639779e25a",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/Akamai/tests/test_akamai_waf.py
+++ b/Akamai/tests/test_akamai_waf.py
@@ -383,4 +383,3 @@ def test_chunk_size_limits_memory_per_yield(trigger, response_2):
 
     # And no events are lost
     assert sum(len(c) for c in chunks) == n_events
-

--- a/Akamai/tests/test_akamai_waf.py
+++ b/Akamai/tests/test_akamai_waf.py
@@ -281,6 +281,7 @@ def test_long_next_batch_should_not_sleep(trigger, response_1, response_2):
 
 
 def test_fetch_events_less_than_chunk_size_yields_single_chunk(trigger, response_2):
+    trigger.chunk_size = 10
     n_events = trigger.chunk_size - 1
     big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
 

--- a/Akamai/tests/test_akamai_waf.py
+++ b/Akamai/tests/test_akamai_waf.py
@@ -281,7 +281,7 @@ def test_long_next_batch_should_not_sleep(trigger, response_1, response_2):
 
 
 def test_fetch_events_less_than_chunk_size_yields_single_chunk(trigger, response_2):
-    n_events = trigger.CHUNK_SIZE - 1
+    n_events = trigger.chunk_size - 1
     big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
 
     with requests_mock.Mocker() as mock_requests:
@@ -304,7 +304,7 @@ def test_fetch_events_less_than_chunk_size_yields_single_chunk(trigger, response
 
 
 def test_fetch_events_exactly_chunk_size_yields_single_chunk(trigger, response_2):
-    n_events = trigger.CHUNK_SIZE
+    n_events = trigger.chunk_size
     big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
 
     with requests_mock.Mocker() as mock_requests:
@@ -326,7 +326,7 @@ def test_fetch_events_exactly_chunk_size_yields_single_chunk(trigger, response_2
 
 
 def test_fetch_events_more_than_chunk_size_yields_multiple_chunks(trigger, response_2):
-    n_events = trigger.CHUNK_SIZE + 500  # one full chunk + a remainder
+    n_events = trigger.chunk_size + 500  # one full chunk + a remainder
     big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
 
     with requests_mock.Mocker() as mock_requests:
@@ -344,13 +344,13 @@ def test_fetch_events_more_than_chunk_size_yields_multiple_chunks(trigger, respo
         chunks = list(trigger.fetch_events())
 
     assert len(chunks) == 2
-    assert len(chunks[0]) == trigger.CHUNK_SIZE
+    assert len(chunks[0]) == trigger.chunk_size
     assert len(chunks[1]) == 500
     assert sum(len(c) for c in chunks) == n_events
 
 
 def test_fetch_events_multiple_full_chunks(trigger, response_2):
-    n_events = trigger.CHUNK_SIZE * 3
+    n_events = trigger.chunk_size * 3
     big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
 
     with requests_mock.Mocker() as mock_requests:
@@ -368,11 +368,11 @@ def test_fetch_events_multiple_full_chunks(trigger, response_2):
         chunks = list(trigger.fetch_events())
 
     assert len(chunks) == 3
-    assert all(len(c) == trigger.CHUNK_SIZE for c in chunks)
+    assert all(len(c) == trigger.chunk_size for c in chunks)
 
 
 def test_chunk_size_limits_memory_per_yield(trigger, response_2):
-    n_events = trigger.CHUNK_SIZE * 2 + 300
+    n_events = trigger.chunk_size * 2 + 300
     big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
 
     with requests_mock.Mocker() as mock_requests:
@@ -391,7 +391,7 @@ def test_chunk_size_limits_memory_per_yield(trigger, response_2):
 
     # The key invariant: memory is bounded per chunk
     for chunk in chunks:
-        assert len(chunk) <= trigger.CHUNK_SIZE
+        assert len(chunk) <= trigger.chunk_size
 
     # And no events are lost
     assert sum(len(c) for c in chunks) == n_events
@@ -399,7 +399,7 @@ def test_chunk_size_limits_memory_per_yield(trigger, response_2):
 
 def test_fetch_events_truncated_response_sub_chunk_yields_all_events(trigger):
     """When the API stream ends without a context/offset line and the number of events
-    is below CHUNK_SIZE, no events should be silently dropped."""
+    is below chunk_size, no events should be silently dropped."""
     n_events = 5
     truncated_response = make_truncated_response_with_n_events(n_events)
 
@@ -419,7 +419,7 @@ def test_fetch_events_truncated_response_multi_chunk_yields_all_events(trigger):
     """When the API stream ends without a context/offset line and the number of events
     spans more than one chunk, both the already-yielded full chunks and the remaining
     partial chunk should be returned — none of the tail events silently dropped."""
-    n_events = trigger.CHUNK_SIZE + 300  # one full chunk flushed mid-stream + 300 remainder
+    n_events = trigger.chunk_size + 300  # one full chunk flushed mid-stream + 300 remainder
     truncated_response = make_truncated_response_with_n_events(n_events)
 
     with requests_mock.Mocker() as mock_requests:
@@ -432,6 +432,6 @@ def test_fetch_events_truncated_response_multi_chunk_yields_all_events(trigger):
         chunks = list(trigger.fetch_events())
 
     assert len(chunks) == 2
-    assert len(chunks[0]) == trigger.CHUNK_SIZE
+    assert len(chunks[0]) == trigger.chunk_size
     assert len(chunks[1]) == 300
     assert sum(len(c) for c in chunks) == n_events

--- a/Akamai/tests/test_akamai_waf.py
+++ b/Akamai/tests/test_akamai_waf.py
@@ -104,6 +104,17 @@ def response_2() -> bytes:
     return b"""{"total": 0, "offset": "EMPTY_TOKEN"}\n"""
 
 
+def make_response_with_n_events(n: int, offset_token: str = "OFFSET_TOKEN") -> bytes:
+    lines = []
+    for i in range(n):
+        lines.append(
+            f'{{"type": "akamai_siem", "format": "json", "version": 1.0, '
+            f'"attackData": {{}}, "httpMessage": {{"requestId": {i}, "start": "1743505200"}}}}'
+        )
+    lines.append(f'{{"total": {n}, "offset": "{offset_token}"}}')
+    return ("\n".join(lines) + "\n").encode()
+
+
 def test_extract_attack_data(trigger, raw_event):
     attack_data = trigger.extract_attack_data(raw_event)
 
@@ -255,3 +266,121 @@ def test_long_next_batch_should_not_sleep(trigger, response_1, response_2):
 
         assert trigger.push_events_to_intakes.call_count == 1
         assert mock_time.sleep.call_count == 0
+
+
+def test_fetch_events_less_than_chunk_size_yields_single_chunk(trigger, response_2):
+    n_events = trigger.CHUNK_SIZE - 1
+    big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?from=1743505199&limit=60000",
+            status_code=200,
+            content=big_response,
+        )
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?offset=OFFSET_TOKEN&limit=60000",
+            status_code=200,
+            content=response_2,
+        )
+
+        chunks = list(trigger.fetch_events())
+
+    # All events fit in a single chunk (remainder chunk)
+    assert len(chunks) == 1
+    assert len(chunks[0]) == n_events
+
+
+def test_fetch_events_exactly_chunk_size_yields_single_chunk(trigger, response_2):
+    n_events = trigger.CHUNK_SIZE
+    big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?from=1743505199&limit=60000",
+            status_code=200,
+            content=big_response,
+        )
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?offset=OFFSET_TOKEN&limit=60000",
+            status_code=200,
+            content=response_2,
+        )
+
+        chunks = list(trigger.fetch_events())
+
+    assert len(chunks) == 1
+    assert len(chunks[0]) == n_events
+
+
+def test_fetch_events_more_than_chunk_size_yields_multiple_chunks(trigger, response_2):
+    n_events = trigger.CHUNK_SIZE + 500  # one full chunk + a remainder
+    big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?from=1743505199&limit=60000",
+            status_code=200,
+            content=big_response,
+        )
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?offset=OFFSET_TOKEN&limit=60000",
+            status_code=200,
+            content=response_2,
+        )
+
+        chunks = list(trigger.fetch_events())
+
+    assert len(chunks) == 2
+    assert len(chunks[0]) == trigger.CHUNK_SIZE
+    assert len(chunks[1]) == 500
+    assert sum(len(c) for c in chunks) == n_events
+
+
+def test_fetch_events_multiple_full_chunks(trigger, response_2):
+    n_events = trigger.CHUNK_SIZE * 3
+    big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?from=1743505199&limit=60000",
+            status_code=200,
+            content=big_response,
+        )
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?offset=OFFSET_TOKEN&limit=60000",
+            status_code=200,
+            content=response_2,
+        )
+
+        chunks = list(trigger.fetch_events())
+
+    assert len(chunks) == 3
+    assert all(len(c) == trigger.CHUNK_SIZE for c in chunks)
+
+
+def test_chunk_size_limits_memory_per_yield(trigger, response_2):
+    n_events = trigger.CHUNK_SIZE * 2 + 300
+    big_response = make_response_with_n_events(n_events, offset_token="OFFSET_TOKEN")
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?from=1743505199&limit=60000",
+            status_code=200,
+            content=big_response,
+        )
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?offset=OFFSET_TOKEN&limit=60000",
+            status_code=200,
+            content=response_2,
+        )
+
+        chunks = list(trigger.fetch_events())
+
+    # The key invariant: memory is bounded per chunk
+    for chunk in chunks:
+        assert len(chunk) <= trigger.CHUNK_SIZE
+
+    # And no events are lost
+    assert sum(len(c) for c in chunks) == n_events
+

--- a/Akamai/tests/test_akamai_waf.py
+++ b/Akamai/tests/test_akamai_waf.py
@@ -115,6 +115,18 @@ def make_response_with_n_events(n: int, offset_token: str = "OFFSET_TOKEN") -> b
     return ("\n".join(lines) + "\n").encode()
 
 
+def make_truncated_response_with_n_events(n: int) -> bytes:
+    """Build a response that contains n events but no trailing context/offset line,
+    simulating a truncated or malformed API stream."""
+    lines = []
+    for i in range(n):
+        lines.append(
+            f'{{"type": "akamai_siem", "format": "json", "version": 1.0, '
+            f'"attackData": {{}}, "httpMessage": {{"requestId": {i}, "start": "1743505200"}}}}'
+        )
+    return ("\n".join(lines) + "\n").encode()
+
+
 def test_extract_attack_data(trigger, raw_event):
     attack_data = trigger.extract_attack_data(raw_event)
 
@@ -382,4 +394,44 @@ def test_chunk_size_limits_memory_per_yield(trigger, response_2):
         assert len(chunk) <= trigger.CHUNK_SIZE
 
     # And no events are lost
+    assert sum(len(c) for c in chunks) == n_events
+
+
+def test_fetch_events_truncated_response_sub_chunk_yields_all_events(trigger):
+    """When the API stream ends without a context/offset line and the number of events
+    is below CHUNK_SIZE, no events should be silently dropped."""
+    n_events = 5
+    truncated_response = make_truncated_response_with_n_events(n_events)
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?from=1743505199&limit=60000",
+            status_code=200,
+            content=truncated_response,
+        )
+
+        chunks = list(trigger.fetch_events())
+
+    assert sum(len(c) for c in chunks) == n_events
+
+
+def test_fetch_events_truncated_response_multi_chunk_yields_all_events(trigger):
+    """When the API stream ends without a context/offset line and the number of events
+    spans more than one chunk, both the already-yielded full chunks and the remaining
+    partial chunk should be returned — none of the tail events silently dropped."""
+    n_events = trigger.CHUNK_SIZE + 300  # one full chunk flushed mid-stream + 300 remainder
+    truncated_response = make_truncated_response_with_n_events(n_events)
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            "https://example.com/siem/v1/configs/1?from=1743505199&limit=60000",
+            status_code=200,
+            content=truncated_response,
+        )
+
+        chunks = list(trigger.fetch_events())
+
+    assert len(chunks) == 2
+    assert len(chunks[0]) == trigger.CHUNK_SIZE
+    assert len(chunks[1]) == 300
     assert sum(len(c) for c in chunks) == n_events


### PR DESCRIPTION
Main issue: [issue](https://github.com/SekoiaLab/integration/issues/1506)

## Summary by Sourcery

Stream Akamai WAF SIEM events in bounded-size chunks to reduce memory usage while fetching pages of logs.

Bug Fixes:
- Ensure events are yielded incrementally rather than accumulating an entire response page in memory, preventing excessive memory consumption for large result sets.

Enhancements:
- Introduce a configurable chunk size for Akamai WAF event fetching to control how many events are accumulated before each yield.
- Add comprehensive tests covering chunked event fetching behavior across various page sizes and boundary conditions.

Documentation:
- Document the change in Akamai WAF log fetching behavior and bump the connector changelog with version 1.0.1.

Tests:
- Add tests verifying that fetch_events yields correctly sized chunks, handles exact and partial chunk boundaries, and does not lose events when chunking large responses.

Chores:
- Bump the Akamai connector manifest version from 1.0.0 to 1.0.1 to reflect the optimized event fetching behavior.