### PR TITLE
SentinelOneDV: change the default message visibility timeout

### DIFF
--- a/SentinelOneDeepVisibility/CHANGELOG.md
+++ b/SentinelOneDeepVisibility/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-27 - 1.1.8
+
+### Changed
+
+- Change the default message visibility timeout to 5 minutes
+
 ## 2026-02-18 - 1.1.7
 
 ### Changed

--- a/SentinelOneDeepVisibility/deep_visibility/connector_s3_logs.py
+++ b/SentinelOneDeepVisibility/deep_visibility/connector_s3_logs.py
@@ -1,4 +1,6 @@
+import os
 from collections.abc import AsyncGenerator
+from typing import Any, Optional
 
 import orjson
 from aws_helpers.utils import AsyncReader
@@ -20,6 +22,12 @@ class DeepVisibilityConnector(AbstractAwsS3QueuedConnector, AwsAccountProvider):
 
     configuration: AwsS3QueuedConfiguration
     name = "DeepVisibility AWS S3 Logs"
+
+    def __init__(self, *args: Any, **kwargs: Optional[Any]) -> None:
+        """Init DeepVisibilityConnector."""
+
+        super().__init__(*args, **kwargs)
+        self.sqs_visibility_timeout = int(os.getenv("AWS_SQS_VISIBILITY_TIMEOUT", 300))
 
     async def _parse_content(self, stream: AsyncReader) -> AsyncGenerator[str, None]:
         """

--- a/SentinelOneDeepVisibility/manifest.json
+++ b/SentinelOneDeepVisibility/manifest.json
@@ -29,7 +29,7 @@
   "name": "SentinelOneDeepVisibility",
   "uuid": "7282a633-0fc2-4b27-a185-3c94f5a3a36f",
   "slug": "sentinelonedeepvisibility",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "categories": [
     "Endpoint"
   ]


### PR DESCRIPTION
- increment the default message visibility timeout to 5 minutes

## Summary by Sourcery

Increase the default SQS message visibility timeout for the SentinelOne Deep Visibility connector and bump its version.

Enhancements:
- Allow configuring SQS visibility timeout via environment variable with a new default of 5 minutes.

Documentation:
- Add a changelog entry documenting the new default message visibility timeout and version 1.1.8.