### PR TITLE
feat: Add incident entities to Microsoft Sentinel

### DIFF
--- a/MicrosoftSentinel/CHANGELOG.md
+++ b/MicrosoftSentinel/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.1.0
+
+### Added
+- Fetch and forward incident entities from the list-entities endpoint.
+
 ## 2025-02-03 - 1.0.0
 
 ### Added

--- a/MicrosoftSentinel/manifest.json
+++ b/MicrosoftSentinel/manifest.json
@@ -45,7 +45,7 @@
   "name": "Microsoft Sentinel",
   "uuid": "ba910388-ba3b-405a-8cb5-cb5953796470",
   "slug": "microsoft-sentinel",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "categories": [
     "Cloud Providers"
   ]

--- a/MicrosoftSentinel/microsoft_sentinel/connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/microsoft_sentinel/connector_microsoft_sentinel.py
@@ -70,6 +70,29 @@ class MicrosoftSentineldConnector(Connector):
             filter=self.incidents_filter,
         )  # type: ignore
 
+    def _get_incident_entities(self, incident_id: str) -> list[Dict[str, Any]]:
+        """
+        Fetch entities for a given incident.
+        """
+        try:
+            response = self.client.incidents.list_entities(
+                resource_group_name=self.module.configuration.resource_group,
+                workspace_name=self.module.configuration.workspace_name,
+                incident_id=incident_id
+            )
+            entities = getattr(response, "entities", response)
+            if entities:
+                return [
+                    entity.as_dict() if hasattr(entity, "as_dict") else (
+                        entity.serialize() if hasattr(entity, "serialize") else dict(entity)
+                    )
+                    for entity in entities
+                ]
+            return []
+        except Exception as e:
+            self.log_exception(e, message=f"Failed to fetch entities for incident {incident_id}")
+            return []
+
     def _serialize_incident(self, incident: Incident) -> Dict[str, Any]:
         keys_to_extract = list(MicrosoftSentinelResponseModel.__fields__.keys())
         conversion_map: Dict[type, Callable[[Any], Any]] = {
@@ -80,7 +103,7 @@ class MicrosoftSentineldConnector(Connector):
         new_dict = {}
 
         for key in keys_to_extract:
-            value = getattr(incident, key)
+            value = getattr(incident, key, None)
             if isinstance(value, list) and all(isinstance(item, IncidentLabel) for item in value):
                 new_dict[key] = [labels_data_to_dict(item) for item in value]
             elif type(value) in conversion_map:
@@ -107,6 +130,15 @@ class MicrosoftSentineldConnector(Connector):
         for item in response:
             created_time = item.created_time_utc
             serialezed_incident = self._serialize_incident(item)
+            
+            incident_id = getattr(item, "name", None)
+            if incident_id:
+                entities = self._get_incident_entities(incident_id)
+                if entities:
+                    serialezed_incident["Entities"] = entities
+                    # Also keep lowercased to match model key if preferred
+                    serialezed_incident["entities"] = entities
+
             jsonify_item = orjson.dumps(serialezed_incident).decode("utf-8")
             alerts_batch.append(jsonify_item)
 

--- a/MicrosoftSentinel/microsoft_sentinel/connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/microsoft_sentinel/connector_microsoft_sentinel.py
@@ -81,25 +81,13 @@ class MicrosoftSentineldConnector(Connector):
                 workspace_name=self.module.configuration.workspace_name,
                 incident_id=incident_id,
             )
-            entities: Any = getattr(response, "entities", response)
+            entities: Any = getattr(response, "entities", None)
             if not entities:
                 return []
 
             parsed_entities = []
             for entity in entities:
-                if hasattr(entity, "as_dict"):
-                    parsed_entities.append(entity.as_dict())
-                elif hasattr(entity, "serialize"):
-                    parsed_entities.append(entity.serialize())
-                elif isinstance(entity, dict):
-                    parsed_entities.append(entity)
-                else:
-                    try:
-                        parsed_entities.append(dict(entity))
-                    except (TypeError, ValueError):
-                        self.log(
-                            level="warning", message=f"Could not reliably parse entity for incident {incident_id}"
-                        )
+                parsed_entities.append(entity.as_dict())
 
             return parsed_entities
 
