### PR TITLE
new software asset connector

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-29 - 1.30.0
+
+### Added
+
+- Add software asset connector to fetch application inventory from HarfangLab agents
+
 ## 2026-04-20 - 1.29.8
 
 ### Changed

--- a/HarfangLab/connector_harfanglab_software_assets.json
+++ b/HarfangLab/connector_harfanglab_software_assets.json
@@ -1,0 +1,37 @@
+{
+  "name": "Harfanglab Software",
+  "description": "Fetch Harfanglab software asset",
+  "uuid": "4cf1749a-b36e-478c-827f-5e2ff11f0a70",
+  "docker_parameters": "harfanglab_software_asset_connector",
+  "type": "asset",
+  "capability": "software_enrichment",
+  "arguments": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "sekoia_base_url": {
+        "description": "Sekoia base URL",
+        "type": "string"
+      },
+      "frequency": {
+          "type": "integer",
+          "description": "Batch frequency in seconds",
+          "minimum": 1,
+          "default": 60
+      },
+      "sekoia_api_key": {
+          "description": "API key to use from sekoia.io",
+          "type": "string"
+      },
+      "batch_size": {
+          "type": "integer",
+          "description": "Number of assets to process in one batch",
+          "minimum": 1,
+          "default": 100
+      }
+    },
+    "required": ["sekoia_api_key"],
+    "secrets": ["sekoia_api_key"],
+    "internal": ["sekoia_base_url", "sekoia_api_key", "frequency", "batch_size"]
+  }
+}

--- a/HarfangLab/harfanglab/asset_connector/models.py
+++ b/HarfangLab/harfanglab/asset_connector/models.py
@@ -326,3 +326,33 @@ class HarfanglabAgentPage(BaseModel):
 
     class Config:
         extra = "allow"
+
+
+class HarfanglabApplication(BaseModel):
+    id: str
+    name: str
+    active: Optional[bool] = None
+    installation_date: Optional[str] = None
+    first_seen: Optional[str] = None
+    last_seen: Optional[str] = None
+    first_version: Optional[str] = None
+    last_version: Optional[str] = None
+    installation_count: Optional[int] = None
+    publisher: Optional[str] = None
+    ostype: Optional[str] = None
+    cpe_prefix: Optional[str] = None
+    app_type: Optional[str] = None
+    description: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class HarfanglabApplicationPage(BaseModel):
+    count: int = 0
+    next: Optional[str] = None
+    previous: Optional[str] = None
+    results: List[HarfanglabApplication] = []
+
+    class Config:
+        extra = "allow"

--- a/HarfangLab/harfanglab/asset_connector/software_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/software_assets.py
@@ -208,8 +208,6 @@ class HarfanglabSoftwareAssetConnector(AssetConnector):
             device_response = self.client.get(current_url, params=params)
             device_response.raise_for_status()
 
-            page_number = 1
-
             while self.running:
                 raw_page = device_response.json()
                 count = raw_page.get("count", 0)
@@ -234,7 +232,6 @@ class HarfanglabSoftwareAssetConnector(AssetConnector):
                 if not next_page:
                     return
 
-                page_number += 1
                 current_url = urljoin(self.base_url, next_page)
                 device_response = self.client.get(current_url)
                 device_response.raise_for_status()

--- a/HarfangLab/harfanglab/asset_connector/software_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/software_assets.py
@@ -145,9 +145,7 @@ class HarfanglabSoftwareAssetConnector(AssetConnector):
             SoftwarePackage: Mapped OCSF SoftwarePackage.
         """
         app_type = (app.app_type or "").lower()
-        pkg_type, pkg_type_id = self.APP_TYPE_MAP.get(
-            app_type, (PackageTypeStr.UNKNOWN, PackageTypeId.UNKNOWN)
-        )
+        pkg_type, pkg_type_id = self.APP_TYPE_MAP.get(app_type, (PackageTypeStr.UNKNOWN, PackageTypeId.UNKNOWN))
 
         return SoftwarePackage(
             name=app.name,
@@ -245,9 +243,7 @@ class HarfanglabSoftwareAssetConnector(AssetConnector):
             self.log(f"API request failed - URL: {current_url}, Error: {str(e)}", level="error")
             raise
 
-    def _fetch_applications(
-        self, agent_uid: str
-    ) -> Generator[list[HarfanglabApplication], None, None]:
+    def _fetch_applications(self, agent_uid: str) -> Generator[list[HarfanglabApplication], None, None]:
         """
         Fetch applications installed on a specific agent.
         Args:
@@ -276,8 +272,7 @@ class HarfanglabSoftwareAssetConnector(AssetConnector):
                         apps.append(HarfanglabApplication.parse_obj(item))
                     except ValidationError as e:
                         self.log(
-                            f"Skipping application (ID: {item.get('id', 'unknown')}) "
-                            f"due to validation error: {e}",
+                            f"Skipping application (ID: {item.get('id', 'unknown')}) " f"due to validation error: {e}",
                             level="warning",
                         )
 

