### PR TITLE
Fix: O365 Session Closed Error

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-01 - 2.20.5
+
+### Changed
+
+- Add additional error handling
+
 ## 2026-05-22 - 2.20.4
 
 ### Fixed

--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2026-06-01 - 2.20.5
 
-### Changed
+### Fixed
 
-- Add additional error handling
+- Handle unexpected aiohttp session closures by raising `SessionClosedError` and rebuilding the Office365 client when needed.
 
 ## 2026-05-22 - 2.20.4
 

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.20.4",
+  "version": "2.20.5",
   "categories": [
     "Email"
   ]

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -118,37 +118,37 @@ class Office365Connector(AsyncConnector):
 
         await self.push_data_to_intakes(events=events)
 
-    async def activate_subscriptions(self):
+    async def _activate_subscriptions(self, recover: bool = False):
         """Activates an Office 365 subscriptions"""
         try:
             await self.client.activate_subscriptions()
         except SessionClosedError as exp:
-            if not self.running:
-                self.log(
-                    message="Skipped Office365 subscription activation: client session closed during shutdown.",
-                    level="info",
-                )
-                return
-            # Unexpected closure while still running: rebuild the client and try once more.
-            self.log_exception(
-                exception=exp,
-                message=(
-                    "Office365 client session was closed unexpectedly during subscription activation; "
-                    "rebuilding client."
-                ),
-            )
-            self._reset_client()
-            try:
-                await self.client.activate_subscriptions()
-            except SessionClosedError as retry_exp:
+            if not recover:
                 self.log_exception(
-                    exception=retry_exp,
+                    exception=exp,
                     message=(
                         "Office365 client session was closed again after recovery; "
                         "skipping subscription activation this run."
                     ),
                 )
                 return
+            else:
+                if not self.running:
+                    self.log(
+                        message="Skipped Office365 subscription activation: client session closed during shutdown.",
+                        level="info",
+                    )
+                    return
+                # Unexpected closure while still running: rebuild the client and try once more.
+                self.log_exception(
+                    exception=exp,
+                    message=(
+                        "Office365 client session was closed unexpectedly during subscription activation; "
+                        "rebuilding client."
+                    ),
+                )
+                self._reset_client()
+                await self._activate_subscriptions(False)
         except FailedToActivateO365Subscription as exp:
             self.log_exception(
                 exception=exp,
@@ -158,6 +158,10 @@ class Office365Connector(AsyncConnector):
                 message="Failed to activate Office365 subscriptions. The connector will produce no events.",
                 level="critical",
             )
+
+    async def activate_subscriptions(self):
+        """Activates an Office 365 subscriptions"""
+        await self._activate_subscriptions(True)
 
     async def forward_next_batches(self, checkpoint: Checkpoint):
         start_pull_date = checkpoint.offset

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -13,7 +13,7 @@ from office365.metrics import FORWARD_EVENTS_DURATION, OUTCOMING_EVENTS
 
 from .checkpoint import Checkpoint
 from .configuration import Office365Configuration
-from .errors import ApplicationAuthenticationFailed, FailedToActivateO365Subscription
+from .errors import ApplicationAuthenticationFailed, FailedToActivateO365Subscription, SessionClosedError
 from .helpers import split_date_range
 from .office365_client import Office365API
 
@@ -55,6 +55,15 @@ class Office365Connector(AsyncConnector):
         )
         self._client_closed = False
         return client