@@ -146,15 +134,14 @@ class MicrosoftSentineldConnector(Connector):
         incoming_events_sum = 0
         for item in response:
             created_time = item.created_time_utc
-            serialezed_incident = self._serialize_incident(item)
+            serialized_incident = self._serialize_incident(item)
 
             incident_id = getattr(item, "name", None)
             if incident_id:
                 entities = self._get_incident_entities(incident_id)
-                if entities:
-                    serialezed_incident["entities"] = entities
+                serialized_incident["entities"] = entities
 
-            jsonify_item = orjson.dumps(serialezed_incident).decode("utf-8")
+            jsonify_item = orjson.dumps(serialized_incident).decode("utf-8")
             alerts_batch.append(jsonify_item)
 
             if stored_time is None:

--- a/MicrosoftSentinel/microsoft_sentinel/connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/microsoft_sentinel/connector_microsoft_sentinel.py
@@ -78,13 +78,15 @@ class MicrosoftSentineldConnector(Connector):
             response = self.client.incidents.list_entities(
                 resource_group_name=self.module.configuration.resource_group,
                 workspace_name=self.module.configuration.workspace_name,
-                incident_id=incident_id
+                incident_id=incident_id,
             )
-            entities = getattr(response, "entities", response)
+            entities: Any = getattr(response, "entities", response)
             if entities:
                 return [
-                    entity.as_dict() if hasattr(entity, "as_dict") else (
-                        entity.serialize() if hasattr(entity, "serialize") else dict(entity)
+                    (
+                        entity.as_dict()
+                        if hasattr(entity, "as_dict")
+                        else (entity.serialize() if hasattr(entity, "serialize") else dict(entity))
                     )
                     for entity in entities
                 ]
@@ -100,7 +102,7 @@ class MicrosoftSentineldConnector(Connector):
             IncidentOwnerInfo: owner_data_to_dict,
             date_time.datetime: lambda dt: dt.isoformat(),
         }
-        new_dict = {}
+        new_dict: Dict[str, Any] = {}
 
         for key in keys_to_extract:
             value = getattr(incident, key, None)
@@ -130,7 +132,7 @@ class MicrosoftSentineldConnector(Connector):
         for item in response:
             created_time = item.created_time_utc
             serialezed_incident = self._serialize_incident(item)
-            
+
             incident_id = getattr(item, "name", None)
             if incident_id:
                 entities = self._get_incident_entities(incident_id)

--- a/MicrosoftSentinel/microsoft_sentinel/connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/microsoft_sentinel/connector_microsoft_sentinel.py
@@ -13,6 +13,7 @@ from requests.exceptions import HTTPError
 from azure.identity import ClientSecretCredential
 from azure.mgmt.securityinsight import SecurityInsights
 from azure.core.paging import ItemPaged
+from azure.core.exceptions import AzureError
 from azure.mgmt.securityinsight.models import IncidentAdditionalData, IncidentOwnerInfo, Incident, IncidentLabel
 
 from sekoia_automation.connector import Connector
@@ -81,18 +82,32 @@ class MicrosoftSentineldConnector(Connector):
                 incident_id=incident_id,
             )
             entities: Any = getattr(response, "entities", response)
-            if entities:
-                return [
-                    (
-                        entity.as_dict()
-                        if hasattr(entity, "as_dict")
-                        else (entity.serialize() if hasattr(entity, "serialize") else dict(entity))
-                    )
-                    for entity in entities
-                ]
+            if not entities:
+                return []
+
+            parsed_entities = []
+            for entity in entities:
+                if hasattr(entity, "as_dict"):
+                    parsed_entities.append(entity.as_dict())
+                elif hasattr(entity, "serialize"):
+                    parsed_entities.append(entity.serialize())
+                elif isinstance(entity, dict):
+                    parsed_entities.append(entity)
+                else:
+                    try:
+                        parsed_entities.append(dict(entity))
+                    except (TypeError, ValueError):
+                        self.log(
+                            level="warning", message=f"Could not reliably parse entity for incident {incident_id}"
+                        )
+
+            return parsed_entities
+
+        except AzureError as e:
+            self.log_exception(e, message=f"AzureError while fetching entities for incident {incident_id}")
             return []
         except Exception as e:
