### PR TITLE
Feature: NetScope New Events (1549)

### DIFF
--- a/Netskope/CHANGELOG.md
+++ b/Netskope/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-05-11 - 1.13.0
+
+### Added
+
+- New `netskope_security_check_connector` that collects Netskope sandbox / security-check.
+
 ## 2026-04-23 - 1.12.0
 
 ### Fixed

--- a/Netskope/connector_security_check.json
+++ b/Netskope/connector_security_check.json
@@ -1,0 +1,35 @@
+{
+  "description": "Get Netskope sandbox/security-check alerts (Cloud Sandbox, malicious sites, DLP) from the Netskope API v2",
+  "docker_parameters": "netskope_security_check_connector",
+  "name": "Fetch Netskope Security Check alerts",
+  "arguments": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "api_token": {
+        "type": "string",
+        "description": "The API token"
+      },
+      "intake_server": {
+        "description": "Server of the intake server (e.g. 'https://intake.sekoia.io')",
+        "default": "https://intake.sekoia.io",
+        "type": "string"
+      },
+      "intake_key": {
+        "description": "Intake key to use when sending events",
+        "type": "string"
+      },
+      "consumer_group": {
+        "description": "A unique name to track event consumption (default empty for auto-generated one)",
+        "type": "string",
+        "default": ""
+      }
+    },
+    "required": [
+      "api_token",
+      "intake_key"
+    ],
+    "title": "The configuration to fetch Netskope security check alerts",
+    "type": "object"
+  },
+  "uuid": "9e292f7e-146f-4839-926e-dac6ba8a6275"
+}

--- a/Netskope/main.py
+++ b/Netskope/main.py
@@ -1,9 +1,13 @@
 from netskope_modules import NetskopeModule
 from netskope_modules.connector_pubsub_lite import PubSubLite
 from netskope_modules.connector_pull_events_v2 import NetskopeEventConnector
+from netskope_modules.connector_security_check import NetskopeSecurityCheckConnector
 
 if __name__ == "__main__":
     module = NetskopeModule()
+
     module.register(NetskopeEventConnector, "netskope_events_connector_v2")
     module.register(PubSubLite, "netskope_pubsub_lite")
+    module.register(NetskopeSecurityCheckConnector, "netskope_security_check_connector")
+
     module.run()

--- a/Netskope/manifest.json
+++ b/Netskope/manifest.json
@@ -20,7 +20,7 @@
   "name": "Netskope",
   "uuid": "1e3f2e33-fb9c-4387-bcf7-8d7ece37f913",
   "slug": "netskope",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "categories": [
     "Network"
   ]

--- a/Netskope/netskope_modules/connector_security_check.py
+++ b/Netskope/netskope_modules/connector_security_check.py
@@ -1,0 +1,22 @@
+from functools import cached_property
+
+from netskope_modules.connector_pull_events_v2 import NetskopeEventConnector
+from netskope_modules.types import NetskopeAlertType, NetskopeEventType
+
+
+class NetskopeSecurityCheckConnector(NetskopeEventConnector):
+    """
+    Fetches Netskope sandbox / security-check alerts only.
+
+    Netskope API references:
+    - https://docs.netskope.com/en/using-the-rest-api-v2-dataexport-iterator-endpoints/
+    - https://docs.netskope.com/en/rest-api-events-and-alerts-response-descriptions/
+    """
+
+    @cached_property
+    def dataexports(self) -> list[tuple[NetskopeEventType, NetskopeAlertType | None]]:
+        return [
+            (NetskopeEventType.ALERT, NetskopeAlertType.MALWARE),
+            (NetskopeEventType.ALERT, NetskopeAlertType.MALSITE),
+            (NetskopeEventType.ALERT, NetskopeAlertType.DLP),
+        ]

