### PR TITLE
fix(crowdstrike): fix organization field

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-27 - 1.25.14
+
+### Fixed
+
+- Fix `Organization` model validation error when `service_provider` is `None` by using a fallback value `"Unknown"`
+
 ## 2026-04-14 - 1.25.13
 
 ### Changed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
@@ -238,7 +238,7 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
         if cid:
             return Organization(
                 uid=cid,
-                name=device.service_provider,
+                name=device.service_provider or "Unknown",
             )
         return None
 

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "CrowdStrike Falcon is a cloud-native cybersecurity platform known for its advanced threat detection, endpoint protection, and real-time response capabilities. It leverages AI and machine learning to protect against malware and sophisticated cyberattacks.",
-  "version": "1.25.12",
+  "version": "1.25.14",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {


### PR DESCRIPTION
Main issue: [issue](https://github.com/SekoiaLab/integration/issues/1552)

## Summary by Sourcery

Fix CrowdStrike Falcon organization name handling when the service provider field is missing or null.

Bug Fixes:
- Prevent Organization model validation errors by defaulting the organization name to "Unknown" when the device service_provider is None.

Build:
- Bump the CrowdStrike Falcon integration version to 1.25.14.

Documentation:
- Document the organization name fallback fix in the CrowdStrike Falcon changelog.