-            self.log_exception(e, message=f"Failed to fetch entities for incident {incident_id}")
+            self.log_exception(e, message=f"Unexpected error while fetching entities for incident {incident_id}")
             return []
 
     def _serialize_incident(self, incident: Incident) -> Dict[str, Any]:
@@ -137,8 +152,6 @@ class MicrosoftSentineldConnector(Connector):
             if incident_id:
                 entities = self._get_incident_entities(incident_id)
                 if entities:
-                    serialezed_incident["Entities"] = entities
-                    # Also keep lowercased to match model key if preferred
                     serialezed_incident["entities"] = entities
 
             jsonify_item = orjson.dumps(serialezed_incident).decode("utf-8")

--- a/MicrosoftSentinel/microsoft_sentinel/models.py
+++ b/MicrosoftSentinel/microsoft_sentinel/models.py
@@ -58,3 +58,4 @@ class MicrosoftSentinelResponseModel(BaseModel):
     severity: Optional[str]
     status: Optional[str]
     title: Optional[str]
+    entities: Optional[List[Dict[str, Any]]] = None

--- a/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
@@ -1,7 +1,7 @@
 import pytest
 import orjson
 from datetime import datetime, timezone
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, call
 
 
 from microsoft_sentinel import MicrosoftSentinelModule
@@ -160,14 +160,17 @@ def test_get_incidents_without_batch(trigger, incidents_list):
         mock_get_incident_entities.return_value = [{"id": "dummy_entity_id"}]
 
         trigger.get_incidents()
-        results = [call.kwargs["events"] for call in trigger.push_events_to_intakes.call_args_list]
+        results = [c.kwargs["events"] for c in trigger.push_events_to_intakes.call_args_list]
 
         assert len(results[0]) == 2
 
+        assert mock_get_incident_entities.call_count == len(incidents_list)
+        assert mock_get_incident_entities.call_args_list == [call(incident.name) for incident in incidents_list]
+
         parsed_first = orjson.loads(results[0][0])
         assert parsed_first["title"] == "title"
-        assert parsed_first["Entities"] == [{"id": "dummy_entity_id"}]
+        assert parsed_first["entities"] == [{"id": "dummy_entity_id"}]
 
         parsed_second = orjson.loads(results[0][1])
         assert parsed_second["title"] == "title 2"
-        assert parsed_second["Entities"] == [{"id": "dummy_entity_id"}]
+        assert parsed_second["entities"] == [{"id": "dummy_entity_id"}]

--- a/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
@@ -148,11 +148,14 @@ def test_serialize_incident(trigger, first_incident_item):
 
 
 def test_get_incidents_without_batch(trigger, incidents_list):
-    with patch(
-        "microsoft_sentinel.connector_microsoft_sentinel.MicrosoftSentineldConnector._incidents_iterator"
-    ) as mock_incidents_iterator, patch(
-        "microsoft_sentinel.connector_microsoft_sentinel.MicrosoftSentineldConnector._get_incident_entities"
-    ) as mock_get_incident_entities:
+    with (
+        patch(
+            "microsoft_sentinel.connector_microsoft_sentinel.MicrosoftSentineldConnector._incidents_iterator"
+        ) as mock_incidents_iterator,
+        patch(
+            "microsoft_sentinel.connector_microsoft_sentinel.MicrosoftSentineldConnector._get_incident_entities"
+        ) as mock_get_incident_entities,
+    ):
         mock_incidents_iterator.return_value = incidents_list
         mock_get_incident_entities.return_value = [{"id": "dummy_entity_id"}]
 
@@ -160,11 +163,11 @@ def test_get_incidents_without_batch(trigger, incidents_list):
         results = [call.kwargs["events"] for call in trigger.push_events_to_intakes.call_args_list]
 
         assert len(results[0]) == 2
-        
+
         parsed_first = orjson.loads(results[0][0])
         assert parsed_first["title"] == "title"
         assert parsed_first["Entities"] == [{"id": "dummy_entity_id"}]
-        
+
         parsed_second = orjson.loads(results[0][1])
         assert parsed_second["title"] == "title 2"
         assert parsed_second["Entities"] == [{"id": "dummy_entity_id"}]

