### PR TITLE
Fix/harfanglab mac address

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-04-30 - 1.30.1
+
+### Added
+
+- Add gateway MAC address to device network interface information
+
 ## 2026-04-29 - 1.30.0
 
 ### Added

--- a/HarfangLab/harfanglab/asset_connector/device_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/device_assets.py
@@ -177,6 +177,7 @@ class HarfanglabAssetConnector(AssetConnector):
             type=interface_type,
             type_id=interface_type_id,
             uid=subnet_info.id if subnet_info else None,
+            mac=subnet_info.gateway_macaddress if subnet_info and subnet_info.gateway_macaddress else None,
         )
 
     def build_device(self, agent: HarfanglabAgent) -> Device:

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "categories": [
     "Endpoint"
   ],

--- a/HarfangLab/tests/asset_connector/test_device_assets.py
+++ b/HarfangLab/tests/asset_connector/test_device_assets.py
@@ -1084,7 +1084,9 @@ def test_fetch_devices_skips_invalid_item(test_harfanglab_asset_connector):
             status_code=200,
             json=response,
         )
-        with patch("harfanglab.asset_connector.device_assets.HarfanglabAgent.parse_obj", side_effect=Exception("invalid")):
+        with patch(
+            "harfanglab.asset_connector.device_assets.HarfanglabAgent.parse_obj", side_effect=Exception("invalid")
+        ):
             # Should not raise; the item is skipped via ValidationError handler
             pass
 
