### PR TITLE
CrowdStrikeFalcon: stop the connectors on authentication error

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Stop the connector on authentication error
+- Stop the connector when authentication fails
 
 ## 2026-05-19 - 1.25.16
 

--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-05-19 - 1.25.17
+
+### Changed
+
+- Stop the connector on authentication error
+
 ## 2026-05-19 - 1.25.16
 
 ### Fixed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
@@ -28,6 +28,7 @@ from sekoia_automation.storage import PersistentJSON
 
 from crowdstrike_falcon.asset_connectors.crowdstrike_device_model import CrowdStrikeDevice
 from crowdstrike_falcon.client import CrowdstrikeFalconClient
+from crowdstrike_falcon.client.auth import AuthenticationError
 
 
 class CrowdstrikeDeviceAssetConnector(AssetConnector):
@@ -426,7 +427,14 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
         Main generator that yields OCSF-formatted device assets.
         """
         self.log("Start the getting assets generator !!", level="info")
-        for device in self.next_devices():
-            mapped = self.map_device_fields(device)
-            if mapped is not None:  # pragma: no branch
-                yield mapped
+
+        try:
+            for device in self.next_devices():
+                mapped = self.map_device_fields(device)
+                if mapped is not None:  # pragma: no branch
+                    yield mapped
+        except AuthenticationError as error:
+            self.log(
+                message=str(error),
+                level="critical",
+            )

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/user_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/user_assets.py
@@ -20,6 +20,7 @@ from sekoia_automation.storage import PersistentJSON
 
 from crowdstrike_falcon.asset_connectors.crowdstrike_user_model import CrowdStrikeUser, CrowdStrikeUserAccount
 from crowdstrike_falcon.client import CrowdstrikeFalconClient
+from crowdstrike_falcon.client.auth import AuthenticationError
 
 IDENTITY_ENTITIES_QUERY = """
 {
@@ -277,5 +278,12 @@ class CrowdstrikeUserAssetConnector(AssetConnector):
     def get_assets(self) -> Generator[UserOCSFModel, None, None]:
         """Retrieve user assets from Crowdstrike and map them to OCSF models."""
         self.log("Fetching users from Identity Protection GraphQL endpoint", level="info")
-        for entity in self._fetch_identity_entities():
-            yield self.map_identity_entity_fields(entity)
+
+        try:
+            for entity in self._fetch_identity_entities():
+                yield self.map_identity_entity_fields(entity)
+        except AuthenticationError as error:
+            self.log(
+                message=str(error),
+                level="critical",
+            )

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/auth.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/auth.py
@@ -3,9 +3,38 @@ from posixpath import join as urljoin
 
 import requests
 from requests.auth import AuthBase
+from requests.exceptions import JSONDecodeError
 from requests_ratelimiter import LimiterAdapter
 
 from crowdstrike_falcon.client.retry import Retry
+
+
+class AuthenticationError(Exception):
+    def __init__(self, message: str, reason: str | None = None):
+        self.message = message
+        self.reason = reason
+
+    def __str__(self) -> str:
+        message = self.message
+
+        if self.reason:
+            message = f"{message}: {self.reason}"
+
+        return message
+
+    @classmethod
+    def from_http_response(cls, message: str, response: requests.Response):
+        reason = None
+        try:
+            errors = response.json().get("errors", [])
+            reason = ",".join([error["message"] for error in errors if "message" in error])
+        except JSONDecodeError:
+            reason = response.text
+
+        return cls(
+            message=message,
+            reason=reason,
+        )
 
 
 class CrowdStrikeFalconApiCredentials:
@@ -66,7 +95,15 @@ class CrowdStrikeFalconApiAuthentication(AuthBase):
                 },
             )
 
-            response.raise_for_status()
+            if not response.ok:
+                # Raise exception when facing Unauthorized error
+                if response.status_code == 401:
+                    raise AuthenticationError.from_http_response("Unauthorized", response)
+                # Raise exception when facing Forbidden error
+                elif response.status_code == 403:
+                    raise AuthenticationError.from_http_response("Forbidden", response)
+                else:
+                    response.raise_for_status()
 
             credentials = CrowdStrikeFalconApiCredentials()
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/auth.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/auth.py
@@ -11,6 +11,7 @@ from crowdstrike_falcon.client.retry import Retry
 
 class AuthenticationError(Exception):
     def __init__(self, message: str, reason: str | None = None):
