### PR TITLE
fix mokn

### DIFF
--- a/MokN/CHANGELOG.md
+++ b/MokN/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.0.1] - 2026-05-26
+
+### Fixed
+
+- Update manifest.json version to 1.0.1
+
 ## [1.0.0] - 2026-05-26
 
 ### Changed

--- a/MokN/manifest.json
+++ b/MokN/manifest.json
@@ -36,5 +36,5 @@
     "Threat Intelligence"
   ],
   "uuid": "1939221d-3f25-11f1-9fc3-b03cdc7e4d7a",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
## Summary by Sourcery

Bump the MokN package version and document the patch release.

Bug Fixes:
- Align manifest.json version to 1.0.1 to reflect the latest release.

Documentation:
- Add a 1.0.1 entry to the MokN changelog describing the version update.