--- a/HarfangLab/harfanglab/asset_connector/software_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/software_assets.py
@@ -1,0 +1,392 @@
+from collections.abc import Generator
+from datetime import datetime, timedelta
+from functools import cached_property
+from typing import Optional
+from urllib.parse import urljoin
+
+from dateutil.parser import isoparse
+from pydantic.v1 import ValidationError
+from requests.exceptions import RequestException
+from sekoia_automation.asset_connector import AssetConnector
+from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product
+from sekoia_automation.asset_connector.models.ocsf.device import (
+    Device,
+    DeviceTypeId,
+    DeviceTypeStr,
+    OperatingSystem,
+    OSTypeId,
+    OSTypeStr,
+)
+from sekoia_automation.asset_connector.models.ocsf.software import (
+    PackageTypeId,
+    PackageTypeStr,
+    SoftwareBillOfMaterials,
+    SoftwareOCSFModel,
+    SoftwarePackage,
+)
+from sekoia_automation.storage import PersistentJSON
+
+from harfanglab.asset_connector.models import HarfanglabAgent, HarfanglabApplication
+from harfanglab.client import ApiClient
+from harfanglab.helpers import handle_uri
+
+
+class HarfanglabSoftwareAssetConnector(AssetConnector):
+
+    # Configuration Constants
+    AGENT_ENDPOINT: str = "/api/data/endpoint/Agent"
+    APPLICATION_ENDPOINT_TEMPLATE: str = "/api/data/endpoint/Agent/{agent_uid}/applications/"
+    DEVICE_ORDERING_FIELD: str = "firstseen"
+    PRODUCT_NAME: str = "Harfanglab EDR"
+    PRODUCT_VERSION: str = "24.12"
+    METADATA_VERSION: str = "1.5.0"
+    DEFAULT_LIMIT: int = 1000
+
+    # OCSF Constants
+    ACTIVITY_ID: int = 2
+    ACTIVITY_NAME: str = "Collect"
+    CATEGORY_NAME: str = "Discovery"
+    CATEGORY_UID: int = 5
+    CLASS_NAME: str = "Software Inventory Info"
+    CLASS_UID: int = 5020
+    TYPE_NAME: str = "Software Inventory Info: Collect"
+    TYPE_UID: int = 502002
+
+    # Application type mapping
+    APP_TYPE_MAP: dict[str, tuple[PackageTypeStr, PackageTypeId]] = {
+        "uwp": (PackageTypeStr.APPLICATION, PackageTypeId.APPLICATION),
+        "win32": (PackageTypeStr.APPLICATION, PackageTypeId.APPLICATION),
+        "macos": (PackageTypeStr.APPLICATION, PackageTypeId.APPLICATION),
+        "linux": (PackageTypeStr.APPLICATION, PackageTypeId.APPLICATION),
+        "os": (PackageTypeStr.OPERATINGSYSTEM, PackageTypeId.OPERATINGSYSTEM),
+    }
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.context = PersistentJSON("software_context.json", self._data_path)
+
+    @property
+    def most_recent_date_seen(self) -> str | None:
+        with self.context as cache:
+            return cache.get("most_recent_date_seen")
+
+    @cached_property
+    def base_url(self) -> str:
+        return handle_uri(self.module.configuration["url"])
+
+    @cached_property
+    def client(self) -> ApiClient:
+        return ApiClient(token=self.module.configuration["api_token"], instance_url=self.base_url)
+
+    @staticmethod
+    def extract_timestamp(agent: HarfanglabAgent) -> datetime:
+        return isoparse(agent.firstseen)
+
+    @staticmethod
+    def extract_os_type(os_type: str | None) -> str:
+        if not os_type:
+            return "UNKNOWN"
+
+        normalized_os = os_type.strip().upper()
+        valid_types = {member.name for member in OSTypeStr}
+
+        if normalized_os not in valid_types:
+            return "OTHER"
+
+        return normalized_os
+
+    @cached_property
+    def metadata(self) -> Metadata:
+        return Metadata(
+            product=Product(name=self.PRODUCT_NAME, version=self.PRODUCT_VERSION), version=self.METADATA_VERSION
+        )
+
+    def build_operating_system(self, os_product_type: Optional[str], os_type: Optional[str]) -> OperatingSystem:
+        os_type = self.extract_os_type(os_type)
+        return OperatingSystem(name=os_product_type, type=OSTypeStr[os_type], type_id=OSTypeId[os_type])
+
+    def build_device(self, agent: HarfanglabAgent) -> Device:
+        """
+        Build a minimal Device object for software OCSF model.
+        Args:
+            agent (HarfanglabAgent): Harfanglab agent data.
+        Returns:
+            Device: Mapped OCSF Device object.
+        """
+        first_seen_time = None
+        last_seen_time = None
+
+        try:
+            if agent.firstseen:
+                first_seen_time = isoparse(agent.firstseen).timestamp()
+            if agent.lastseen:
+                last_seen_time = isoparse(agent.lastseen).timestamp()
+        except (ValueError, TypeError) as e:
+            self.log(f"Error parsing timestamps for asset {agent.id}: {e}", level="warning")
+
+        return Device(
+            type_id=DeviceTypeId.DESKTOP,
+            type=DeviceTypeStr.DESKTOP,
+            uid=agent.id,
+            os=self.build_operating_system(agent.osproducttype, agent.ostype),
+            hostname=agent.hostname,
+            domain=agent.domainname,
+            ip=agent.ipaddress,
+            first_seen_time=first_seen_time,
+            last_seen_time=last_seen_time,
+        )
+
+    def build_software_package(self, app: HarfanglabApplication) -> SoftwarePackage:
+        """
+        Build a SoftwarePackage from a Harfanglab application.
+        Args:
+            app (HarfanglabApplication): Application data from Harfanglab.
+        Returns:
+            SoftwarePackage: Mapped OCSF SoftwarePackage.
+        """
+        app_type = (app.app_type or "").lower()
+        pkg_type, pkg_type_id = self.APP_TYPE_MAP.get(
+            app_type, (PackageTypeStr.UNKNOWN, PackageTypeId.UNKNOWN)
+        )
+
+        return SoftwarePackage(
+            name=app.name,
+            version=app.last_version or app.first_version or "unknown",
+            uid=app.id,
+            cpe_name=app.cpe_prefix,
+            type=pkg_type,
+            type_id=pkg_type_id,
+        )
+
+    def map_software_fields(
+        self, agent: HarfanglabAgent, app: HarfanglabApplication, device: Device
+    ) -> SoftwareOCSFModel:
+        """
+        Map a Harfanglab application to an OCSF SoftwareOCSFModel.
+        Args:
+            agent (HarfanglabAgent): The agent the application belongs to.
+            app (HarfanglabApplication): Application data from Harfanglab.
+            device (Device): Pre-built OCSF Device for the agent.
+        Returns:
+            SoftwareOCSFModel: Mapped OCSF software model.
+        """
+        return SoftwareOCSFModel(
+            activity_id=self.ACTIVITY_ID,
+            activity_name=self.ACTIVITY_NAME,
+            category_name=self.CATEGORY_NAME,
+            category_uid=self.CATEGORY_UID,
+            class_name=self.CLASS_NAME,
+            class_uid=self.CLASS_UID,
+            type_name=self.TYPE_NAME,
+            type_uid=self.TYPE_UID,
+            time=self.extract_timestamp(agent).timestamp(),
+            metadata=self.metadata,
+            device=device,
+            sbom=SoftwareBillOfMaterials(
+                package=self.build_software_package(app),
+            ),
+        )
+
+    def _fetch_devices(self, from_date: str | None) -> Generator[list[HarfanglabAgent], None, None]:
+        """
+        Fetch devices from Harfanglab API with pagination.
+        Args:
+            from_date (str | None): ISO 8601 formatted date string to filter devices.
+        Yields:
+            Generator[list[HarfanglabAgent]]: Generator yielding lists of parsed agent objects.
+        """
+        self.log(f"Fetching devices from Harfanglab API - Start date: {from_date or 'beginning'}", level="info")
+
+        current_url = urljoin(self.base_url, self.AGENT_ENDPOINT)
+        params: dict[str, str | int] = {
+            "ordering": self.DEVICE_ORDERING_FIELD,
+            "limit": self.DEFAULT_LIMIT,
+        }
+
+        if from_date:
+            params["firstseen"] = from_date
+
+        try:
+            device_response = self.client.get(current_url, params=params)
+            device_response.raise_for_status()
+
+            page_number = 1
+
+            while self.running:
+                raw_page = device_response.json()
+                count = raw_page.get("count", 0)
+
+                if not raw_page or count == 0:
+                    self.log("No more devices to fetch", level="info")
+                    return
+
+                agents: list[HarfanglabAgent] = []
+                for item in raw_page.get("results", []):
+                    try:
+                        agents.append(HarfanglabAgent.parse_obj(item))
+                    except ValidationError as e:
+                        self.log(
+                            f"Skipping device (ID: {item.get('id', 'unknown')}) due to validation error: {e}",
+                            level="warning",
+                        )
+
+                yield agents
+
+                next_page = raw_page.get("next")
+                if not next_page:
+                    return
+
+                page_number += 1
+                current_url = urljoin(self.base_url, next_page)
+                device_response = self.client.get(current_url)
+                device_response.raise_for_status()
+
+        except RequestException as e:
+            self.log(f"API request failed - URL: {current_url}, Error: {str(e)}", level="error")
+            raise
+
+    def _fetch_applications(
+        self, agent_uid: str
+    ) -> Generator[list[HarfanglabApplication], None, None]:
+        """
+        Fetch applications installed on a specific agent.
+        Args:
+            agent_uid (str): The agent UID to fetch applications for.
+        Yields:
+            Generator[list[HarfanglabApplication]]: Generator yielding lists of application objects.
+        """
+        endpoint = self.APPLICATION_ENDPOINT_TEMPLATE.format(agent_uid=agent_uid)
+        current_url = urljoin(self.base_url, endpoint)
+        params: dict[str, str | int] = {"limit": self.DEFAULT_LIMIT}
+
+        try:
+            app_response = self.client.get(current_url, params=params)
+            app_response.raise_for_status()
+
+            while self.running:
+                raw_page = app_response.json()
+                count = raw_page.get("count", 0)
+
+                if not raw_page or count == 0:
+                    return
+
+                apps: list[HarfanglabApplication] = []
+                for item in raw_page.get("results", []):
+                    try:
+                        apps.append(HarfanglabApplication.parse_obj(item))
+                    except ValidationError as e:
+                        self.log(
+                            f"Skipping application (ID: {item.get('id', 'unknown')}) "
+                            f"due to validation error: {e}",
+                            level="warning",
+                        )
+
+                yield apps
+
+                next_page = raw_page.get("next")
+                if not next_page:
+                    return
+
+                current_url = urljoin(self.base_url, next_page)
+                app_response = self.client.get(current_url)
+                app_response.raise_for_status()
+
+        except RequestException as e:
+            self.log(
+                f"Failed to fetch applications for agent {agent_uid}: {str(e)}",
+                level="warning",
+            )
+
+    def iterate_devices(self) -> Generator[list[HarfanglabAgent], None, None]:
+        """
+        Iterate over devices fetched from the Harfanglab API, updating the checkpoint timestamp.
+        Yields:
+            Generator[list[HarfanglabAgent]]: Generator yielding lists of agent objects.
+        """
+        orig_date = isoparse(self.most_recent_date_seen) if self.most_recent_date_seen else None
+        max_date: datetime | None = None
+
+        self.log(f"Starting device iteration - Checkpoint date: {self.most_recent_date_seen or 'None'}", level="info")
+
+        device_count = 0
+
+        try:
+            for agents in self._fetch_devices(from_date=self.most_recent_date_seen):
+                if not agents:
+                    continue
+
+                device_count += len(agents)
+
+                last_agent = max(agents, key=self.extract_timestamp)
+                last_ts = self.extract_timestamp(last_agent)
+                candidate = last_ts + timedelta(microseconds=1)
+
+                if max_date is None or candidate > max_date:
+                    max_date = candidate
+
+                yield agents
+
+            self.log(f"Device iteration complete - Total devices processed: {device_count}", level="info")
+
+            if max_date and (orig_date is None or max_date > orig_date):
+                self._latest_time = max_date.isoformat()
+
+        except Exception as e:
+            self.log(f"Device iteration failed - Error: {str(e)}, Devices processed: {device_count}", level="error")
+            raise
+
+    def update_checkpoint(self) -> None:
+        if self._latest_time:
+            with self.context as cache:
+                cache["most_recent_date_seen"] = self._latest_time
+
+            self.log(f"Checkpoint updated successfully - New timestamp: {self._latest_time}", level="debug")
+        else:
+            self.log("No checkpoint update needed - No new timestamp available", level="debug")
+
+    def get_assets(self) -> Generator[SoftwareOCSFModel, None, None]:
+        self.log(f"Software asset generation started - Data path: {self._data_path.absolute()}", level="info")
+
+        software_generated = 0
+        assets_skipped = 0
+
+        try:
+            for agents in self.iterate_devices():
+                for agent in agents:
+                    try:
+                        device = self.build_device(agent)
+                    except (KeyError, ValueError) as e:
+                        assets_skipped += 1
+                        self.log(
+                            f"Device build skipped - ID: {agent.id}, Hostname: {agent.hostname}, Reason: {str(e)}",
+                            level="warning",
+                        )
+                        continue
+
+                    for apps in self._fetch_applications(agent.id):
+                        for app in apps:
+                            try:
+                                yield self.map_software_fields(agent, app, device)
+                                software_generated += 1
+                            except (KeyError, ValueError) as e:
+                                assets_skipped += 1
+                                self.log(
+                                    f"Software asset skipped - Agent: {agent.id}, "
+                                    f"App: {app.name}, Reason: {str(e)}",
+                                    level="warning",
+                                )
+                                continue
+
+            self.log(
+                f"Software asset generation completed - Total generated: {software_generated}, "
+                f"Skipped: {assets_skipped}",
+                level="info",
+            )
+
+        except Exception as e:
+            self.log(
+                f"Software asset generation failed - Generated: {software_generated}, "
+                f"Skipped: {assets_skipped}, Error: {str(e)}",
+                level="error",
+            )
+            raise