--- a/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
@@ -180,39 +180,19 @@ def test_get_incident_entities_coverage(trigger):
     from azure.core.exceptions import AzureError
     from unittest.mock import MagicMock
 
-    # Case 1: as_dict
     class EntityAsDict:
         def as_dict(self):
             return {"type": "as_dict"}
 
-    # Case 2: serialize
-    class EntitySerialize:
-        def serialize(self):
-            return {"type": "serialize"}
-
-    # Case 3: dict parse
-    class EntityDictParse:
-        def __iter__(self):
-            yield "type", "dict_parse"
-
-    # Case 4: Exception type
-    class EntityDictError:
-        pass
-
-    entity_dict = {"type": "dict"}
-
     mock_response = MagicMock()
-    mock_response.entities = [EntityAsDict(), EntitySerialize(), entity_dict, EntityDictParse(), EntityDictError()]
+    mock_response.entities = [EntityAsDict()]
 
     trigger.client = MagicMock()
     trigger.client.incidents.list_entities.return_value = mock_response
 
     res = trigger._get_incident_entities("inc1")
-    assert len(res) == 4
+    assert len(res) == 1
     assert res[0] == {"type": "as_dict"}
-    assert res[1] == {"type": "serialize"}
-    assert res[2] == {"type": "dict"}
-    assert res[3] == {"type": "dict_parse"}
 
     # Test exceptions
     trigger.client.incidents.list_entities.side_effect = AzureError("azure_err")
@@ -228,9 +208,9 @@ def test_get_incident_entities_coverage(trigger):
     # Test when response has no entities attribute at all
     mock_response_no_entities = MagicMock()
     del mock_response_no_entities.entities
+    trigger.client.incidents.list_entities.side_effect = None
     trigger.client.incidents.list_entities.return_value = mock_response_no_entities
     assert trigger._get_incident_entities("inc1") == []
-    trigger.client.incidents.list_entities.side_effect = None
     trigger.client.incidents.list_entities.return_value = mock_response_empty
     assert trigger._get_incident_entities("inc1") == []
 

--- a/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
@@ -223,7 +223,13 @@ def test_get_incident_entities_coverage(trigger):
 
     # Test None / no entities
     mock_response_empty = MagicMock()
-    del mock_response_empty.entities
+    mock_response_empty.entities = []
+    
+    # Test when response has no entities attribute at all
+    mock_response_no_entities = MagicMock()
+    del mock_response_no_entities.entities
+    trigger.client.incidents.list_entities.return_value = mock_response_no_entities
+    assert trigger._get_incident_entities("inc1") == []
     trigger.client.incidents.list_entities.side_effect = None
     trigger.client.incidents.list_entities.return_value = mock_response_empty
     assert trigger._get_incident_entities("inc1") == []

--- a/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
@@ -224,7 +224,7 @@ def test_get_incident_entities_coverage(trigger):
     # Test None / no entities
     mock_response_empty = MagicMock()
     mock_response_empty.entities = []
-    
+
     # Test when response has no entities attribute at all
     mock_response_no_entities = MagicMock()
     del mock_response_no_entities.entities
@@ -233,3 +233,39 @@ def test_get_incident_entities_coverage(trigger):
     trigger.client.incidents.list_entities.side_effect = None
     trigger.client.incidents.list_entities.return_value = mock_response_empty
     assert trigger._get_incident_entities("inc1") == []
+
+
+def test_run_method_coverage(trigger):
+    from requests.exceptions import HTTPError
+
+    # We will control the while loop by changing trigger._stop_event to True after one iteration
+    def mock_get_incidents():
+        trigger._stop_event.set()
+
+    trigger.get_incidents = mock_get_incidents
+
+    # normal run
+    trigger._stop_event.clear()
+    trigger.run()
+
+    # HTTPError run
+    def mock_get_incidents_http():
+        trigger._stop_event.set()
+        raise HTTPError("http error")
+
+    trigger.get_incidents = mock_get_incidents_http
+    trigger._stop_event.clear()
+    trigger.run()
+
+    # Exception run
+    def mock_get_incidents_err():
+        trigger._stop_event.set()
+        raise Exception("generic error")
+
+    trigger.get_incidents = mock_get_incidents_err
+    trigger._stop_event.clear()
+
+    import pytest
+
+    with pytest.raises(Exception):
+        trigger.run()