--- a/Netskope/tests/test_security_check_connector.py
+++ b/Netskope/tests/test_security_check_connector.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests_mock
+from netskope_api.iterator.netskope_iterator import NetskopeIterator
+
+from netskope_modules import NetskopeModule
+from netskope_modules.connector_pull_events_v2 import NetskopeEventConsumer
+from netskope_modules.connector_security_check import NetskopeSecurityCheckConnector
+from netskope_modules.types import NetskopeAlertType, NetskopeEventType
+
+
+@pytest.fixture
+def trigger(symphony_storage):
+    module = NetskopeModule()
+    module._trigger_configuration_uuid = "ec92e51c-d45e-47b1-b820-29b97721623f"
+    trigger = NetskopeSecurityCheckConnector(module=module, data_path=symphony_storage)
+    trigger.log = MagicMock()
+    trigger.log_exception = MagicMock()
+    trigger.push_events_to_intakes = MagicMock()
+    trigger.module.configuration = {
+        "base_url": "https://my.fake.sekoia",
+    }
+    trigger.configuration = {
+        "api_token": "api_token",
+        "intake_key": "intake_key",
+        "consumer_group": "",
+    }
+    return trigger
+
+
+def test_dataexports_only_contains_security_check_alerts(trigger):
+    assert trigger.dataexports == [
+        (NetskopeEventType.ALERT, NetskopeAlertType.MALWARE),
+        (NetskopeEventType.ALERT, NetskopeAlertType.MALSITE),
+        (NetskopeEventType.ALERT, NetskopeAlertType.DLP),
+    ]
+
+
+def test_create_iterators_covers_only_three_endpoints(trigger):
+    iterators = trigger.create_iterators(trigger.dataexports)
+
+    assert len(iterators) == 3
+    assert set(iterators.keys()) == {"alert-malware", "alert-malsite", "alert-dlp"}
+    for iterator in iterators.values():
+        assert isinstance(iterator, NetskopeIterator)
+
+
+@pytest.mark.parametrize(
+    "alert_type,endpoint",
+    [
+        (NetskopeAlertType.MALWARE, "https://my.fake.sekoia/api/v2/events/dataexport/alerts/malware"),
+        (NetskopeAlertType.MALSITE, "https://my.fake.sekoia/api/v2/events/dataexport/alerts/malsite"),
+        (NetskopeAlertType.DLP, "https://my.fake.sekoia/api/v2/events/dataexport/alerts/dlp"),
+    ],
+)
+def test_next_batch_pushes_events_for_each_alert_type(trigger, alert_type, endpoint):
+    with patch("netskope_modules.connector_pull_events_v2.time") as mock_time, requests_mock.Mocker() as mock_requests:
+        mock_requests.get(
+            endpoint,
+            status_code=200,
+            json={
+                "ok": 1,
+                "result": [
+                    {
+                        "timestamp": 1651424472,
+                        "_id": "abc123",
+                        "alert_type": alert_type.value,
+                    }
+                ],
+            },
+        )
+        iterator = trigger.create_iterator(NetskopeEventType.ALERT, alert_type)
+        consumer = NetskopeEventConsumer(trigger, f"alert-{alert_type.value}", iterator)
+        start_time = 1666711174.0
+        end_time = start_time + 5
+        mock_time.time.side_effect = [start_time, end_time, end_time]
+
+        consumer.next_batch()
+
+        assert trigger.push_events_to_intakes.call_count == 1


### PR DESCRIPTION
Relates to [1549](https://github.com/SekoiaLab/integration/issues/1549)

## Summary by Sourcery

Introduce a dedicated Netskope connector to collect sandbox/security-check alerts and wire it into the Netskope integration.

New Features:
- Add `netskope_security_check_connector` to fetch malware, malsite, and DLP alerts from Netskope data export APIs.

Enhancements:
- Register the new security check connector in the Netskope module entrypoint and bump the integration version to 1.13.0.
- Document the new connector in the Netskope changelog.

Tests:
- Add unit tests covering the security check connector data exports, iterator creation, and event consumption flow.