### PR TITLE
fix(sophos): fix sophos whoami url

### DIFF
--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-23 - 1.18.1
+
+### Added
+
+- Update whoami for the Sophos Device Asset Connector to use the account validator
+
 ## 2026-04-23 - 1.18.0
 
 ### Added

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,7 +38,7 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "categories": [
     "Endpoint",
     "Network"

--- a/Sophos/sophos_module/client/auth.py
+++ b/Sophos/sophos_module/client/auth.py
@@ -87,8 +87,9 @@ class SophosApiAuthentication(AuthBase):
         Call the Whoami endpoint to get tenancy information
         """
         # Get the whoami
+        # Doc: https://developer.sophos.com/intro
         response = self.__http_session.get(
-            url=f"{self.__api_host}/whoami/v1",
+            url="https://api.central.sophos.com/whoami/v1",
             headers={"Authorization": credentials.authorization},
         )
 


### PR DESCRIPTION
As i have 504 http error on sophos asset connector. So i changed the whoami url.
I don't know why is it working for other event connectors

## Summary by Sourcery

Update the Sophos connector to use the documented global whoami endpoint and bump the connector version.

Bug Fixes:
- Fix Sophos Device Asset Connector whoami calls by switching to the official global whoami URL.

Documentation:
- Add changelog entry documenting the whoami URL change for the Sophos Device Asset Connector.