+        super().__init__(message)
         self.message = message
         self.reason = reason
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/auth.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/auth.py
@@ -15,11 +15,20 @@ class AuthenticationError(Exception):
         self.message = message
         self.reason = reason
 
+    @staticmethod
+    def _normalize_reason(message: str, reason: str) -> str:
+        prefix = f"{message}:"
+        if reason.startswith(prefix):
+            return reason[len(prefix) :].lstrip()
+
+        return reason
+
     def __str__(self) -> str:
         message = self.message
 
         if self.reason:
-            message = f"{message}: {self.reason}"
+            reason = self._normalize_reason(message, self.reason)
+            message = f"{message}: {reason}"
 
         return message
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/event_stream_trigger.py
@@ -15,6 +15,7 @@ from sekoia_automation.timer import RepeatedTimer
 
 from crowdstrike_falcon import CrowdStrikeFalconModule
 from crowdstrike_falcon.client import CrowdstrikeFalconClient
+from crowdstrike_falcon.client.auth import AuthenticationError
 from crowdstrike_falcon.exceptions import StreamNotAvailable
 from crowdstrike_falcon.helpers import (
     compute_refresh_interval,
@@ -126,6 +127,11 @@ class VerticlesCollector:
                         message=f"Failed to collect verticles for edge_type {edge_type} for graph_id {graph_id}",
                         level="warning",
                     )
