### PR TITLE
fix asset connector

### DIFF
--- a/MicrosoftDefender/CHANGELOG.md
+++ b/MicrosoftDefender/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-05-26 - 1.2.1
+
+### Fixed
+
+- Fix `rbacGroupId` type in DefenderMachine model to accept integer values from the API
+
 ## 2026-05-06 - 1.2.0
 
 ### Added

--- a/MicrosoftDefender/asset_connector/device_assets.py
+++ b/MicrosoftDefender/asset_connector/device_assets.py
@@ -185,7 +185,12 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
         uid_alt = machine.aadDeviceId
         groups: list[Group] | None = None
         if machine.rbacGroupName:
-            groups = [Group(name=machine.rbacGroupName, uid=machine.rbacGroupId)]
+            groups = [
+                Group(
+                    name=machine.rbacGroupName,
+                    uid=str(machine.rbacGroupId) if machine.rbacGroupId is not None else None,
+                )
+            ]
 
         if managed_device:
             if managed_device.wi_fi_mac_address or managed_device.ethernet_mac_address:

--- a/MicrosoftDefender/asset_connector/models.py
+++ b/MicrosoftDefender/asset_connector/models.py
@@ -21,7 +21,7 @@ class DefenderMachine(BaseModel):
     lastExternalIpAddress: Optional[str] = None
     healthStatus: Optional[str] = None
     rbacGroupName: Optional[str] = None
-    rbacGroupId: Optional[str] = None
+    rbacGroupId: Optional[int] = None
     riskScore: Optional[str] = None
     exposureLevel: Optional[str] = None
     aadDeviceId: Optional[str] = None

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -50,6 +50,6 @@
   "categories": [
     "Endpoint"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "supports_validation": true
 }

--- a/MicrosoftDefender/tests/asset_connector/test_device_assets.py
+++ b/MicrosoftDefender/tests/asset_connector/test_device_assets.py
@@ -60,7 +60,7 @@ def sample_defender_machine():
         lastExternalIpAddress="167.220.196.71",
         osBuild=18209,
         healthStatus="Active",
-        rbacGroupId="140",
+        rbacGroupId=140,
         rbacGroupName="The-A-Team",
         riskScore="Low",
         exposureLevel="Medium",


### PR DESCRIPTION
## Summary by Sourcery

Correct asset connector handling of Defender machine RBAC group IDs and bump the integration patch version.

Bug Fixes:
- Align the DefenderMachine model rbacGroupId field type with the API by changing it to an integer and converting it to a string when creating Group instances to avoid type issues.

Build:
- Bump the MicrosoftDefender integration manifest version from 1.2.0 to 1.2.1.

Documentation:
- Update the changelog with a new 1.2.1 release entry describing the RBAC group ID fix.

Tests:
- Adjust existing asset connector tests to use an integer RBAC group ID, matching the updated model type.