@@ -1124,9 +1126,7 @@ def test_iterate_devices_no_checkpoint(test_harfanglab_asset_connector, agent_en
             assert test_harfanglab_asset_connector._latest_time is not None
 
 
-def test_iterate_devices_no_checkpoint_update_when_older(
-    test_harfanglab_asset_connector, agent_endpoint_response
-):
+def test_iterate_devices_no_checkpoint_update_when_older(test_harfanglab_asset_connector, agent_endpoint_response):
     with requests_mock.Mocker() as agent_request:
         agent_request.get(
             f"{test_harfanglab_asset_connector.base_url}/api/data/endpoint/Agent?ordering=firstseen&firstseen=2030-01-01T00%3A00%3A00%2B00%3A00&limit=1000",
@@ -1140,7 +1140,10 @@ def test_iterate_devices_no_checkpoint_update_when_older(
             new_callable=lambda: property(lambda self: "2030-01-01T00:00:00+00:00"),
         ):
             list(test_harfanglab_asset_connector.iterate_devices())
-            assert not hasattr(test_harfanglab_asset_connector, "_latest_time") or test_harfanglab_asset_connector._latest_time is None
+            assert (
+                not hasattr(test_harfanglab_asset_connector, "_latest_time")
+                or test_harfanglab_asset_connector._latest_time is None
+            )
 
 
 def test_update_checkpoint(test_harfanglab_asset_connector):

--- a/HarfangLab/tests/asset_connector/test_device_assets.py
+++ b/HarfangLab/tests/asset_connector/test_device_assets.py
@@ -976,3 +976,219 @@ def test_iterate_devices_request_failure(test_harfanglab_asset_connector):
         ):
             with pytest.raises(requests.exceptions.HTTPError):
                 list(test_harfanglab_asset_connector.iterate_devices())
+
+
+def test_extract_os_type_other(test_harfanglab_asset_connector):
+    os_type = test_harfanglab_asset_connector.extract_os_type("freebsd")
+    assert os_type == "OTHER"
+
+
+def test_detect_network_interface_wireless(test_harfanglab_asset_connector):
+    from harfanglab.asset_connector.models import HarfanglabSubnet
+
+    agent = HarfanglabAgent(
+        id="test-id",
+        hostname="test-host",
+        firstseen="2023-10-01T12:00:00Z",
+        subnet=HarfanglabSubnet(id="subnet-1", name="wlan0"),
+        ipaddress="192.168.1.1",
+    )
+    iface_type, iface_type_id = test_harfanglab_asset_connector._detect_network_interface_type(agent)
+    from sekoia_automation.asset_connector.models.ocsf.device import NetworkInterfaceTypeId, NetworkInterfaceTypeStr
+
+    assert iface_type == NetworkInterfaceTypeStr.WIRELESS
+    assert iface_type_id == NetworkInterfaceTypeId.WIRELESS
+
+
+def test_detect_network_interface_mobile(test_harfanglab_asset_connector):
+    from harfanglab.asset_connector.models import HarfanglabSubnet
+
+    agent = HarfanglabAgent(
+        id="test-id",
+        hostname="test-host",
+        firstseen="2023-10-01T12:00:00Z",
+        subnet=HarfanglabSubnet(id="subnet-1", name="wwan0"),
+        ipaddress="10.0.0.1",
+    )
+    iface_type, iface_type_id = test_harfanglab_asset_connector._detect_network_interface_type(agent)
+    from sekoia_automation.asset_connector.models.ocsf.device import NetworkInterfaceTypeId, NetworkInterfaceTypeStr
+
+    assert iface_type == NetworkInterfaceTypeStr.MOBILE
+    assert iface_type_id == NetworkInterfaceTypeId.MOBILE
+
+
+def test_detect_network_interface_tunnel(test_harfanglab_asset_connector):
+    from harfanglab.asset_connector.models import HarfanglabSubnet
+
+    agent = HarfanglabAgent(
+        id="test-id",
+        hostname="test-host",
+        firstseen="2023-10-01T12:00:00Z",
+        subnet=HarfanglabSubnet(id="subnet-1", name="tun0"),
+        ipaddress="10.8.0.2",
+    )
+    iface_type, iface_type_id = test_harfanglab_asset_connector._detect_network_interface_type(agent)
+    from sekoia_automation.asset_connector.models.ocsf.device import NetworkInterfaceTypeId, NetworkInterfaceTypeStr
+
+    assert iface_type == NetworkInterfaceTypeStr.TUNNEL
+    assert iface_type_id == NetworkInterfaceTypeId.TUNNEL
+
+
+def test_build_device_timestamp_parse_error(test_harfanglab_asset_connector):
+    agent = HarfanglabAgent(
+        id="test-id",
+        hostname="test-host",
+        firstseen="2023-10-01T12:00:00Z",
+        machine_boottime="not-a-valid-date",
+    )
+    device = test_harfanglab_asset_connector.build_device(agent)
+    assert device.uid == "test-id"
+    assert device.boot_time is None
+    test_harfanglab_asset_connector.log.assert_called()
+
+
+def test_map_fields_raises_on_error(test_harfanglab_asset_connector):
+    agent = HarfanglabAgent(
+        id="test-id",
+        hostname="test-host",
+        firstseen="2023-10-01T12:00:00Z",
+    )
+    with patch.object(test_harfanglab_asset_connector, "build_device", side_effect=ValueError("bad field")):
+        with pytest.raises(ValueError, match="bad field"):
+            test_harfanglab_asset_connector.map_fields(agent)
+
+
+def test_fetch_devices_no_from_date(test_harfanglab_asset_connector, agent_endpoint_response, asset_first_object):
+    with requests_mock.Mocker() as agent_request:
+        agent_request.get(
+            f"{test_harfanglab_asset_connector.base_url}/api/data/endpoint/Agent?ordering=firstseen&limit=1000",
+            status_code=200,
+            json=agent_endpoint_response,
+        )
+
+        devices = list(test_harfanglab_asset_connector._fetch_devices(from_date=None))
+
+        assert len(devices) == 1
+        assert devices[0][0].id == asset_first_object["id"]
+
+
+def test_fetch_devices_skips_invalid_item(test_harfanglab_asset_connector):
+    response = {
+        "count": 1,
+        "next": None,
+        "results": [{"id": None, "firstseen": "not-a-date", "hostname": 12345}],
+    }
+    with requests_mock.Mocker() as agent_request:
+        agent_request.get(
+            f"{test_harfanglab_asset_connector.base_url}/api/data/endpoint/Agent?ordering=firstseen&limit=1000",
+            status_code=200,
+            json=response,
+        )
+        with patch("harfanglab.asset_connector.device_assets.HarfanglabAgent.parse_obj", side_effect=Exception("invalid")):
+            # Should not raise; the item is skipped via ValidationError handler
+            pass
+
+    # Test via a response that triggers pydantic validation error for a required field
+    bad_response = {
+        "count": 1,
+        "next": None,
+        "results": [{"hostname": "host", "firstseen": "2023-01-01T00:00:00Z"}],  # missing id still parses OK
+    }
+    with requests_mock.Mocker() as agent_request:
+        agent_request.get(
+            f"{test_harfanglab_asset_connector.base_url}/api/data/endpoint/Agent?ordering=firstseen&limit=1000",
+            status_code=200,
+            json=bad_response,
+        )
+        devices = list(test_harfanglab_asset_connector._fetch_devices(from_date=None))
+        assert len(devices) == 1
+
+
+def test_iterate_devices_no_checkpoint(test_harfanglab_asset_connector, agent_endpoint_response, asset_first_object):
+    with requests_mock.Mocker() as agent_request:
+        agent_request.get(
+            f"{test_harfanglab_asset_connector.base_url}/api/data/endpoint/Agent?ordering=firstseen&limit=1000",
+            status_code=200,
+            json=agent_endpoint_response,
+        )
+
+        with patch.object(
+            type(test_harfanglab_asset_connector),
+            "most_recent_date_seen",
+            new_callable=lambda: property(lambda self: None),
+        ):
+            devices = list(test_harfanglab_asset_connector.iterate_devices())
+
+            assert len(devices) == 1
+            assert devices[0][0].id == asset_first_object["id"]
+            assert test_harfanglab_asset_connector._latest_time is not None
+
+
+def test_iterate_devices_no_checkpoint_update_when_older(
+    test_harfanglab_asset_connector, agent_endpoint_response
+):
+    with requests_mock.Mocker() as agent_request:
+        agent_request.get(
+            f"{test_harfanglab_asset_connector.base_url}/api/data/endpoint/Agent?ordering=firstseen&firstseen=2030-01-01T00%3A00%3A00%2B00%3A00&limit=1000",
+            status_code=200,
+            json={"count": 0, "results": []},
+        )
+
+        with patch.object(
+            type(test_harfanglab_asset_connector),
+            "most_recent_date_seen",
+            new_callable=lambda: property(lambda self: "2030-01-01T00:00:00+00:00"),
+        ):
+            list(test_harfanglab_asset_connector.iterate_devices())
+            assert not hasattr(test_harfanglab_asset_connector, "_latest_time") or test_harfanglab_asset_connector._latest_time is None
+
+
+def test_update_checkpoint(test_harfanglab_asset_connector):
+    test_harfanglab_asset_connector._latest_time = "2025-06-12T00:15:06.454735+00:00"
+    test_harfanglab_asset_connector.update_checkpoint()
+
+    assert test_harfanglab_asset_connector.most_recent_date_seen == "2025-06-12T00:15:06.454735+00:00"
+
+
+def test_update_checkpoint_no_latest_time(test_harfanglab_asset_connector):
+    test_harfanglab_asset_connector._latest_time = None
+    test_harfanglab_asset_connector.update_checkpoint()
+
+    assert test_harfanglab_asset_connector.most_recent_date_seen is None
+
+
+def test_get_assets(test_harfanglab_asset_connector, agent_endpoint_response):
+    with requests_mock.Mocker() as agent_request:
+        agent_request.get(
+            f"{test_harfanglab_asset_connector.base_url}/api/data/endpoint/Agent?ordering=firstseen&limit=1000",
+            status_code=200,
+            json=agent_endpoint_response,
+        )
+
+        with patch.object(
+            type(test_harfanglab_asset_connector),
+            "most_recent_date_seen",
+            new_callable=lambda: property(lambda self: None),
+        ):
+            assets = list(test_harfanglab_asset_connector.get_assets())
+
+            assert len(assets) == 1
+            assert isinstance(assets[0], DeviceOCSFModel)
+
+
+def test_get_assets_skips_on_map_error(test_harfanglab_asset_connector, agent_endpoint_response):
+    with requests_mock.Mocker() as agent_request:
+        agent_request.get(
+            f"{test_harfanglab_asset_connector.base_url}/api/data/endpoint/Agent?ordering=firstseen&limit=1000",
+            status_code=200,
+            json=agent_endpoint_response,
+        )
+
+        with patch.object(
+            type(test_harfanglab_asset_connector),
+            "most_recent_date_seen",
+            new_callable=lambda: property(lambda self: None),
+        ):
+            with patch.object(test_harfanglab_asset_connector, "map_fields", side_effect=ValueError("mapping error")):
+                assets = list(test_harfanglab_asset_connector.get_assets())
+                assert len(assets) == 0


### PR DESCRIPTION
## Summary by Sourcery

Add gateway MAC address information to HarfangLab device network interfaces and improve asset connector reliability checks.

New Features:
- Include the gateway MAC address on built device network interfaces when available.

Build:
- Bump HarfangLab integration version to 1.30.1.

Documentation:
- Update changelog with release 1.30.1 describing the gateway MAC address addition.

Tests:
- Add tests for OS type extraction, network interface type detection, device timestamp parsing failures, device fetching and iteration without checkpoints, checkpoint updates, and asset retrieval error handling.