### PR TITLE
Fix: Jira Add Public Comment (1491)

### DIFF
--- a/JIRA/CHANGELOG.md
+++ b/JIRA/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-24 - 1.5.0
+
+### Added
+
+- Add `public` argument to the "Comment Issue" action to post public comments on Jira
+
 ## 2025-12-17 - 1.4.1
 
 ### Fixed

--- a/JIRA/action_comment_issue.json
+++ b/JIRA/action_comment_issue.json
@@ -17,6 +17,12 @@
         "title": "Comment",
         "description": "Text of a comment",
         "type": "string"
+      },
+      "public": {
+        "title": "Public",
+        "description": "If true, the comment is posted as public (visible to customers) on Jira Service Management issues. If false, the comment is internal. Has no effect on non-JSM issues.",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": [

--- a/JIRA/jira_modules/action_comment_issue.py
+++ b/JIRA/jira_modules/action_comment_issue.py
@@ -7,6 +7,7 @@ from .base import JIRAModule
 class JiraAddCommentArguments(BaseModel):
     issue_key: str = Field(..., description="Issue key (e.g. PROJ-1)")
     comment: str = Field(..., description="Text of a comment")
+    public: bool = False
 
 
 class JIRAAddCommentToIssue(JIRAAction):
@@ -14,27 +15,36 @@ class JIRAAddCommentToIssue(JIRAAction):
     description = "Add a comment to an issue"
     module: JIRAModule
 
-    def add_comment_to_issue(self, issue_key: str, comment: str) -> dict | None:
-        return self.post_json(
-            path=f"issue/{issue_key}/comment",
-            json={
-                "body": {
-                    "content": [
-                        {
-                            "content": [
-                                {
-                                    "text": comment,
-                                    "type": "text",
-                                }
-                            ],
-                            "type": "paragraph",
-                        }
-                    ],
-                    "type": "doc",
-                    "version": 1,
-                }
+    def add_comment_to_issue(self, issue_key: str, comment: str, public: bool = False) -> dict | None:
+        payload: dict = {
+            "body": {
+                "content": [
+                    {
+                        "content": [
+                            {
+                                "text": comment,
+                                "type": "text",
+                            }
+                        ],
+                        "type": "paragraph",
+                    }
+                ],
+                "type": "doc",
+                "version": 1,
             },
-        )
+            "properties": [
+                {
+                    "key": "sd.public.comment",
+                    "value": {"internal": not public},
+                }
+            ],
+        }
+
+        return self.post_json(path=f"issue/{issue_key}/comment", json=payload)
 
     def run(self, arguments: JiraAddCommentArguments) -> None:
-        self.add_comment_to_issue(issue_key=arguments.issue_key, comment=arguments.comment)
+        self.add_comment_to_issue(
+            issue_key=arguments.issue_key,
+            comment=arguments.comment,
+            public=arguments.public,
+        )

--- a/JIRA/manifest.json
+++ b/JIRA/manifest.json
@@ -2,7 +2,7 @@
   "uuid": "d1445e5e-8e3b-417f-ae19-bca67a10affd",
   "name": "Atlassian JIRA",
   "slug": "atlassian-jira",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Atlassian JIRA is a popular project management and issue-tracking software designed to help teams plan, track, and manage agile software development projects efficiently. It offers customizable workflows and integrates seamlessly with other Atlassian products.",
   "configuration": {
     "title": "JIRA",

--- a/JIRA/tests/test_comment_issue.py
+++ b/JIRA/tests/test_comment_issue.py
@@ -1,8 +1,6 @@
-import time
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock
 
 import pytest
-import requests.exceptions
 import requests_mock
 
 from jira_modules.action_comment_issue import JiraAddCommentArguments, JIRAAddCommentToIssue
@@ -25,7 +23,7 @@ def action():
     return action
 
 
-def test_add_comment(action: JIRAAddCommentToIssue):
+def test_add_comment_defaults_to_internal(action: JIRAAddCommentToIssue):
     with requests_mock.Mocker() as mock:
         mock.register_uri(
             "POST",
@@ -34,3 +32,18 @@ def test_add_comment(action: JIRAAddCommentToIssue):
         )
         args = JiraAddCommentArguments(issue_key="PRJ-1", comment="Hello, world")
         action.run(args)
+
+        assert mock.last_request.json()["properties"] == [{"key": "sd.public.comment", "value": {"internal": True}}]
+
+
+def test_add_public_comment(action: JIRAAddCommentToIssue):
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            "https://test.atlassian.net/rest/api/3/issue/PRJ-1/comment",
+            json={},
+        )
+        args = JiraAddCommentArguments(issue_key="PRJ-1", comment="Hello, world", public=True)
+        action.run(args)
+
+        assert mock.last_request.json()["properties"] == [{"key": "sd.public.comment", "value": {"internal": False}}]


### PR DESCRIPTION
Relates to [1491](https://github.com/SekoiaLab/integration/issues/1491)

## Summary by Sourcery

Allow Jira issue comments to be posted as either internal or public and bump the JIRA integration version.

New Features:
- Add a `public` flag to the Jira "Comment Issue" action to control whether a comment is internal or public.

Build:
- Bump the JIRA integration manifest version from 1.4.1 to 1.5.0.

Documentation:
- Update the JIRA changelog with a new 1.5.0 release entry describing the new `public` argument.

Tests:
- Add tests to verify that comments default to internal and that setting `public` to true posts a public comment.