--- a/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
@@ -150,11 +150,21 @@ def test_serialize_incident(trigger, first_incident_item):
 def test_get_incidents_without_batch(trigger, incidents_list):
     with patch(
         "microsoft_sentinel.connector_microsoft_sentinel.MicrosoftSentineldConnector._incidents_iterator"
-    ) as mock_incidents_iterator:
+    ) as mock_incidents_iterator, patch(
+        "microsoft_sentinel.connector_microsoft_sentinel.MicrosoftSentineldConnector._get_incident_entities"
+    ) as mock_get_incident_entities:
         mock_incidents_iterator.return_value = incidents_list
+        mock_get_incident_entities.return_value = [{"id": "dummy_entity_id"}]
+
         trigger.get_incidents()
         results = [call.kwargs["events"] for call in trigger.push_events_to_intakes.call_args_list]
 
         assert len(results[0]) == 2
-        assert orjson.loads(results[0][0])["title"] == "title"
-        assert orjson.loads(results[0][1])["title"] == "title 2"
+        
+        parsed_first = orjson.loads(results[0][0])
+        assert parsed_first["title"] == "title"
+        assert parsed_first["Entities"] == [{"id": "dummy_entity_id"}]
+        
+        parsed_second = orjson.loads(results[0][1])
+        assert parsed_second["title"] == "title 2"
+        assert parsed_second["Entities"] == [{"id": "dummy_entity_id"}]

--- a/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
+++ b/MicrosoftSentinel/tests/test_connector_microsoft_sentinel.py
@@ -174,3 +174,56 @@ def test_get_incidents_without_batch(trigger, incidents_list):
         parsed_second = orjson.loads(results[0][1])
         assert parsed_second["title"] == "title 2"
         assert parsed_second["entities"] == [{"id": "dummy_entity_id"}]
+
+
+def test_get_incident_entities_coverage(trigger):
+    from azure.core.exceptions import AzureError
+    from unittest.mock import MagicMock
+
+    # Case 1: as_dict
+    class EntityAsDict:
+        def as_dict(self):
+            return {"type": "as_dict"}
+
+    # Case 2: serialize
+    class EntitySerialize:
+        def serialize(self):
+            return {"type": "serialize"}
+
+    # Case 3: dict parse
+    class EntityDictParse:
+        def __iter__(self):
+            yield "type", "dict_parse"
+
+    # Case 4: Exception type
+    class EntityDictError:
+        pass
+
+    entity_dict = {"type": "dict"}
+
+    mock_response = MagicMock()
+    mock_response.entities = [EntityAsDict(), EntitySerialize(), entity_dict, EntityDictParse(), EntityDictError()]
+
+    trigger.client = MagicMock()
+    trigger.client.incidents.list_entities.return_value = mock_response
+
+    res = trigger._get_incident_entities("inc1")
+    assert len(res) == 4
+    assert res[0] == {"type": "as_dict"}
+    assert res[1] == {"type": "serialize"}
+    assert res[2] == {"type": "dict"}
+    assert res[3] == {"type": "dict_parse"}
+
+    # Test exceptions
+    trigger.client.incidents.list_entities.side_effect = AzureError("azure_err")
+    assert trigger._get_incident_entities("inc1") == []
+
+    trigger.client.incidents.list_entities.side_effect = Exception("err")
+    assert trigger._get_incident_entities("inc1") == []
+
+    # Test None / no entities
+    mock_response_empty = MagicMock()
+    del mock_response_empty.entities
+    trigger.client.incidents.list_entities.side_effect = None
+    trigger.client.incidents.list_entities.return_value = mock_response_empty
+    assert trigger._get_incident_entities("inc1") == []


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1445

## Summary by Sourcery

Add support for retrieving and including Microsoft Sentinel incident entities in exported incidents and bump the integration version.

New Features:
- Retrieve incident entities from the Microsoft Sentinel list-entities endpoint and attach them to exported incidents.

Enhancements:
- Improve incident serialization robustness when optional fields are missing.

Build:
- Bump the Microsoft Sentinel integration manifest version to 1.1.0.

Documentation:
- Document the new incident entities support in the changelog.

Tests:
- Extend connector tests to cover inclusion of incident entities in pushed events.