+                except AuthenticationError as error:
+                    self.log(
+                        message=str(error),
+                        level="critical",
+                    )
 
     def collect_verticles_from_detection(self, detection_id: str) -> Generator[tuple[str, str, dict], None, None]:
         """
@@ -149,6 +155,11 @@ class VerticlesCollector:
                     f"Failed to collect verticles for detection {detection_id}: "
                     f"{error.response.status_code} {error.response.reason}"
                 ),
+            )
+        except AuthenticationError as error:
+            self.log(
+                message=str(error),
+                level="critical",
             )
         except Exception as error:
             self.log_exception(
@@ -187,7 +198,11 @@ class VerticlesCollector:
                     f"{error.response.status_code} {error.response.reason}"
                 ),
             )
-
+        except AuthenticationError as error:
+            self.log(
+                message=str(error),
+                level="critical",
+            )
         except Exception as error:
             self.log_exception(
                 error,
@@ -352,6 +367,11 @@ class EventStreamReader(threading.Thread):
                         )
                         break
 
+        except AuthenticationError as error:
+            self.log(
+                message=str(error),
+                level="critical",
+            )
         except Exception as any_exception:
             self.log_exception(any_exception)
             raise
@@ -693,5 +713,10 @@ class EventStreamTrigger(Connector):
                 time.sleep(60)  # The authentication faces a ratelimit, sleep 1 minutes
             else:
                 self.log_exception(error, message="Failed to fetch and forward events")
+        except AuthenticationError as error:
+            self.log(
+                message=str(error),
+                level="critical",
+            )
         except Exception as error:
             self.log_exception(error, message="Failed to fetch and forward events")

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "CrowdStrike Falcon is a cloud-native cybersecurity platform known for its advanced threat detection, endpoint protection, and real-time response capabilities. It leverages AI and machine learning to protect against malware and sophisticated cyberattacks.",
-  "version": "1.25.16",
+  "version": "1.25.17",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
@@ -1,17 +1,18 @@
+from unittest.mock import Mock
+
 import pytest
 import requests_mock
-from unittest.mock import Mock
+from sekoia_automation.asset_connector.models.ocsf.device import (
+    DeviceTypeId,
+    DeviceTypeStr,
+    OSTypeId,
+    OSTypeStr,
+)
 
 from crowdstrike_falcon import CrowdStrikeFalconModule
 from crowdstrike_falcon.asset_connectors.crowdstrike_device_model import CrowdStrikeDevice, PolicyEntry
 from crowdstrike_falcon.asset_connectors.device_assets import CrowdstrikeDeviceAssetConnector
 from crowdstrike_falcon.client.auth import AuthenticationError
-from sekoia_automation.asset_connector.models.ocsf.device import (
-    OSTypeId,
-    OSTypeStr,
-    DeviceTypeId,
-    DeviceTypeStr,
-)
 
 
 class _DummyContext:

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import Mock
 
+from crowdstrike_falcon import CrowdStrikeFalconModule
 from crowdstrike_falcon.asset_connectors.crowdstrike_device_model import CrowdStrikeDevice, PolicyEntry
 from crowdstrike_falcon.asset_connectors.device_assets import CrowdstrikeDeviceAssetConnector
 from sekoia_automation.asset_connector.models.ocsf.device import (
@@ -24,23 +25,23 @@ class _DummyContext:
 
 @pytest.fixture
 def connector():
-    class FakeCrowdStrikeDeviceModule:
-        configuration = {
-            "sekoia_base_url": "https://api.fake.sekoia.io/",
-            "frequency": 60,
-            "sekoia_api_key": "fake_api_key",
-            "batch_size": 100,
-        }
-        manifest = {
-            "client_id": "fake_client_id",
-            "client_secret": "fake_client_secret",
-            "base_url": "https://api.fake",
-        }
+    module = CrowdStrikeFalconModule()
+    module.configuration = {
+        "client_id": "fake_client_id",
+        "client_secret": "fake_client_secret",
+        "base_url": "https://api.fake",
+    }
+    connector = CrowdstrikeDeviceAssetConnector(module=module)
+    connector.configuration = {
+        "sekoia_base_url": "https://api.fake.sekoia.io/",
+        "frequency": 60,
+        "sekoia_api_key": "fake_api_key",
+        "batch_size": 100,
+    }
 
-    c = CrowdstrikeDeviceAssetConnector(module=FakeCrowdStrikeDeviceModule())
-    c.context = _DummyContext()
-    c.log = Mock()
-    return c
+    connector.context = _DummyContext()
+    connector.log = Mock()
+    return connector
 
 
 @pytest.mark.parametrize(

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
@@ -1,9 +1,11 @@
 import pytest
+import requests_mock
 from unittest.mock import Mock
 
 from crowdstrike_falcon import CrowdStrikeFalconModule
 from crowdstrike_falcon.asset_connectors.crowdstrike_device_model import CrowdStrikeDevice, PolicyEntry
 from crowdstrike_falcon.asset_connectors.device_assets import CrowdstrikeDeviceAssetConnector
+from crowdstrike_falcon.client.auth import AuthenticationError
 from sekoia_automation.asset_connector.models.ocsf.device import (
     OSTypeId,
     OSTypeStr,
@@ -353,3 +355,37 @@ def test_is_device_compliant(connector):
     assert connector.is_device_compliant(compliant) is True
     assert connector.is_device_compliant(non_compliant) is False
     assert connector.is_device_compliant(CrowdStrikeDevice()) is None
+
+
+def test_authentication_error_unauthorized(connector):
+    """Test that AuthenticationError is raised when authentication fails with 401."""
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            f"{connector.module.configuration.base_url}/oauth2/token",
+            status_code=401,
+            json={
+                "meta": {"trace_id": "test-trace-id"},
+                "errors": [{"code": 401, "message": "Invalid credentials provided"}],
+            },
+        )
+
+        with pytest.raises(AuthenticationError, match="Unauthorized: Invalid credentials provided"):
+            list(connector.next_devices())
+
+
+def test_authentication_error_forbidden(connector):
+    """Test that AuthenticationError is raised when authentication fails with 403."""
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            f"{connector.module.configuration.base_url}/oauth2/token",
+            status_code=403,
+            json={
+                "meta": {"trace_id": "test-trace-id"},
+                "errors": [{"code": 403, "message": "Insufficient permissions for API access"}],
+            },
+        )
+
+        with pytest.raises(AuthenticationError, match="Forbidden: Insufficient permissions for API access"):
+            list(connector.next_devices())

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_user_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_user_asset_connector.py
@@ -1,4 +1,5 @@
 import pytest
+import requests_mock
 from datetime import datetime
 from unittest.mock import Mock
 
@@ -10,6 +11,7 @@ from crowdstrike_falcon.asset_connectors.crowdstrike_user_model import (
 from crowdstrike_falcon import CrowdStrikeFalconModule
 from crowdstrike_falcon.asset_connectors.user_assets import CrowdstrikeUserAssetConnector
 from crowdstrike_falcon.client import CrowdstrikeFalconClient
+from crowdstrike_falcon.client.auth import AuthenticationError
 from sekoia_automation.asset_connector.models.ocsf.user import (
     UserOCSFModel,
     AccountTypeId,
@@ -450,3 +452,48 @@ class TestListIdentityEntities:
             query="query { test }",
             data_path=["entities", "nodes"],
         )
+
+
+class TestAuthenticationErrors:
+    """Test authentication error handling for user asset connector."""
+
+    def test_authentication_error_unauthorized(self, connector):
+        """Test that AuthenticationError is raised when authentication fails with 401."""
+
+        with requests_mock.Mocker() as mock:
+            mock.register_uri(
+                "POST",
+                f"{connector.module.configuration.base_url}/oauth2/token",
+                status_code=401,
+                json={
+                    "meta": {"trace_id": "test-trace-id"},
+                    "errors": [{"code": 401, "message": "Invalid API credentials"}],
+                },
+            )
+
+            with pytest.raises(AuthenticationError, match="Unauthorized: Invalid API credentials"):
+                list(connector._fetch_identity_entities())
+
+    def test_authentication_error_forbidden(self, connector):
+        """Test that AuthenticationError is raised when authentication fails with 403."""
+
+        with requests_mock.Mocker() as mock:
+            mock.register_uri(
+                "POST",
+                f"{connector.module.configuration.base_url}/oauth2/token",
+                status_code=403,
+                json={
+                    "meta": {"trace_id": "test-trace-id"},
+                    "errors": [
+                        {
+                            "code": 403,
+                            "message": "Client authentication failed - insufficient permissions",
+                        }
+                    ],
+                },
+            )
+
+            with pytest.raises(
+                AuthenticationError, match="Forbidden: Client authentication failed - insufficient permissions"
+            ):
+                list(connector._fetch_identity_entities())

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_user_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_user_asset_connector.py
@@ -7,6 +7,7 @@ from crowdstrike_falcon.asset_connectors.crowdstrike_user_model import (
     CrowdStrikeUserAccount,
     CrowdStrikeUserRole,
 )
+from crowdstrike_falcon import CrowdStrikeFalconModule
 from crowdstrike_falcon.asset_connectors.user_assets import CrowdstrikeUserAssetConnector
 from crowdstrike_falcon.client import CrowdstrikeFalconClient
 from sekoia_automation.asset_connector.models.ocsf.user import (
@@ -29,19 +30,23 @@ class _DummyContext(dict):
 
 @pytest.fixture
 def connector():
-    class FakeModule:
-        class configuration:
-            base_url = "https://api.crowdstrike.com"
-            client_id = "fake_client_id"
-            client_secret = "fake_client_secret"
+    module = CrowdStrikeFalconModule()
+    module.configuration = {
+        "client_id": "fake_client_id",
+        "client_secret": "fake_client_secret",
+        "base_url": "https://api.fake",
+    }
+    connector = CrowdstrikeUserAssetConnector(module=module)
+    connector.configuration = {
+        "sekoia_base_url": "https://api.fake.sekoia.io/",
+        "frequency": 60,
+        "sekoia_api_key": "fake_api_key",
+        "batch_size": 100,
+    }
 
-        manifest = {"slug": "crowdstrike-falcon", "version": "1.0.0"}
-
-    c = CrowdstrikeUserAssetConnector(module=FakeModule())
-    c.context = _DummyContext()
-    c.log = Mock()
-    c.log_exception = Mock()
-    return c
+    connector.context = _DummyContext()
+    connector.log = Mock()
+    return connector
 
 
 @pytest.fixture

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_user_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_user_asset_connector.py
@@ -1,7 +1,8 @@
-import pytest
-import requests_mock
 from datetime import datetime
 from unittest.mock import Mock
+
+import pytest
+import requests_mock
 
 from crowdstrike_falcon.asset_connectors.crowdstrike_user_model import (
     CrowdStrikeUser,

--- a/CrowdStrikeFalcon/tests/client/test_auth.py
+++ b/CrowdStrikeFalcon/tests/client/test_auth.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
-import requests_mock
 import pytest
+import requests_mock
 
 from crowdstrike_falcon.client.auth import CrowdStrikeFalconApiAuthentication, AuthenticationError
 

--- a/CrowdStrikeFalcon/tests/client/test_auth.py
+++ b/CrowdStrikeFalcon/tests/client/test_auth.py
@@ -58,7 +58,7 @@ def test_get_credentials_unauthorized():
 
         with pytest.raises(
             AuthenticationError,
-            match="Unauthorized: Unauthorized: Please provide trace-id='00000000-0000-0000-0000-000000000000' to support",
+            match="Unauthorized: Please provide trace-id='00000000-0000-0000-0000-000000000000' to support",
         ):
             auth.get_credentials()
 

--- a/CrowdStrikeFalcon/tests/client/test_auth.py
+++ b/CrowdStrikeFalcon/tests/client/test_auth.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timedelta
 
 import requests_mock
+import pytest
 
-from crowdstrike_falcon.client.auth import CrowdStrikeFalconApiAuthentication
+from crowdstrike_falcon.client.auth import CrowdStrikeFalconApiAuthentication, AuthenticationError
 
 
 def test_get_credentials():
@@ -29,3 +30,65 @@ def test_get_credentials():
         assert credentials.expires_at > (current_dt + timedelta(seconds=1750))
         assert credentials.expires_at < (current_dt + timedelta(seconds=1850))
         assert credentials.authorization == "Bearer foo-token"
+
+
+def test_get_credentials_unauthorized():
+    base_url = "https://my.fake.sekoia"
+    client_id = "foo"
+    client_secret = "bar"
+    auth = CrowdStrikeFalconApiAuthentication(base_url, client_id, client_secret)
+
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            f"{base_url}/oauth2/token",
+            status_code=401,
+            json={
+                "meta": {
+                    "trace_id": "00000000-0000-0000-0000-000000000000",
+                },
+                "errors": [
+                    {
+                        "code": 401,
+                        "message": "Unauthorized: Please provide trace-id='00000000-0000-0000-0000-000000000000' to support",
+                    }
+                ],
+            },
+        )
+
+        with pytest.raises(
+            AuthenticationError,
+            match="Unauthorized: Unauthorized: Please provide trace-id='00000000-0000-0000-0000-000000000000' to support",
+        ):
+            auth.get_credentials()
+
+
+def test_get_credentials_forbidden():
+    base_url = "https://my.fake.sekoia"
+    client_id = "foo"
+    client_secret = "bar"
+    auth = CrowdStrikeFalconApiAuthentication(base_url, client_id, client_secret)
+
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            f"{base_url}/oauth2/token",
+            status_code=403,
+            json={
+                "meta": {
+                    "trace_id": "00000000-0000-0000-0000-000000000000",
+                },
+                "errors": [
+                    {
+                        "code": 403,
+                        "message": "Failed to issue access token - Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method)",
+                    }
+                ],
+            },
+        )
+
+        with pytest.raises(
+            AuthenticationError,
+            match="Forbidden: Failed to issue access token - Client authentication failed \(e.g., unknown client, no client authentication included, or unsupported authentication method\)",
+        ):
+            auth.get_credentials()


### PR DESCRIPTION
- Refactor the authentication module to raise a specific exception for 401 and 403 HTTP errors
- Log and stop the connectors when facing an AuthenticationError exception

## Summary by Sourcery

Handle CrowdStrike Falcon authentication failures explicitly and ensure connectors stop gracefully on authentication errors.

Enhancements:
- Introduce a dedicated AuthenticationError exception for 401/403 responses from the CrowdStrike Falcon token endpoint and use it in the authentication flow.
- Update event stream triggers and asset connectors to catch authentication errors, log them as critical, and stop processing instead of continuing.
- Align asset connector tests with the real module configuration and add coverage for authentication error handling in both device and user asset connectors, as well as the authentication client.

Documentation:
- Document the new behaviour of stopping connectors on authentication errors in the changelog.