+
+    def _reset_client(self) -> None:
+        """Drop the cached Office365API so a fresh client (and aiohttp session) is built on next access.
+
+        Called after a SessionClosedError surfaces while the connector is still running, so the
+        next request rebuilds the underlying aiohttp.ClientSession.
+        """
+        self.__dict__.pop("client", None)
+        self._client_closed = False
 
     async def pull_content(self, start_date: datetime, end_date: datetime) -> AsyncGenerator[list[str], None]:
         """Pulls content from Office 365 subscriptions
@@ -113,6 +122,33 @@ class Office365Connector(AsyncConnector):
         """Activates an Office 365 subscriptions"""
         try:
             await self.client.activate_subscriptions()
+        except SessionClosedError as exp:
+            if not self.running:
+                self.log(
+                    message="Skipped Office365 subscription activation: client session closed during shutdown.",
+                    level="info",
+                )
+                return
+            # Unexpected closure while still running: rebuild the client and try once more.
+            self.log_exception(
+                exception=exp,
+                message=(
+                    "Office365 client session was closed unexpectedly during subscription activation; "
+                    "rebuilding client."
+                ),
+            )
+            self._reset_client()
+            try:
+                await self.client.activate_subscriptions()
+            except SessionClosedError as retry_exp:
+                self.log_exception(
+                    exception=retry_exp,
+                    message=(
+                        "Office365 client session was closed again after recovery; "
+                        "skipping subscription activation this run."
+                    ),
+                )
+                return
         except FailedToActivateO365Subscription as exp:
             self.log_exception(
                 exception=exp,
@@ -161,6 +197,19 @@ class Office365Connector(AsyncConnector):
                 delta_sleep = self._frequency - batch_duration
                 if delta_sleep > 0:
                     await asyncio.sleep(delta_sleep)
+            except SessionClosedError as exp:
+                if not self.running:
+                    self.log(
+                        message="Stopping event forwarding: client session closed during shutdown.",
+                        level="info",
+                    )
+                    return
+                self.log_exception(
+                    exp,
+                    message="Office365 client session was closed unexpectedly; rebuilding client and continuing.",
+                )
+                self._reset_client()
+                await asyncio.sleep(self._frequency)
             except Exception as error:
                 self.log_exception(error, message="Failed to forward events")
                 # Continue the loop to retry after logging
@@ -216,5 +265,17 @@ class Office365Connector(AsyncConnector):
 
             self.log_exception(auth_error)
             self.log(message=message, level="critical")
+
+        except SessionClosedError as session_error:
+            if self.running:
+                self.log_exception(
+                    session_error,
+                    message="Office365 client session closed unexpectedly; the connector will stop.",
+                )
+            else:
+                self.log(
+                    message="Office365 client session closed during shutdown.",
+                    level="info",
+                )
 
         self.log(message="Office365 Trigger has stopped", level="info")

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -209,11 +209,11 @@ class Office365Connector(AsyncConnector):
                     )
                     return
                 self.log_exception(
-                    exp,
                     message="Office365 client session was closed unexpectedly; rebuilding client and continuing.",
                 )
                 self._reset_client()
-                await asyncio.sleep(self._frequency)
+                if self.running:
+                    await asyncio.sleep(self._frequency)
             except Exception as error:
                 self.log_exception(error, message="Failed to forward events")
                 # Continue the loop to retry after logging

--- a/Office365/office365/management_api/errors.py
+++ b/Office365/office365/management_api/errors.py
@@ -34,3 +34,9 @@ class FailedToGetO365SubscriptionContents(ContextualizedO365Exception):
 
 class FailedToGetO365AuditContent(ContextualizedO365Exception):
     pass
+
+
+class SessionClosedError(O365Exception):
+    """Raised when an Office365 API call is attempted on a closed aiohttp session."""
+
+    pass

--- a/Office365/office365/management_api/office365_client.py
+++ b/Office365/office365/management_api/office365_client.py
@@ -16,6 +16,7 @@ from .errors import (
     FailedToGetO365AuditContent,
     FailedToGetO365SubscriptionContents,
     FailedToListO365Subscriptions,
+    SessionClosedError,
 )
 from .logging import get_logger
 
@@ -78,6 +79,9 @@ class Office365API:
 
         Check the expiration time of the current token and renew it if expired
         """
+        if self._session.closed:
+            raise SessionClosedError("Office365 client session is already closed")
+
         if time.time() > self._token_expiration - 10:
             await self._authenticate_client()
 
@@ -97,30 +101,38 @@ class Office365API:
         missing_types = EXPECTED_SUBSCRIPTIONS - already_enabled_types
 
         # Activate missing types
