### PR TITLE
fix doc

### DIFF
--- a/Stormshield/CONFIGURE.md
+++ b/Stormshield/CONFIGURE.md
@@ -1,13 +1,3 @@
-uuid: 59498b29-5cfb-46e6-aaf1-9c0c3afeb00c
-name: Stormshield
-type: playbook
-
-# Stormshield
-
-![Stormshield](/assets/playbooks/library/stormshield-ses.png){ align=right width=150 }
-
-Stormshield Network Security is a range of network security appliances.
-
 ## Configuration
 
 ### Create a Stormshield REST API key


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Remove front matter metadata, title, and branding image from the Stormshield CONFIGURE documentation page.