### PR TITLE
Microsoft Entra ID GraphAPI - fix checkpoint for the signin events

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-05-21 - 2.10.22
+
+### Fixed
+
+- Fix checkpoint for signing events
+
 ## 2026-05-05 - 2.10.21
 
 ### Fixed

--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix checkpoint for signing events
+- Fix checkpoint for sign-in events
 
 ## 2026-05-05 - 2.10.21
 

--- a/MicrosoftEntraID/azure_ad/connector_entraid_graph_api.py
+++ b/MicrosoftEntraID/azure_ad/connector_entraid_graph_api.py
@@ -126,8 +126,8 @@ class MicrosoftEntraIdGraphApiConnector(AsyncConnector):
     async def run_signin(self) -> int:
         events: list[SignIn] = []
         total_events = 0
-        new_offset = self.last_event_date_directory.offset
-        async for event in self.client.get_signin_logs(start_date=self.last_event_date_directory.offset):
+        new_offset = self.last_event_date_signin.offset
+        async for event in self.client.get_signin_logs(start_date=self.last_event_date_signin.offset):
             if not self.running:  # pragma: no cover
                 break
 
@@ -142,7 +142,7 @@ class MicrosoftEntraIdGraphApiConnector(AsyncConnector):
                     new_offset = max(new_offset, data.created_date_time)
                     self.signin_cache[data.id] = True
 
-                self.last_event_date_directory.offset = new_offset
+                self.last_event_date_signin.offset = new_offset
                 self.persist_cache("signin")
                 events = []
 
@@ -153,7 +153,7 @@ class MicrosoftEntraIdGraphApiConnector(AsyncConnector):
                 new_offset = max(new_offset, data.created_date_time)
                 self.signin_cache[data.id] = True
 
-            self.last_event_date_directory.offset = new_offset
+            self.last_event_date_signin.offset = new_offset
             self.persist_cache("signin")
 
         return total_events

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.10.21",
+  "version": "2.10.22",
   "categories": [
     "IAM"
   ],


### PR DESCRIPTION
https://github.com/SekoiaLab/platform/issues/86075

## Summary by Sourcery

Fix incorrect checkpoint tracking for Microsoft Entra ID signin events and bump connector version.

Bug Fixes:
- Correct checkpoint offset handling to use the signin event cursor instead of the directory cursor for signin log collection.

Build:
- Bump Microsoft Entra ID connector version to 2.10.22.

Documentation:
- Document the signin checkpoint fix in the Microsoft Entra ID changelog.