### PR TITLE
fix(pubsub): connector conf

### DIFF
--- a/Google/CHANGELOG.md
+++ b/Google/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- use default connector configuration inheritance instead of the one used.
+- Use default connector configuration inheritance.
 
 ## 2026-01-09 - 1.22.0
 

--- a/Google/CHANGELOG.md
+++ b/Google/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-30 - 1.22.1
+
+### Fixed
+
+- use default connector configuration inheritance instead of the one used.
+
 ## 2026-01-09 - 1.22.0
 
 ### Added

--- a/Google/google_module/pubsub.py
+++ b/Google/google_module/pubsub.py
@@ -11,16 +11,15 @@ from google.cloud.pubsub_v1 import SubscriberClient, types
 from google_module.base import GoogleTrigger
 from google_module.metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, INCOMING_MESSAGES, OUTCOMING_EVENTS
 from pydantic import BaseModel
+from sekoia_automation.connector import DefaultConnectorConfiguration
 
 max_chunk_size: int = 1000
 
 
-class PubSubConfig(BaseModel):
-    intake_key: str
+class PubSubConfig(DefaultConnectorConfiguration):
     subject_id: str
     project_id: str
     frequency: int = 20
-    intake_server: str = "https://intake.sekoia.io"
     chunk_size: int = 1000
 
 

--- a/Google/google_module/pubsub.py
+++ b/Google/google_module/pubsub.py
@@ -10,7 +10,6 @@ from google.api_core import exceptions, retry
 from google.cloud.pubsub_v1 import SubscriberClient, types
 from google_module.base import GoogleTrigger
 from google_module.metrics import EVENTS_LAG, FORWARD_EVENTS_DURATION, INCOMING_MESSAGES, OUTCOMING_EVENTS
-from pydantic import BaseModel
 from sekoia_automation.connector import DefaultConnectorConfiguration
 
 max_chunk_size: int = 1000

--- a/Google/manifest.json
+++ b/Google/manifest.json
@@ -66,6 +66,6 @@
   "name": "Google Cloud",
   "uuid": "4f682a9e-9a25-43a5-8a48-cd9bd7fade7e",
   "slug": "google",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "categories": ["Cloud Providers"]
 }


### PR DESCRIPTION
Main issue: [issue](https://github.com/SekoiaLab/platform/issues/84987)

## Summary by Sourcery

Fix Google Pub/Sub connector configuration inheritance and bump the Google Cloud module patch version.

Bug Fixes:
- Use the default connector configuration inheritance for the Google Pub/Sub connector instead of a custom configuration model.

Build:
- Update the Google Cloud integration manifest version from 1.22.0 to 1.22.1.

Documentation:
- Add a 1.22.1 entry to the Google module changelog documenting the Pub/Sub connector configuration fix.