--- a/HarfangLab/harfanglab/asset_connector/software_mapping.yml
+++ b/HarfangLab/harfanglab/asset_connector/software_mapping.yml
@@ -250,7 +250,7 @@ mapping:
             "last_seen_time": 1749317226,
             "os": {
               "name": "Windows 11 Enterprise Evaluation",
-              "type": "Windows",
+              "type": "windows",
               "type_id": 100
             }
           },

--- a/HarfangLab/harfanglab/asset_connector/software_mapping.yml
+++ b/HarfangLab/harfanglab/asset_connector/software_mapping.yml
@@ -1,0 +1,266 @@
+mapping:
+  ocsf_class: "Software Inventory Info"
+  class_uid: 5020
+  ocsf_version: "1.5.0"
+
+  samples:
+    - name: "HarfangLab Software Inventory Sample"
+      description: "Agent data sample for harfanglab api response (used to build the device context)."
+      data: |
+        {
+          "id": "3891597d-8696-4fc4-a260-b04880bdbd68",
+          "hostname": "testhostaname1",
+          "firstseen": "2025-06-11T00:15:06.454734Z",
+          "lastseen": "2025-06-11T00:27:06.693963Z",
+          "ostype": "windows",
+          "osproducttype": "Windows 11 Enterprise Evaluation",
+          "ipaddress": "1.2.2.5",
+          "domainname": "TestGROUP"
+        }
+
+    - name: "HarfangLab Application Sample"
+      description: "Application data sample from GET /api/data/endpoint/Agent/<agent_uid>/applications/."
+      data: |
+        {
+          "id": "0e8412d1-f81f-4739-b254-2879bb7bc5e5",
+          "active": true,
+          "installation_date": null,
+          "first_seen": "2026-03-27T10:05:27.558496Z",
+          "last_seen": "2026-03-27T10:06:59.416022Z",
+          "first_version": "0.19051.7-0",
+          "last_version": "0.19051.7-0",
+          "installation_count": 1,
+          "name": "YourPhone",
+          "publisher": "Microsoft Corporation",
+          "ostype": "windows",
+          "cpe_prefix": null,
+          "app_type": "uwp",
+          "description": null
+        }
+
+  fields:
+    # OCSF EVENT CLASSIFICATION
+    - source: "static: 2"
+      target: "activity_id"
+      type: "integer"
+      logic: "Always 2 for 'Collect' activity"
+      description: "OCSF activity ID"
+
+    - source: "static: Collect"
+      target: "activity_name"
+      type: "string"
+      logic: "Always 'Collect' for asset inventory"
+      description: "OCSF activity name"
+
+    - source: "static: Discovery"
+      target: "category_name"
+      type: "string"
+      logic: "Always 'Discovery'"
+      description: "OCSF category name"
+
+    - source: "static: 5"
+      target: "category_uid"
+      type: "integer"
+      logic: "Always 5 for Discovery category"
+      description: "OCSF category UID"
+
+    - source: "static: Software Inventory Info"
+      target: "class_name"
+      type: "string"
+      logic: "Always 'Software Inventory Info'"
+      description: "OCSF class name"
+
+    - source: "static: 5020"
+      target: "class_uid"
+      type: "integer"
+      logic: "Always 5020 for Software Inventory Info"
+      description: "OCSF class UID"
+
+    - source: "static: 502002"
+      target: "type_uid"
+      type: "integer"
+      logic: "Always 502002 for Software Inventory Info: Collect"
+      description: "OCSF type UID"
+
+    - source: "static: Software Inventory Info: Collect"
+      target: "type_name"
+      type: "string"
+      logic: "Always 'Software Inventory Info: Collect' for this event type"
+      description: "OCSF type name"
+
+    # TIMESTAMPS
+    - source: "agent.firstseen"
+      target: "time"
+      type: "timestamp"
+      logic: "Convert ISO 8601 to Unix epoch from the parent agent; use for OCSF event timestamp"
+      description: "OCSF event timestamp"
+
+    # METADATA
+    - source: "static: HarfangLab EDR"
+      target: "metadata.product.name"
+      type: "string"
+      logic: "Always 'HarfangLab EDR'"
+      description: "Source product name"
+
+    - source: "static: 24.12"
+      target: "metadata.product.version"
+      type: "string"
+      logic: "Fixed HarfangLab product version"
+      description: "Product version"
+
+    - source: "static: 1.5.0"
+      target: "metadata.version"
+      type: "string"
+      logic: "Fixed OCSF schema version"
+      description: "OCSF schema version"
+
+    # DEVICE ATTRIBUTES (from parent agent)
+    - source: "static: 2"
+      target: "device.type_id"
+      type: "integer"
+      logic: "Direct mapping of type to desktop type ID"
+      description: "Device type ID"
+
+    - source: "static: Desktop"
+      target: "device.type"
+      type: "string"
+      logic: "Direct mapping of type to desktop type"
+      description: "OCSF device type"
+
+    - source: "agent.id"
+      target: "device.uid"
+      type: "string"
+      logic: "Direct mapping of HarfangLab agent unique ID"
+      description: "Device unique identifier"
+
+    - source: "agent.osproducttype"
+      target: "device.os.name"
+      type: "string"
+      logic: "Direct mapping of OS product type (e.g., 'Windows 10 Professional', 'Ubuntu 20.04')"
+      description: "Operating system name and version"
+
+    - source: "agent.ostype"
+      target: "device.os.type"
+      type: "string"
+      logic: "Normalize ostype to OCSF OSTypeStr: WINDOWS→'Windows', LINUX→'Linux', MACOS→'macOS', OTHER→'Other', UNKNOWN→'Unknown'"
+      description: "Operating system type"
+
+    - source: "agent.ostype"
+      target: "device.os.type_id"
+      type: "integer"
+      logic: "Map ostype to OCSF OSTypeId: WINDOWS→100, LINUX→200, MACOS→300, OTHER→99, UNKNOWN→0"
+      description: "OCSF operating system type ID"
+
+    - source: "agent.hostname"
+      target: "device.hostname"
+      type: "string"
+      logic: "Direct mapping of hostname"
+      description: "Device hostname"
+
+    - source: "agent.domainname"
+      target: "device.domain"
+      type: "string"
+      logic: "Direct mapping of domain name"
+      description: "Device domain or realm"
+
+    - source: "agent.ipaddress"
+      target: "device.ip"
+      type: "string"
+      logic: "Direct mapping of IP address"
+      description: "Device IP address"
+
+    - source: "agent.firstseen"
+      target: "device.first_seen_time"
+      type: "timestamp"
+      logic: "Convert ISO 8601 to Unix epoch"
+      description: "Device first seen timestamp"
+
+    - source: "agent.lastseen"
+      target: "device.last_seen_time"
+      type: "timestamp"
+      logic: "Convert ISO 8601 to Unix epoch"
+      description: "Device last seen timestamp"
+
+    # SBOM - SOFTWARE BILL OF MATERIALS
+    - source: "application.name"
+      target: "sbom.package.name"
+      type: "string"
+      logic: "Direct mapping of application name"
+      description: "Software package name"
+
+    - source: "application.last_version || application.first_version || 'unknown'"
+      target: "sbom.package.version"
+      type: "string"
+      logic: "Use last_version if available, fallback to first_version, then 'unknown'"
+      description: "Software package version"
+
+    - source: "application.id"
+      target: "sbom.package.uid"
+      type: "string"
+      logic: "Direct mapping of application unique ID"
+      description: "Software package unique identifier"
+
+    - source: "application.cpe_prefix"
+      target: "sbom.package.cpe_name"
+      type: "string"
+      logic: "Direct mapping of CPE prefix if available; null otherwise"
+      description: "Common Platform Enumeration name"
+
+    - source: "application.app_type"
+      target: "sbom.package.type"
+      type: "string"
+      logic: "Map app_type to OCSF PackageTypeStr: uwp/win32/macos/linux→'Application', os→'Operating System', unknown→'Unknown'"
+      description: "Software package type"
+
+    - source: "application.app_type"
+      target: "sbom.package.type_id"
+      type: "integer"
+      logic: "Map app_type to OCSF PackageTypeId: uwp/win32/macos/linux→1 (APPLICATION), os→2 (OPERATINGSYSTEM), unknown→0 (UNKNOWN)"
+      description: "OCSF software package type ID"
+
+  ocsf_samples:
+    - name: "Software Inventory Info: Collect"
+      description: "Transformed HarfangLab api response to OCSF Software Inventory Info event"
+      data: |
+        {
+          "activity_id": 2,
+          "activity_name": "Collect",
+          "category_name": "Discovery",
+          "category_uid": 5,
+          "class_name": "Software Inventory Info",
+          "class_uid": 5020,
+          "type_name": "Software Inventory Info: Collect",
+          "type_uid": 502002,
+          "time": 1749316506,
+          "metadata": {
+            "product": {
+              "name": "HarfangLab EDR",
+              "version": "24.12"
+            },
+            "version": "1.5.0"
+          },
+          "device": {
+            "uid": "3891597d-8696-4fc4-a260-b04880bdbd68",
+            "hostname": "testhostaname1",
+            "type": "Desktop",
+            "type_id": 2,
+            "ip": "1.2.2.5",
+            "domain": "TestGROUP",
+            "first_seen_time": 1749316506,
+            "last_seen_time": 1749317226,
+            "os": {
+              "name": "Windows 11 Enterprise Evaluation",
+              "type": "Windows",
+              "type_id": 100
+            }
+          },
+          "sbom": {
+            "package": {
+              "name": "YourPhone",
+              "version": "0.19051.7-0",
+              "uid": "0e8412d1-f81f-4739-b254-2879bb7bc5e5",
+              "type": "Application",
+              "type_id": 1
+            }
+          }
+        }

