### PR TITLE
fix(sophos): fix account validator

### DIFF
--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-27 - 1.18.1
+
+### Fixed
+
+- Fix how we register the Sophos account validator in the main module
+
 ## 2026-04-23 - 1.18.0
 
 ### Added

--- a/Sophos/main.py
+++ b/Sophos/main.py
@@ -15,6 +15,6 @@ if __name__ == "__main__":
     module.register(ActionSophosEDRDeIsolateEndpoint, "sophos_edr_deisolate_endpoint")
     module.register(ActionSophosEDRScan, "sophos_edr_run_scan")
     module.register(SophosDeviceAssetConnector, "sophos_device_asset_connector")
-    module.register(SophosAccountValidator, "sophos_account_validator")
+    module.register_account_validator(SophosAccountValidator)
 
     module.run()

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,7 +38,7 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "categories": [
     "Endpoint",
     "Network"


### PR DESCRIPTION
## Summary by Sourcery

Fix the Sophos integration’s account validator registration and bump the integration version.

Bug Fixes:
- Correct the registration of the Sophos account validator in the main module.

Build:
- Bump the Sophos integration version from 1.18.0 to 1.18.1 in the manifest.

Documentation:
- Document the account validator fix in the Sophos changelog.