### PR TITLE
Stormshield: remove invalid gitattributes fiels

### DIFF
--- a/Stormshield/.gitattributes
+++ b/Stormshield/.gitattributes
@@ -1,1 +1,0 @@
-git config --global core.autocrlf false


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the obsolete or invalid Stormshield/.gitattributes configuration file from version control.