### PR TITLE
Office365: Clean up the way to shutdown the connector

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Log as critical when failing to activate the subscription
-- Fix the way to shutdown the connector
+- Fix the way to shut down the connector
 
 ## 2026-04-16 - 2.20.2
 

--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-27 - 2.20.3
+
+### Fixed
+
+- Log as critical when failing to activate the subscription
+- Fix the way to shutdown the connector
+
 ## 2026-04-16 - 2.20.2
 
 ### Fixed

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "categories": [
     "Email"
   ]

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -168,7 +168,7 @@ class Office365Connector(AsyncConnector):
 
     def _handle_stop_signal(self, loop):
         """
-        Handle gracefully the shutdown
+        Handle graceful shutdown
         """
         self.log(message="Received stop signal", level="info")
         loop.create_task(self.shutdown())

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -177,14 +177,15 @@ class Office365Connector(AsyncConnector):
         """
         Fetch and forward the events
         """
-        checkpoint = Checkpoint(self._data_path, self.configuration.intake_key)
-
         # Get the current asyncio loop
         loop = asyncio.get_running_loop()
 
         # Register shutdown handler
         loop.add_signal_handler(signal.SIGTERM, self._handle_stop_signal, loop)
         loop.add_signal_handler(signal.SIGINT, self._handle_stop_signal, loop)
+
+        # Initialize the checkpoint
+        checkpoint = Checkpoint(self._data_path, self.configuration.intake_key)
 
         try:
             await self.activate_subscriptions()

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -119,6 +119,10 @@ class Office365Connector(AsyncConnector):
                 exception=exp,
                 message="An exception occurred when trying to subscribe to Office365 events.",
             )
+            self.log(
+                message="Failed to activate Office365 subscriptions. The connector will produce no events.",
+                level="critical",
+            )
 
     async def forward_next_batches(self, checkpoint: Checkpoint):
         start_pull_date = checkpoint.offset

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -65,7 +65,7 @@ class Office365Connector(AsyncConnector):
             end_date (datetime): End date of the interval
 
         Returns:
-            list[dict]: List of events recevied for the interval
+            AsyncGenerator[list[str], None]: Batches of events received for the interval
         """
         pulled_events: list[str] = []
 

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -31,8 +31,7 @@ class Office365Connector(AsyncConnector):
         """
         Shutdown the connector
         """
-        # Call Trigger.stop() to set stop event and stop logs timer
-        # Skip Connector/AsyncConnector.stop() as they have sync issues in async context
+        # Stop the connector
         super().stop()
 
         # Close client if it exists (cached_property stores in __dict__)
@@ -167,8 +166,25 @@ class Office365Connector(AsyncConnector):
                 # Continue the loop to retry after logging
                 await asyncio.sleep(self._frequency)
 
+    def _handle_stop_signal(self):
+        """
+        Handle gracefully the shutdown
+        """
+        self.log(message="Received stop signal", level="info")
+        loop.create_task(self.shutdown())
+
     async def collect_events(self):
+        """
+        Fetch and forward the events
+        """
         checkpoint = Checkpoint(self._data_path, self.configuration.intake_key)
+
+        # Get the current asyncio loop
+        loop = asyncio.get_running_loop()
+
+        # Register shutdown handler
+        loop.add_signal_handler(signal.SIGTERM, self._handle_stop_signal)
+        loop.add_signal_handler(signal.SIGINT, self._handle_stop_signal)
 
         try:
             await self.activate_subscriptions()
@@ -187,18 +203,8 @@ class Office365Connector(AsyncConnector):
         """
         self.log(message="Office365 Trigger has started", level="info")
 
-        loop = asyncio.get_event_loop()
-
-        # Set up signal handlers to stop gracefully
-        def handle_stop_signal():
-            self.log(message="Received stop signal", level="info")
-            loop.create_task(self.shutdown())
-
-        loop.add_signal_handler(signal.SIGTERM, handle_stop_signal)
-        loop.add_signal_handler(signal.SIGINT, handle_stop_signal)
-
         try:
-            loop.run_until_complete(self.collect_events())
+            asyncio.run(self.collect_events())
 
         except ApplicationAuthenticationFailed as auth_error:
             message = "Authentication failed. Please check your client ID, client secret and tenant ID."

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -166,7 +166,7 @@ class Office365Connector(AsyncConnector):
                 # Continue the loop to retry after logging
                 await asyncio.sleep(self._frequency)
 
-    def _handle_stop_signal(self):
+    def _handle_stop_signal(self, loop):
         """
         Handle gracefully the shutdown
         """
@@ -183,8 +183,8 @@ class Office365Connector(AsyncConnector):
         loop = asyncio.get_running_loop()
 
         # Register shutdown handler
-        loop.add_signal_handler(signal.SIGTERM, self._handle_stop_signal)
-        loop.add_signal_handler(signal.SIGINT, self._handle_stop_signal)
+        loop.add_signal_handler(signal.SIGTERM, self._handle_stop_signal, loop)
+        loop.add_signal_handler(signal.SIGINT, self._handle_stop_signal, loop)
 
         try:
             await self.activate_subscriptions()


### PR DESCRIPTION
- Clean up the way to shutdown the connector
- Several little fixes

## Summary by Sourcery

Improve graceful shutdown and event collection flow for the Office365 connector.

Bug Fixes:
- Ensure the Office365 connector shuts down gracefully using asyncio.run and centralized signal handling in the async event loop.
- Log failures to activate Office365 subscriptions as critical so that lack of events is clearly surfaced.
- Clarify the pull_content return type documentation to reflect batched async event generation.

Build:
- Bump the Office365 connector manifest version to 2.20.3.

Documentation:
- Document the 2.20.3 release with fixes to shutdown handling and subscription failure logging in the changelog.