--- a/HarfangLab/harfanglab/asset_connector/software_mapping.yml
+++ b/HarfangLab/harfanglab/asset_connector/software_mapping.yml
@@ -96,10 +96,10 @@ mapping:
       description: "OCSF event timestamp"
 
     # METADATA
-    - source: "static: HarfangLab EDR"
+    - source: "static: Harfanglab EDR"
       target: "metadata.product.name"
       type: "string"
-      logic: "Always 'HarfangLab EDR'"
+      logic: "Always 'Harfanglab EDR'"
       description: "Source product name"
 
     - source: "static: 24.12"

--- a/HarfangLab/main.py
+++ b/HarfangLab/main.py
@@ -2,6 +2,7 @@ from sekoia_automation.module import Module
 
 from harfanglab.account_validator import HarfanglabAccountValidator
 from harfanglab.asset_connector.device_assets import HarfanglabAssetConnector
+from harfanglab.asset_connector.software_assets import HarfanglabSoftwareAssetConnector
 from harfanglab.download_file_from_endpoint import DownloadFileFromEndpointAction
 from harfanglab.endpoint_actions import (
     EndpointAgentDeisolationAction,
@@ -22,6 +23,7 @@ if __name__ == "__main__":
     module = Module()
     module.register_account_validator(HarfanglabAccountValidator)
     module.register(HarfanglabAssetConnector, "harfanglab_asset_connector")
+    module.register(HarfanglabSoftwareAssetConnector, "harfanglab_software_asset_connector")
     module.register(GetProcessListAction, "harfanglab_get_process_list")
     module.register(GetProcessListActionV2, "harfanglab_get_process_list_v2")
     module.register(GetPipeListAction, "harfanglab_get_pipe_list")

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.29.8",
+  "version": "1.30.0",
   "categories": [
     "Endpoint"
   ],

--- a/HarfangLab/tests/asset_connector/test_software_assets.py
+++ b/HarfangLab/tests/asset_connector/test_software_assets.py
@@ -241,9 +241,7 @@ def test_map_software_fields(test_software_connector, sample_agent, sample_appli
     assert software.metadata.version == "1.5.0"
 
 
-def test_map_software_fields_json_serializable(
-    test_software_connector, sample_agent, sample_application
-):
+def test_map_software_fields_json_serializable(test_software_connector, sample_agent, sample_application):
     device = test_software_connector.build_device(sample_agent)
     software = test_software_connector.map_software_fields(sample_agent, sample_application, device)
     json_data = software.model_dump()

--- a/HarfangLab/tests/asset_connector/test_software_assets.py
+++ b/HarfangLab/tests/asset_connector/test_software_assets.py
@@ -1,0 +1,503 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+import requests_mock
+from sekoia_automation.asset_connector.models.ocsf.software import (
+    PackageTypeId,
+    PackageTypeStr,
+    SoftwareOCSFModel,
+)
+from sekoia_automation.module import Module
+
+from harfanglab.asset_connector.models import HarfanglabAgent, HarfanglabApplication
+from harfanglab.asset_connector.software_assets import HarfanglabSoftwareAssetConnector
+
+
+@pytest.fixture
+def test_software_connector(symphony_storage):
+    module = Module()
+    module.configuration = {
+        "url": "https://example.com",
+        "api_token": "fake_harfanglab_api_key",
+    }
+
+    connector = HarfanglabSoftwareAssetConnector(module=module, data_path=symphony_storage)
+    connector.configuration = {
+        "sekoia_base_url": "https://sekoia.io",
+        "sekoia_api_key": "fake_api_key",
+        "frequency": 60,
+    }
+
+    connector.log = Mock()
+    connector.log_exception = Mock()
+
+    yield connector
+
+
+@pytest.fixture
+def sample_agent():
+    return HarfanglabAgent(
+        id="3891597d-8696-4fc4-a260-b04880bdbd68",
+        hostname="testhost1",
+        firstseen="2025-06-11T00:15:06.454734Z",
+        ostype="windows",
+        osproducttype="Windows 11 Enterprise Evaluation",
+        ipaddress="1.2.2.5",
+        ipmask="255.255.255.0",
+        domainname="TestGROUP",
+    )
+
+
+@pytest.fixture
+def sample_application_response():
+    return {
+        "count": 3,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "id": "0e8412d1-f81f-4739-b254-2879bb7bc5e5",
+                "active": True,
+                "installation_date": None,
+                "first_seen": "2026-03-27T10:05:27.558496Z",
+                "last_seen": "2026-03-27T10:06:59.416022Z",
+                "first_version": "0.19051.7-0",
+                "last_version": "0.19051.7-0",
+                "installation_count": 1,
+                "name": "YourPhone",
+                "publisher": "Microsoft Corporation",
+                "ostype": "windows",
+                "cpe_prefix": None,
+                "app_type": "uwp",
+                "description": None,
+            },
+            {
+                "id": "cec21248-77a6-4c33-b792-760f1ad3f1e2",
+                "active": True,
+                "installation_date": "2026-03-27T11:58:33.609974Z",
+                "first_seen": "2026-03-27T10:05:27.558496Z",
+                "last_seen": "2026-03-27T10:06:59.416022Z",
+                "first_version": "7.2.6.172322",
+                "last_version": "7.2.6.172322",
+                "installation_count": 1,
+                "name": "Oracle VirtualBox Guest Additions 7.2.6",
+                "publisher": "Oracle and/or its affiliates",
+                "ostype": "windows",
+                "cpe_prefix": None,
+                "app_type": "win32",
+                "description": None,
+            },
+            {
+                "id": "667d7385-bb8e-4fa0-b222-6d328d7b8836",
+                "active": True,
+                "installation_date": "2026-03-27T00:00:00Z",
+                "first_seen": "2026-03-27T10:06:59.416022Z",
+                "last_seen": "2026-03-27T10:06:59.416022Z",
+                "first_version": "24.12.11",
+                "last_version": "24.12.11",
+                "installation_count": 1,
+                "name": "HarfangLab Hurukai agent",
+                "publisher": "HarfangLab",
+                "ostype": "windows",
+                "cpe_prefix": None,
+                "app_type": "win32",
+                "description": None,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_application():
+    return HarfanglabApplication(
+        id="0e8412d1-f81f-4739-b254-2879bb7bc5e5",
+        name="YourPhone",
+        active=True,
+        first_version="0.19051.7-0",
+        last_version="0.19051.7-0",
+        publisher="Microsoft Corporation",
+        ostype="windows",
+        app_type="uwp",
+    )
+
+
+def test_build_software_package_uwp(test_software_connector, sample_application):
+    pkg = test_software_connector.build_software_package(sample_application)
+
+    assert pkg.name == "YourPhone"
+    assert pkg.version == "0.19051.7-0"
+    assert pkg.uid == "0e8412d1-f81f-4739-b254-2879bb7bc5e5"
+    assert pkg.cpe_name is None
+    assert pkg.type == PackageTypeStr.APPLICATION
+    assert pkg.type_id == PackageTypeId.APPLICATION
+
+
+def test_build_software_package_win32(test_software_connector):
+    app = HarfanglabApplication(
+        id="cec21248-77a6-4c33-b792-760f1ad3f1e2",
+        name="Oracle VirtualBox Guest Additions 7.2.6",
+        app_type="win32",
+        last_version="7.2.6.172322",
+        cpe_prefix="cpe:2.3:a:oracle:vm_virtualbox",
+    )
+
+    pkg = test_software_connector.build_software_package(app)
+
+    assert pkg.name == "Oracle VirtualBox Guest Additions 7.2.6"
+    assert pkg.version == "7.2.6.172322"
+    assert pkg.cpe_name == "cpe:2.3:a:oracle:vm_virtualbox"
+    assert pkg.type == PackageTypeStr.APPLICATION
+    assert pkg.type_id == PackageTypeId.APPLICATION
+
+
+def test_build_software_package_unknown_type(test_software_connector):
+    app = HarfanglabApplication(
+        id="test-id",
+        name="SomeApp",
+        app_type="custom_unknown",
+        last_version="1.0",
+    )
+
+    pkg = test_software_connector.build_software_package(app)
+
+    assert pkg.type == PackageTypeStr.UNKNOWN
+    assert pkg.type_id == PackageTypeId.UNKNOWN
+
+
+def test_build_software_package_no_app_type(test_software_connector):
+    app = HarfanglabApplication(
+        id="test-id",
+        name="SomeApp",
+        last_version="1.0",
+    )
+
+    pkg = test_software_connector.build_software_package(app)
+
+    assert pkg.type == PackageTypeStr.UNKNOWN
+    assert pkg.type_id == PackageTypeId.UNKNOWN
+
+
+def test_build_software_package_fallback_version(test_software_connector):
+    app = HarfanglabApplication(
+        id="test-id",
+        name="SomeApp",
+        first_version="0.9",
+        last_version=None,
+    )
+
+    pkg = test_software_connector.build_software_package(app)
+    assert pkg.version == "0.9"
+
+
+def test_build_software_package_no_version(test_software_connector):
+    app = HarfanglabApplication(
+        id="test-id",
+        name="SomeApp",
+    )
+
+    pkg = test_software_connector.build_software_package(app)
+    assert pkg.version == "unknown"
+
+
+def test_build_device(test_software_connector, sample_agent):
+    device = test_software_connector.build_device(sample_agent)
+
+    assert device.uid == sample_agent.id
+    assert device.hostname == "testhost1"
+    assert device.domain == "TestGROUP"
+    assert device.ip == "1.2.2.5"
+    assert device.os.type == "windows"
+    assert device.first_seen_time is not None
+    assert device.type_id == 2
+    assert device.type == "Desktop"
+
+
+def test_map_software_fields(test_software_connector, sample_agent, sample_application):
+    device = test_software_connector.build_device(sample_agent)
+    software = test_software_connector.map_software_fields(sample_agent, sample_application, device)
+
+    assert isinstance(software, SoftwareOCSFModel)
+    assert software.activity_id == 2
+    assert software.activity_name == "Collect"
+    assert software.category_name == "Discovery"
+    assert software.category_uid == 5
+    assert software.class_name == "Software Inventory Info"
+    assert software.class_uid == 5020
+    assert software.type_name == "Software Inventory Info: Collect"
+    assert software.type_uid == 502002
+
+    # Device should be populated
+    assert software.device.uid == sample_agent.id
+    assert software.device.hostname == "testhost1"
+
+    # SBOM should contain the package
+    assert software.sbom is not None
+    assert software.sbom.package.name == "YourPhone"
+    assert software.sbom.package.version == "0.19051.7-0"
+
+    # Metadata
+    assert software.metadata.product.name == "Harfanglab EDR"
+    assert software.metadata.version == "1.5.0"
+
+
+def test_map_software_fields_json_serializable(
+    test_software_connector, sample_agent, sample_application
+):
+    device = test_software_connector.build_device(sample_agent)
+    software = test_software_connector.map_software_fields(sample_agent, sample_application, device)
+    json_data = software.model_dump()
+    serialized = json.dumps(json_data)
+
+    assert serialized
+    assert json_data["class_uid"] == 5020
+    assert json_data["sbom"]["package"]["name"] == "YourPhone"
+    assert json_data["device"]["hostname"] == "testhost1"
+
+
+def test_fetch_applications(test_software_connector, sample_application_response):
+    agent_uid = "3891597d-8696-4fc4-a260-b04880bdbd68"
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/{agent_uid}/applications/?limit=1000",
+            status_code=200,
+            json=sample_application_response,
+        )
+
+        apps_pages = list(test_software_connector._fetch_applications(agent_uid))
+
+        assert len(apps_pages) == 1
+        assert len(apps_pages[0]) == 3
+        assert apps_pages[0][0].name == "YourPhone"
+        assert apps_pages[0][1].name == "Oracle VirtualBox Guest Additions 7.2.6"
+        assert apps_pages[0][2].name == "HarfangLab Hurukai agent"
+
+
+def test_fetch_applications_empty(test_software_connector):
+    agent_uid = "test-agent-uid"
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/{agent_uid}/applications/?limit=1000",
+            status_code=200,
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        apps_pages = list(test_software_connector._fetch_applications(agent_uid))
+
+        assert len(apps_pages) == 0
+
+
+def test_fetch_applications_api_error_logs_warning(test_software_connector):
+    agent_uid = "test-agent-uid"
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/{agent_uid}/applications/?limit=1000",
+            status_code=500,
+        )
+
+        apps_pages = list(test_software_connector._fetch_applications(agent_uid))
+
+        assert len(apps_pages) == 0
+        test_software_connector.log.assert_any_call(
+            f"Failed to fetch applications for agent {agent_uid}: 500 Server Error: None for url: "
+            f"https://example.com/api/data/endpoint/Agent/{agent_uid}/applications/?limit=1000",
+            level="warning",
+        )
+
+
+def test_fetch_applications_pagination(test_software_connector):
+    agent_uid = "test-agent-uid"
+    page1 = {
+        "count": 2,
+        "next": f"/api/data/endpoint/Agent/{agent_uid}/applications/?limit=1000&offset=1000",
+        "previous": None,
+        "results": [
+            {"id": "app-1", "name": "App1", "app_type": "uwp", "last_version": "1.0"},
+        ],
+    }
+    page2 = {
+        "count": 2,
+        "next": None,
+        "previous": None,
+        "results": [
+            {"id": "app-2", "name": "App2", "app_type": "win32", "last_version": "2.0"},
+        ],
+    }
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/{agent_uid}/applications/?limit=1000",
+            status_code=200,
+            json=page1,
+        )
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/{agent_uid}/applications/?limit=1000&offset=1000",
+            status_code=200,
+            json=page2,
+        )
+
+        apps_pages = list(test_software_connector._fetch_applications(agent_uid))
+
+        assert len(apps_pages) == 2
+        assert apps_pages[0][0].name == "App1"
+        assert apps_pages[1][0].name == "App2"
+
+
+def test_get_assets_yields_software(test_software_connector, sample_application_response):
+    """Test that get_assets yields SoftwareOCSFModel for each application."""
+    agent_data = {
+        "id": "3891597d-8696-4fc4-a260-b04880bdbd68",
+        "hostname": "testhost1",
+        "firstseen": "2025-06-11T00:15:06.454734Z",
+        "ostype": "windows",
+        "osproducttype": "Windows 11 Enterprise Evaluation",
+        "ipaddress": "1.2.2.5",
+        "ipmask": "255.255.255.0",
+        "domainname": "TestGROUP",
+        "policy": None,
+    }
+    agent_endpoint_response = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [agent_data],
+    }
+    agent_uid = agent_data["id"]
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent",
+            status_code=200,
+            json=agent_endpoint_response,
+        )
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/{agent_uid}/applications/",
+            status_code=200,
+            json=sample_application_response,
+        )
+
+        with patch.object(
+            type(test_software_connector),
+            "most_recent_date_seen",
+            new_callable=lambda: property(lambda self: None),
+        ):
+            assets = list(test_software_connector.get_assets())
+
+    # 3 software assets only
+    assert len(assets) == 3
+    assert all(isinstance(a, SoftwareOCSFModel) for a in assets)
+
+    # All software assets reference the same device
+    for sw in assets:
+        assert sw.device.uid == agent_uid
+        assert sw.device.hostname == "testhost1"
+
+    # Check software names
+    sw_names = {sw.sbom.package.name for sw in assets}
+    assert sw_names == {"YourPhone", "Oracle VirtualBox Guest Additions 7.2.6", "HarfangLab Hurukai agent"}
+
+
+def test_get_assets_software_fetch_error_continues(test_software_connector):
+    """Test that a software fetch error for one agent doesn't block other agents."""
+    agent1 = {
+        "id": "agent-1",
+        "hostname": "host1",
+        "firstseen": "2025-06-11T00:15:06.454734Z",
+        "ostype": "windows",
+        "osproducttype": "Windows 11",
+        "policy": None,
+    }
+    agent2 = {
+        "id": "agent-2",
+        "hostname": "host2",
+        "firstseen": "2025-06-12T00:15:06.454734Z",
+        "ostype": "windows",
+        "osproducttype": "Windows 11",
+        "policy": None,
+    }
+    agent_endpoint_response = {
+        "count": 2,
+        "next": None,
+        "previous": None,
+        "results": [agent1, agent2],
+    }
+    app_response = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [
+            {"id": "app-1", "name": "App1", "app_type": "uwp", "last_version": "1.0"},
+        ],
+    }
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent",
+            status_code=200,
+            json=agent_endpoint_response,
+        )
+        # agent-1 applications fail
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/agent-1/applications/",
+            status_code=500,
+        )
+        # agent-2 applications succeed
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/agent-2/applications/",
+            status_code=200,
+            json=app_response,
+        )
+
+        with patch.object(
+            type(test_software_connector),
+            "most_recent_date_seen",
+            new_callable=lambda: property(lambda self: None),
+        ):
+            assets = list(test_software_connector.get_assets())
+
+    # Only agent-2's software should be yielded
+    assert len(assets) == 1
+    assert isinstance(assets[0], SoftwareOCSFModel)
+    assert assets[0].device.uid == "agent-2"
+
+
+def test_get_assets_no_applications(test_software_connector):
+    """Test get_assets when agents have no applications."""
+    agent_data = {
+        "id": "agent-1",
+        "hostname": "host1",
+        "firstseen": "2025-06-11T00:15:06.454734Z",
+        "ostype": "windows",
+        "osproducttype": "Windows 11",
+        "policy": None,
+    }
+    agent_endpoint_response = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [agent_data],
+    }
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent",
+            status_code=200,
+            json=agent_endpoint_response,
+        )
+        m.get(
+            f"{test_software_connector.base_url}/api/data/endpoint/Agent/agent-1/applications/",
+            status_code=200,
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        with patch.object(
+            type(test_software_connector),
+            "most_recent_date_seen",
+            new_callable=lambda: property(lambda self: None),
+        ):
+            assets = list(test_software_connector.get_assets())
+
+    assert len(assets) == 0


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1562

## Summary by Sourcery

Introduce a HarfangLab software asset connector that inventories applications from agents and exposes them as OCSF Software Inventory Info events.

New Features:
- Add HarfanglabApplication and HarfanglabApplicationPage models to represent applications returned by the HarfangLab API.
- Register a HarfanglabSoftwareAssetConnector module entry to collect software inventory from HarfangLab agents and map it to OCSF software events.

Enhancements:
- Persist and use a checkpoint for incremental software asset collection based on agent first-seen timestamps.
- Implement pagination-aware fetching for agents and their applications with improved logging and error handling.

Build:
- Bump HarfangLab integration version to 1.30.0 in the manifest.

Documentation:
- Document the HarfangLab software inventory mapping to OCSF in a dedicated software_mapping.yml file.
- Update the changelog for version 1.30.0 describing the new software asset connector.

Tests:
- Add comprehensive unit tests covering software package and device building, OCSF field mapping, application fetching (including pagination and error cases), and overall asset generation behavior.