### PR TITLE
fix(sophos): fix samples

### DIFF
--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix the samples in the asset connector yml file
+- Fix the samples in the asset connector YAML file (`device_mapping.yml`)
 
 ## 2026-04-27 - 1.18.1
 

--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-05-04 - 1.18.2
+
+### Fixed
+
+- Fix the samples in the asset connector yml file
+
 ## 2026-04-27 - 1.18.1
 
 ### Fixed

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,7 +38,7 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "categories": [
     "Endpoint",
     "Network"

--- a/Sophos/sophos_module/asset_connector/device_mapping.yml
+++ b/Sophos/sophos_module/asset_connector/device_mapping.yml
@@ -6,7 +6,7 @@ mapping:
   samples:
     - name: "Sophos EDR endpoint sample"
       description: "Sample endpoint data from Sophos Central API GET /endpoint/v1/endpoints"
-      data:
+      data: |
         {
           "id": "00000000-0000-0000-0000-000000000001",
           "type": "computer",
@@ -289,7 +289,7 @@ mapping:
   ocsf_samples:
     - name: "Device Inventory Info – Sophos EDR"
       description: "Transformed Sophos endpoint to OCSF Device Inventory Info"
-      data:
+      data: |
         {
           "activity_id": 2,
           "activity_name": "Collect",


### PR DESCRIPTION
## Summary by Sourcery

Bump the Sophos integration to version 1.18.2 and correct the embedded JSON samples in the asset connector mapping configuration.

Bug Fixes:
- Fix improperly formatted sample JSON blocks in the asset connector device mapping configuration so they are treated as literal data instead of YAML structures.

Documentation:
- Add a changelog entry documenting the 1.18.2 release and the fix to the asset connector samples.