### PR TITLE
fix(MicrosoftAD) : Fix pydantic model

### DIFF
--- a/MicrosoftActiveDirectory/CHANGELOG.md
+++ b/MicrosoftActiveDirectory/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-24 - 1.5.4
+
+### Fixed
+
+- Fix `AttributeError` on `basedn` field due to Pydantic v1/v2 mismatch in `MicrosoftADConnectorConfiguration`
+
 ## 2026-04-10 - 1.5.3
 
 ### Fixed
 
 - Fix field mappings in `user_mapping.yml` to align with the actual OCSF models
-=======
+
 ## 2026-04-14 - 1.5.2
 
 ### Changed

--- a/MicrosoftActiveDirectory/manifest.json
+++ b/MicrosoftActiveDirectory/manifest.json
@@ -32,7 +32,7 @@
   "name": "Microsoft Active Directory",
   "uuid": "b2d96259-af89-4f7a-ae6e-a0af2d2400f3",
   "slug": "microsoft-ad",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftActiveDirectory/microsoft_ad/models/common_models.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/models/common_models.py
@@ -16,7 +16,7 @@ class MicrosoftADModule(Module):
 
 
 class MicrosoftADConnectorConfiguration(DefaultAssetConnectorConfiguration):
-    basedn: str | None = Field(None, description="Active directory basedn")
+    basedn: str | None = None
 
 
 class LDAPUserAttributes(BaseModel):


### PR DESCRIPTION
- Main issue : [Issue](https://github.com/SekoiaLab/integration/issues/1521)

## Summary by Sourcery

Fix configuration model compatibility for the Microsoft Active Directory connector.

Bug Fixes:
- Prevent AttributeError on the basedn configuration field caused by Pydantic v1/v2 behavior differences.

Documentation:
- Document the 1.5.4 release with the Microsoft Active Directory connector configuration fix in the changelog.

Chores:
- Bump Microsoft Active Directory integration version to 1.5.4 in the manifest.