### PR TITLE
Beyond: fix version number in the changelog

### DIFF
--- a/BeyondTrust/CHANGELOG.md
+++ b/BeyondTrust/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2026-04-28 - 1.1.2
+## 2026-04-28 - 1.2.0
 
 ### Added
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the BeyondTrust changelog entry date section to reflect version 1.2.0 instead of 1.1.2.