### PR TITLE
CrowdStrikeFalcon: set EVENTS_LAG metric to zero when no event is to forward

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-05-19 - 1.25.16
+
+### Fixed
+
+- Set EVENTS_LAG metric to zero when no event is to forward
+
 ## 2026-05-15 - 1.25.15
 
 ### Fixed

--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Set EVENTS_LAG metric to zero when no event is to forward
+- Set EVENTS_LAG metric to zero when there are no events to forward
 
 ## 2026-05-15 - 1.25.15
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -511,6 +511,10 @@ class EventForwarder(threading.Thread):
                                     intake_key=self.connector.configuration.intake_key, stream=stream_root_url
                                 ).set(lag)
             except queue.Empty:
+                for stream_root_url in self.stream_root_urls:
+                    EVENTS_LAG.labels(intake_key=self.connector.configuration.intake_key, stream=stream_root_url).set(
+                        0
+                    )
                 pass
             except Exception as error:
                 self.log_exception(error, message="Failed to forward events")

--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -436,9 +436,11 @@ class EventForwarder(threading.Thread):
     def __init__(
         self,
         connector: "EventStreamTrigger",
+        stream_root_urls: set[str],
     ):
         super().__init__()
         self.connector = connector
+        self.stream_root_urls = stream_root_urls
         self.events_queue = connector.events_queue
         self._stop_event = threading.Event()
 
@@ -661,7 +663,7 @@ class EventStreamTrigger(Connector):
             streams: dict[str, dict] = self.get_streams(app_id)
 
             # start a thread to consume the internal event queue
-            read_queue_thread = EventForwarder(self)
+            read_queue_thread = EventForwarder(self, set(streams.keys()))
             read_queue_thread.start()
 
             # start threads to consume streams
@@ -672,7 +674,7 @@ class EventStreamTrigger(Connector):
                     # if the read queue thread is down, we spawn a new one
                     if not read_queue_thread.is_alive():
                         self.log(message="Event forwarder failed", level="error")
-                        read_queue_thread = EventForwarder(self)
+                        read_queue_thread = EventForwarder(self, set(streams.keys()))
                         read_queue_thread.start()
 
                     self.supervise_streams(streams, stream_threads)

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "CrowdStrike Falcon is a cloud-native cybersecurity platform known for its advanced threat detection, endpoint protection, and real-time response capabilities. It leverages AI and machine learning to protect against malware and sophisticated cyberattacks.",
-  "version": "1.25.15",
+  "version": "1.25.16",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/CrowdStrikeFalcon/tests/test_event_stream_trigger.py
+++ b/CrowdStrikeFalcon/tests/test_event_stream_trigger.py
@@ -39,10 +39,11 @@ def trigger(symphony_storage):
 
 
 def test_read_queue(trigger):
-    trigger.events_queue.put(("fake-stream-url", '{"metadata": {"offset": 10}, "foo": "bar"}'))
+    stream_root_url = "fake-stream-url"
+    trigger.events_queue.put((stream_root_url, '{"metadata": {"offset": 10}, "foo": "bar"}'))
 
     trigger.push_events_to_intakes = MagicMock()
-    t = EventForwarder(trigger)
+    t = EventForwarder(trigger, {stream_root_url})
     t.start()
 
     time.sleep(2)


### PR DESCRIPTION
## Summary by Sourcery

Ensure the EVENTS_LAG metric is reset to zero whenever no events are available to forward across all active streams and bump the CrowdStrike Falcon connector version.

Bug Fixes:
- Reset the EVENTS_LAG metric to zero for all streams when no events are present or the event queue is empty to avoid stale lag values.

Build:
- Bump the CrowdStrike Falcon integration manifest version to 1.25.16.

Documentation:
- Update the changelog with a new 1.25.16 release entry describing the EVENTS_LAG metric fix.

Tests:
- Adjust the EventForwarder test to pass stream identifiers into the thread to reflect the new metric-reset behavior.