-        async with self._fresh_session() as session:
-            for content_type in missing_types:
-                # activate the subscription
-                base_url = OFFICE365_URL_BASE.format(tenant_id=self.tenant_id)
-                response = await session.post(f"{base_url}/subscriptions/start", params={"contentType": content_type})
-
-                try:
-                    subscription = await response.json(content_type=None)
-                except Exception:
-                    subscription = None
-
-                if isinstance(subscription, dict) and "error" in subscription:
-                    # AF20024 means the subscription is already enabled, which is fine
-                    if subscription["error"].get("code") == "AF20024":
-                        continue
-
-                    raise FailedToActivateO365Subscription(
-                        error_code=subscription["error"].get("code"),
-                        error_message=subscription["error"].get("message"),
+        try:
+            async with self._fresh_session() as session:
+                for content_type in missing_types:
+                    # activate the subscription
+                    base_url = OFFICE365_URL_BASE.format(tenant_id=self.tenant_id)
+                    response = await session.post(
+                        f"{base_url}/subscriptions/start", params={"contentType": content_type}
                     )
 
-                # check HTTP status code
-                if response.status >= 400:
-                    raise FailedToActivateO365Subscription(status_code=response.status, body=await response.text())
+                    try:
+                        subscription = await response.json(content_type=None)
+                    except Exception:
+                        subscription = None
+
+                    if isinstance(subscription, dict) and "error" in subscription:
+                        # AF20024 means the subscription is already enabled, which is fine
+                        if subscription["error"].get("code") == "AF20024":
+                            continue
+
+                        raise FailedToActivateO365Subscription(
+                            error_code=subscription["error"].get("code"),
+                            error_message=subscription["error"].get("message"),
+                        )
+
+                    # check HTTP status code
+                    if response.status >= 400:
+                        raise FailedToActivateO365Subscription(status_code=response.status, body=await response.text())
+
+        except RuntimeError as exc:
+            if "Session is closed" in str(exc):
+                raise SessionClosedError(str(exc)) from exc
+            raise
 
     async def list_subscriptions(self) -> list[str]:
         """
@@ -131,31 +143,37 @@ class Office365API:
         """
         base_url = OFFICE365_URL_BASE.format(tenant_id=self.tenant_id)
 
-        async with self._fresh_session() as session:
-            # get the list of subscriptions
-            response = await session.get(f"{base_url}/subscriptions/list")
+        try:
+            async with self._fresh_session() as session:
+                # get the list of subscriptions
+                response = await session.get(f"{base_url}/subscriptions/list")
 
-            # check HTTP status code
-            if response.status >= 400:
-                raise FailedToListO365Subscriptions(status_code=response.status, body=await response.text())
+                # check HTTP status code
+                if response.status >= 400:
+                    raise FailedToListO365Subscriptions(status_code=response.status, body=await response.text())
 
-            # get the body of the response
-            subscriptions = await response.json()
+                # get the body of the response
+                subscriptions = await response.json()
 
-            # check business errors
-            if "error" in subscriptions:
-                raise FailedToListO365Subscriptions(
-                    error_code=subscriptions["error"].get("code"), error_message=subscriptions["error"].get("message")
-                )
+                # check business errors
+                if "error" in subscriptions:
+                    raise FailedToListO365Subscriptions(
+                        error_code=subscriptions["error"].get("code"),
+                        error_message=subscriptions["error"].get("message"),
+                    )
 
-            # select active subscriptions
-            active_subscriptions = {
-                subscription["contentType"]
-                for subscription in subscriptions
-                if subscription["status"].lower() == OFFICE365_ACTIVE_SUBSCRIPTION_STATUS
-            }
+                # select active subscriptions
+                active_subscriptions = {
+                    subscription["contentType"]
+                    for subscription in subscriptions
+                    if subscription["status"].lower() == OFFICE365_ACTIVE_SUBSCRIPTION_STATUS
+                }
 
-            return list(active_subscriptions)
+                return list(active_subscriptions)
+        except RuntimeError as exc:
+            if "Session is closed" in str(exc):
+                raise SessionClosedError(str(exc)) from exc
+            raise
 
     async def get_subscription_contents(
         self,
@@ -199,27 +217,34 @@ class Office365API:
         next_page_uri: str | None = f"{base_url}/subscriptions/content?{query_string}"
         while next_page_uri is not None:
             # queries the contents for the current page
-            async with self._fresh_session() as session:
-                response = await session.get(
-                    next_page_uri,
-                )
-
-                # check HTTP status code
-                if response.status >= 400:
-                    raise FailedToGetO365SubscriptionContents(status_code=response.status, body=await response.text())
-
-                contents = await response.json()
-
-                # check business errors
-                if "error" in contents:
-                    raise FailedToGetO365SubscriptionContents(
-                        error_code=contents["error"].get("code"), error_message=contents["error"].get("message")
+            try:
+                async with self._fresh_session() as session:
+                    response = await session.get(
+                        next_page_uri,
                     )
 
-                yield contents
+                    # check HTTP status code
+                    if response.status >= 400:
+                        raise FailedToGetO365SubscriptionContents(
+                            status_code=response.status, body=await response.text()
+                        )
 
-                # get the uri for the next page if defined
-                next_page_uri = response.headers.get("NextPageUri")
+                    contents = await response.json()
+
+                    # check business errors
+                    if "error" in contents:
+                        raise FailedToGetO365SubscriptionContents(
+                            error_code=contents["error"].get("code"), error_message=contents["error"].get("message")
+                        )
+
+                    # get the uri for the next page if defined
+                    next_page_uri = response.headers.get("NextPageUri")
+            except RuntimeError as exc:
+                if "Session is closed" in str(exc):
+                    raise SessionClosedError(str(exc)) from exc
+                raise
+
+            yield contents
 
     async def get_content(self, content_uri: str) -> list[dict[str, Any]]:
         """
@@ -230,24 +255,29 @@ class Office365API:
         :rtype: list
         """
         # queries the contents for the current page
-        async with self._fresh_session() as session:
-            response = await session.get(
-                content_uri,
-            )
-
-            # check HTTP status code
-            if response.status >= 400:
-                raise FailedToGetO365AuditContent(status_code=response.status, body=await response.text())
-
-            content = await response.json(content_type=None)
-
-            # check business errors
-            if "error" in content:
-                raise FailedToGetO365AuditContent(
-                    error_code=content["error"].get("code"), error_message=content["error"].get("message")
+        try:
+            async with self._fresh_session() as session:
+                response = await session.get(
+                    content_uri,
                 )
 
-            return content
+                # check HTTP status code
+                if response.status >= 400:
+                    raise FailedToGetO365AuditContent(status_code=response.status, body=await response.text())
+
+                content = await response.json(content_type=None)
+
+                # check business errors
+                if "error" in content:
+                    raise FailedToGetO365AuditContent(
+                        error_code=content["error"].get("code"), error_message=content["error"].get("message")
+                    )
+
+                return content
+        except RuntimeError as exc:
+            if "Session is closed" in str(exc):
+                raise SessionClosedError(str(exc)) from exc
+            raise
 
     def _normalize_office365_url(self) -> str:
         """

--- a/Office365/tests/management_api/test_client.py
+++ b/Office365/tests/management_api/test_client.py
@@ -1,4 +1,5 @@
 import re
+import time
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
@@ -12,6 +13,7 @@ from office365.management_api.errors import (
     FailedToGetO365AuditContent,
     FailedToGetO365SubscriptionContents,
     FailedToListO365Subscriptions,
+    SessionClosedError,
 )
 from office365.management_api.office365_client import Office365API
 
@@ -816,3 +818,58 @@ audit/492638008028$492638008028$f28ab78ad40140608012736e373933ebspo2015043022$4a
 
     # finalize
     await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_subscriptions_raises_session_closed_after_close(mock_azure_authentication, tenant_id):
+    """list_subscriptions should raise SessionClosedError once the session has been closed."""
+    client = Office365API(
+        client_id="client_id",
+        client_secret="client_secret",
+        tenant_id=tenant_id,
+    )
+
+    await client.close()
+
+    with pytest.raises(SessionClosedError):
+        await client.list_subscriptions()
+
+
+@pytest.mark.asyncio
+async def test_activate_subscriptions_raises_session_closed_after_close(mock_azure_authentication, tenant_id):
+    """activate_subscriptions should raise SessionClosedError once the session has been closed."""
+    client = Office365API(
+        client_id="client_id",
+        client_secret="client_secret",
+        tenant_id=tenant_id,
+    )
+
+    await client.close()
+
+    with pytest.raises(SessionClosedError):
+        await client.activate_subscriptions()
+
+
+@pytest.mark.asyncio
+async def test_get_content_translates_runtime_error(mock_azure_authentication, tenant_id):
+    """If aiohttp raises RuntimeError('Session is closed') mid-request, it should surface as SessionClosedError."""
+    client = Office365API(
+        client_id="client_id",
+        client_secret="client_secret",
+        tenant_id=tenant_id,
+    )
+
+    # Skip token refresh so we exercise the request path, not _authenticate_client.
+    client._token_expiration = time.time() + 3600
+
+    async def raise_session_closed(*args, **kwargs):
+        raise RuntimeError("Session is closed")
+
+    # Simulate the race: the guard sees an open session, but the underlying call fails.
+    client._session.get = raise_session_closed  # type: ignore[method-assign]
+
+    try:
+        with pytest.raises(SessionClosedError):
+            await client.get_content("https://manage.office.com/api/v1.0/foo")
+    finally:
+        await client.close()

--- a/Office365/tests/management_api/test_connector.py
+++ b/Office365/tests/management_api/test_connector.py
@@ -8,7 +8,7 @@ from prometheus_client import Counter
 
 from office365.management_api.checkpoint import Checkpoint
 from office365.management_api.connector import FORWARD_EVENTS_DURATION
-from office365.management_api.errors import FailedToActivateO365Subscription
+from office365.management_api.errors import FailedToActivateO365Subscription, SessionClosedError
 
 
 @pytest.mark.asyncio
@@ -203,3 +203,82 @@ async def test_client_property_is_cached(connector):
     client1 = connector.client
     client2 = connector.client
     assert client1 is client2
+
+
+@pytest.mark.asyncio
+async def test_activate_subscriptions_logs_info_when_stopping(connector):
+    """When the connector is shutting down, a closed-session error should be logged at info level, not re-raised."""
+    connector._stop_event.set()  # self.running becomes False
+    connector.client.activate_subscriptions.side_effect = SessionClosedError("closed")
+
+    await connector.activate_subscriptions()
+
+    connector.client.activate_subscriptions.assert_called_once()
+    connector.log.assert_called_once()
+    log_call = connector.log.call_args
+    assert log_call.kwargs.get("level") == "info"
+    assert "shutdown" in log_call.kwargs.get("message", "").lower()
+    connector.log_exception.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_activate_subscriptions_recovers_when_running(connector):
+    """When the connector is still running, a closed-session error should trigger a single retry after _reset_client."""
+    connector.client.activate_subscriptions.side_effect = [SessionClosedError("closed"), None]
+
+    with patch.object(connector, "_reset_client", wraps=connector._reset_client) as reset_spy:
+        await connector.activate_subscriptions()
+
+    assert connector.client.activate_subscriptions.call_count == 2
+    reset_spy.assert_called_once()
+    connector.log_exception.assert_called_once()
+    # The retry succeeded, so no second log_exception call.
+
+
+@pytest.mark.asyncio
+async def test_forward_events_forever_exits_on_session_closed_during_shutdown(connector, symphony_storage):
+    """SessionClosedError during shutdown should stop the forwarding loop cleanly."""
+    checkpoint = Checkpoint(symphony_storage, connector.configuration.intake_key)
+
+    async def mock_forward_next_batches(cp):
+        connector._stop_event.set()
+        raise SessionClosedError("closed")
+
+    with (
+        patch.object(connector, "forward_next_batches", side_effect=mock_forward_next_batches) as forward_mock,
+        patch("office365.management_api.connector.asyncio.sleep", return_value=None) as sleep_mock,
+    ):
+        await connector.forward_events_forever(checkpoint)
+
+    forward_mock.assert_called_once()
+    sleep_mock.assert_not_called()  # no retry-sleep after a shutdown-triggered closure
+    connector.log.assert_called()
+    info_calls = [call for call in connector.log.call_args_list if call.kwargs.get("level") == "info"]
+    assert any("shutdown" in call.kwargs.get("message", "").lower() for call in info_calls)
+
+
+@pytest.mark.asyncio
+async def test_forward_events_forever_resets_client_on_unexpected_session_closed(connector, symphony_storage):
+    """An unexpected SessionClosedError should reset the client and let the loop continue to the next iteration."""
+    checkpoint = Checkpoint(symphony_storage, connector.configuration.intake_key)
+    call_count = 0
+
+    async def mock_forward_next_batches(cp):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise SessionClosedError("closed")
+        # Second iteration: stop the loop cleanly.
+        connector._stop_event.set()
+
+    with (
+        patch.object(connector, "forward_next_batches", side_effect=mock_forward_next_batches),
+        patch.object(connector, "_reset_client", wraps=connector._reset_client) as reset_spy,
+        patch("office365.management_api.connector.asyncio.sleep", return_value=None),
+    ):
+        await connector.forward_events_forever(checkpoint)
+
+    assert call_count == 2
+    reset_spy.assert_called_once()
+    connector.log_exception.assert_called_once()
+    assert "rebuilding" in connector.log_exception.call_args.kwargs.get("message", "").lower()


### PR DESCRIPTION
Relates to [85956](https://github.com/SekoiaLab/platform/issues/85956)

## Summary by Sourcery

Handle closed aiohttp sessions more robustly in the Office365 connector and client, translating them into a dedicated error and ensuring graceful recovery or shutdown.

Bug Fixes:
- Prevent Office365 client methods from operating on already-closed aiohttp sessions by raising a dedicated SessionClosedError.
- Translate underlying RuntimeError('Session is closed') from aiohttp into SessionClosedError during Office365 API calls.
- Ensure the connector exits cleanly or retries appropriately when Office365 client sessions close unexpectedly during activation or event forwarding.

Enhancements:
- Introduce a SessionClosedError type to represent closed-session failures in the Office365 integration.
- Add client reset logic to rebuild the Office365 API client and its aiohttp session after unexpected session closures.
- Improve logging around shutdown and unexpected session closures to distinguish between normal shutdown behavior and recoverable failures.

Documentation:
- Update the changelog to document the new error handling behavior and version 2.20.4.

Tests:
- Add unit tests covering SessionClosedError behavior for subscription activation, listing, content retrieval, and long-running event forwarding loops in the Office365 connector and client.