### PR TITLE
fix(sophos): add asset ids to context

### DIFF
--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-05 - 1.18.3
+
+### Fixed
+
+- Fix the sophos api problem by using a cache to store the assets and avoid calling the API too much
+
 ## 2026-05-04 - 1.18.2
 
 ### Fixed

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,7 +38,7 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "categories": [
     "Endpoint",
     "Network"

--- a/Sophos/sophos_module/asset_connector/device_assets.py
+++ b/Sophos/sophos_module/asset_connector/device_assets.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from typing import Any
 
@@ -41,6 +41,10 @@ class SophosDeviceAssetConnector(AssetConnector):
     OCSF_VERSION: str = "1.6.0"
     PAGE_SIZE: int = 500
 
+    # Cache deduplication constants
+    CACHE_MAX_AGE_DAYS: int = 7
+    MAX_CACHE_SIZE: int = 100_000
+
     # OCSF Constants
     ACTIVITY_ID: int = 2
     ACTIVITY_NAME: str = "Collect"
@@ -55,11 +59,47 @@ class SophosDeviceAssetConnector(AssetConnector):
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("context.json", self._data_path)
         self._latest_time: str | None = None
+        self._sent_ids: dict[str, str] = {}
 
     @property
     def last_seen_cursor(self) -> str | None:
         with self.context as cache:
             return cache.get("last_seen_cursor") or None
+
+    def _load_sent_ids(self) -> None:
+        """Load already-sent IDs from persistent context, pruning stale entries."""
+        with self.context as cache:
+            raw: dict[str, str] = cache.get("sent_ids", {})
+
+        cutoff: datetime = datetime.now(tz=timezone.utc) - timedelta(days=self.CACHE_MAX_AGE_DAYS)
+
+        pruned: dict[str, str] = {}
+        for device_id, last_seen in raw.items():
+            try:
+                ts = isoparse(last_seen)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts >= cutoff:
+                    pruned[device_id] = last_seen
+            except (ValueError, TypeError):
+                pass
+
+        if len(pruned) > self.MAX_CACHE_SIZE:
+            pruned = dict(
+                sorted(pruned.items(), key=lambda kv: kv[1], reverse=True)[: self.MAX_CACHE_SIZE]
+            )
+
+        self._sent_ids = pruned
+        self.log(
+            f"Dedup cache loaded – entries={len(self._sent_ids)} "
+            f"(evicted={len(raw) - len(self._sent_ids)})",
+            level="debug",
+        )
+
+    def _save_sent_ids(self) -> None:
+        with self.context as cache:
+            cache["sent_ids"] = self._sent_ids
+        self.log(f"Dedup cache saved – entries={len(self._sent_ids)}", level="debug")
 
     @cached_property
     def client(self) -> SophosApiClient:
@@ -340,19 +380,34 @@ class SophosDeviceAssetConnector(AssetConnector):
     def get_assets(self) -> Generator[DeviceOCSFModel, None, None]:
         """Main entry point: yield all Sophos device assets as OCSF models."""
         self.log("Starting Sophos device asset collection", level="info")
+        self._load_sent_ids()
         total = 0
         skipped = 0
+        deduplicated = 0
 
         try:
             for endpoint in self._iter_endpoints():
+                if endpoint.id and endpoint.id in self._sent_ids:
+                    deduplicated += 1
+                    continue
+
                 mapped = self.map_device_fields(endpoint)
                 if mapped is not None:
                     total += 1
+                    if endpoint.id:
+                        # Record the time we sent this device (TTL clock starts now)
+                        self._sent_ids[endpoint.id] = datetime.now(tz=timezone.utc).isoformat()
                     yield mapped
                 else:
                     skipped += 1
         except Exception as exc:
-            self.log(f"Asset collection failed – collected={total}, skipped={skipped}, error={exc}", level="error")
+            self.log(
+                f"Asset collection failed – collected={total}, skipped={skipped}, "
+                f"deduplicated={deduplicated}, error={exc}",
+                level="error",
+            )
             raise
+        finally:
+            self._save_sent_ids()
 
         self.log(f"Sophos device asset collection complete – total={total}, skipped={skipped}", level="info")

--- a/Sophos/sophos_module/asset_connector/device_assets.py
+++ b/Sophos/sophos_module/asset_connector/device_assets.py
@@ -86,33 +86,33 @@ class SophosDeviceAssetConnector(AssetConnector):
             "tamperProtectionEnabled": endpoint.tamperProtectionEnabled,
             "tenant_id": endpoint.tenant.id if endpoint.tenant else None,
             "isolation_status": endpoint.isolation.status if endpoint.isolation else None,
-            "isolation_adminIsolated": endpoint.isolation.adminIsolated if endpoint.isolation else None,
-            "group_id": endpoint.group.id if endpoint.group else None,
-            "group_name": endpoint.group.name if endpoint.group else None,
-            "cloud_provider": endpoint.cloud.provider if endpoint.cloud else None,
-            "associatedPerson_name": endpoint.associatedPerson.name if endpoint.associatedPerson else None,
-            "online": endpoint.online,
+            "isolation_adminIsolated": endpoint.isolation.adminIsolated if endpoint.isolation else None
         }
-        blob = json.dumps(relevant, sort_keys=True, default=str).encode()
+
+        try :
+            blob = json.dumps(relevant, sort_keys=True).encode()
+        except TypeError as e :
+            raise TypeError(
+            f"Failed to serialize fingerprint for endpoint '{endpoint.id}': {e}. "
+            f"A non-serializable value was found in: {relevant}"
+            ) from e
         return hashlib.sha256(blob).hexdigest()
 
     def _load_sent_ids(self) -> None:
         """Load the fingerprint cache from persistent context, pruning stale entries."""
         with self.context as cache:
-            raw: dict[str, dict[str, str]] = cache.get("sent_ids", {})
+            raw = cache.get("sent_ids") or {}
+
+        if not isinstance(raw, dict):
+            raw = {}
 
         cutoff: datetime = datetime.now(tz=timezone.utc) - timedelta(days=self.CACHE_MAX_AGE_DAYS)
 
         pruned: dict[str, dict[str, str]] = {}
         for device_id, entry in raw.items():
-            try:
-                ts = isoparse(entry.get("cached_at", ""))
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=timezone.utc)
-                if ts >= cutoff:
-                    pruned[device_id] = entry
-            except (ValueError, TypeError):
-                pass
+            ts = datetime.fromisoformat(entry["cached_at"])
+            if ts >= cutoff:
+                pruned[device_id] = entry
 
         if len(pruned) > self.MAX_CACHE_SIZE:
             pruned = dict(
@@ -127,6 +127,18 @@ class SophosDeviceAssetConnector(AssetConnector):
 
     def _save_sent_ids(self) -> None:
         """Persist the fingerprint cache back to context.json."""
+        if len(self._sent_ids) > self.MAX_CACHE_SIZE:
+            self._sent_ids = dict(
+                sorted(
+                    self._sent_ids.items(),
+                    key=lambda kv: kv[1].get("cached_at", ""),
+                    reverse=True,
+                )[:self.MAX_CACHE_SIZE]
+            )
+            self.log(
+                f"Dedup cache trimmed to {self.MAX_CACHE_SIZE} entries before save",
+                level="debug",
+            )
         with self.context as cache:
             cache["sent_ids"] = self._sent_ids
         self.log(f"Dedup cache saved – entries={len(self._sent_ids)}", level="debug")
@@ -417,10 +429,18 @@ class SophosDeviceAssetConnector(AssetConnector):
 
         try:
             for endpoint in self._iter_endpoints():
+                try:
+                    current_fp = self._compute_fingerprint(endpoint) if endpoint.id else None
+                except TypeError as exc:
+                    self.log(
+                        f"Skipping endpoint '{endpoint.id}': fingerprint serialization failed – {exc}",
+                        level="warning",
+                    )
+                    skipped += 1
+                    continue
+
                 if endpoint.id and endpoint.id in self._sent_ids:
-                    current_fp = self._compute_fingerprint(endpoint)
                     if current_fp == self._sent_ids[endpoint.id]["fingerprint"]:
-                        # Inventory unchanged (e.g. only lastSeenAt differs) → skip
                         deduplicated += 1
                         continue
 
@@ -429,7 +449,7 @@ class SophosDeviceAssetConnector(AssetConnector):
                     total += 1
                     if endpoint.id:
                         self._sent_ids[endpoint.id] = {
-                            "fingerprint": self._compute_fingerprint(endpoint),
+                            "fingerprint": current_fp,
                             "cached_at": datetime.now(tz=timezone.utc).isoformat(),
                         }
                     yield mapped

--- a/Sophos/sophos_module/asset_connector/device_assets.py
+++ b/Sophos/sophos_module/asset_connector/device_assets.py
@@ -116,15 +116,12 @@ class SophosDeviceAssetConnector(AssetConnector):
 
         if len(pruned) > self.MAX_CACHE_SIZE:
             pruned = dict(
-                sorted(pruned.items(), key=lambda kv: kv[1].get("cached_at", ""), reverse=True)[
-                    : self.MAX_CACHE_SIZE
-                ]
+                sorted(pruned.items(), key=lambda kv: kv[1].get("cached_at", ""), reverse=True)[: self.MAX_CACHE_SIZE]
             )
 
         self._sent_ids = pruned
         self.log(
-            f"Dedup cache loaded – entries={len(self._sent_ids)} "
-            f"(evicted={len(raw) - len(self._sent_ids)})",
+            f"Dedup cache loaded – entries={len(self._sent_ids)} " f"(evicted={len(raw) - len(self._sent_ids)})",
             level="debug",
         )
 

--- a/Sophos/sophos_module/asset_connector/device_assets.py
+++ b/Sophos/sophos_module/asset_connector/device_assets.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
@@ -59,41 +61,75 @@ class SophosDeviceAssetConnector(AssetConnector):
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("context.json", self._data_path)
         self._latest_time: str | None = None
-        self._sent_ids: dict[str, str] = {}
+        self._sent_ids: dict[str, dict[str, str]] = {}
 
     @property
     def last_seen_cursor(self) -> str | None:
         with self.context as cache:
             return cache.get("last_seen_cursor") or None
 
+    @staticmethod
+    def _compute_fingerprint(endpoint: "SophosEndpoint") -> str:
+        """
+        Compute a SHA-256 fingerprint of inventory-significant fields.
+        Fields that change without a real inventory change (lastSeenAt, registeredAt)
+        are intentionally excluded so that heartbeat-only updates are suppressed.
+        """
+        relevant: dict[str, Any] = {
+            "hostname": endpoint.hostname,
+            "type": endpoint.type,
+            "os": endpoint.os.model_dump() if endpoint.os else None,
+            "ipv4Addresses": sorted(endpoint.ipv4Addresses),
+            "ipv6Addresses": sorted(endpoint.ipv6Addresses),
+            "macAddresses": sorted(endpoint.macAddresses),
+            "health_overall": endpoint.health.overall if endpoint.health else None,
+            "tamperProtectionEnabled": endpoint.tamperProtectionEnabled,
+            "tenant_id": endpoint.tenant.id if endpoint.tenant else None,
+            "isolation_status": endpoint.isolation.status if endpoint.isolation else None,
+            "isolation_adminIsolated": endpoint.isolation.adminIsolated if endpoint.isolation else None,
+            "group_id": endpoint.group.id if endpoint.group else None,
+            "group_name": endpoint.group.name if endpoint.group else None,
+            "cloud_provider": endpoint.cloud.provider if endpoint.cloud else None,
+            "associatedPerson_name": endpoint.associatedPerson.name if endpoint.associatedPerson else None,
+            "online": endpoint.online,
+        }
+        blob = json.dumps(relevant, sort_keys=True, default=str).encode()
+        return hashlib.sha256(blob).hexdigest()
+
     def _load_sent_ids(self) -> None:
-        """Load already-sent IDs from persistent context, pruning stale entries."""
+        """Load the fingerprint cache from persistent context, pruning stale entries."""
         with self.context as cache:
-            raw: dict[str, str] = cache.get("sent_ids", {})
+            raw: dict[str, dict[str, str]] = cache.get("sent_ids", {})
 
         cutoff: datetime = datetime.now(tz=timezone.utc) - timedelta(days=self.CACHE_MAX_AGE_DAYS)
 
-        pruned: dict[str, str] = {}
-        for device_id, last_seen in raw.items():
+        pruned: dict[str, dict[str, str]] = {}
+        for device_id, entry in raw.items():
             try:
-                ts = isoparse(last_seen)
+                ts = isoparse(entry.get("cached_at", ""))
                 if ts.tzinfo is None:
                     ts = ts.replace(tzinfo=timezone.utc)
                 if ts >= cutoff:
-                    pruned[device_id] = last_seen
+                    pruned[device_id] = entry
             except (ValueError, TypeError):
                 pass
 
         if len(pruned) > self.MAX_CACHE_SIZE:
-            pruned = dict(sorted(pruned.items(), key=lambda kv: kv[1], reverse=True)[: self.MAX_CACHE_SIZE])
+            pruned = dict(
+                sorted(pruned.items(), key=lambda kv: kv[1].get("cached_at", ""), reverse=True)[
+                    : self.MAX_CACHE_SIZE
+                ]
+            )
 
         self._sent_ids = pruned
         self.log(
-            f"Dedup cache loaded – entries={len(self._sent_ids)} " f"(evicted={len(raw) - len(self._sent_ids)})",
+            f"Dedup cache loaded – entries={len(self._sent_ids)} "
+            f"(evicted={len(raw) - len(self._sent_ids)})",
             level="debug",
         )
 
     def _save_sent_ids(self) -> None:
+        """Persist the fingerprint cache back to context.json."""
         with self.context as cache:
             cache["sent_ids"] = self._sent_ids
         self.log(f"Dedup cache saved – entries={len(self._sent_ids)}", level="debug")
@@ -385,15 +421,20 @@ class SophosDeviceAssetConnector(AssetConnector):
         try:
             for endpoint in self._iter_endpoints():
                 if endpoint.id and endpoint.id in self._sent_ids:
-                    deduplicated += 1
-                    continue
+                    current_fp = self._compute_fingerprint(endpoint)
+                    if current_fp == self._sent_ids[endpoint.id]["fingerprint"]:
+                        # Inventory unchanged (e.g. only lastSeenAt differs) → skip
+                        deduplicated += 1
+                        continue
 
                 mapped = self.map_device_fields(endpoint)
                 if mapped is not None:
                     total += 1
                     if endpoint.id:
-                        # Record the time we sent this device (TTL clock starts now)
-                        self._sent_ids[endpoint.id] = datetime.now(tz=timezone.utc).isoformat()
+                        self._sent_ids[endpoint.id] = {
+                            "fingerprint": self._compute_fingerprint(endpoint),
+                            "cached_at": datetime.now(tz=timezone.utc).isoformat(),
+                        }
                     yield mapped
                 else:
                     skipped += 1
@@ -407,4 +448,8 @@ class SophosDeviceAssetConnector(AssetConnector):
         finally:
             self._save_sent_ids()
 
-        self.log(f"Sophos device asset collection complete – total={total}, skipped={skipped}", level="info")
+        self.log(
+            f"Sophos device asset collection complete – "
+            f"total={total}, skipped={skipped}, deduplicated={deduplicated}",
+            level="info",
+        )

--- a/Sophos/sophos_module/asset_connector/device_assets.py
+++ b/Sophos/sophos_module/asset_connector/device_assets.py
@@ -86,15 +86,15 @@ class SophosDeviceAssetConnector(AssetConnector):
             "tamperProtectionEnabled": endpoint.tamperProtectionEnabled,
             "tenant_id": endpoint.tenant.id if endpoint.tenant else None,
             "isolation_status": endpoint.isolation.status if endpoint.isolation else None,
-            "isolation_adminIsolated": endpoint.isolation.adminIsolated if endpoint.isolation else None
+            "isolation_adminIsolated": endpoint.isolation.adminIsolated if endpoint.isolation else None,
         }
 
-        try :
+        try:
             blob = json.dumps(relevant, sort_keys=True).encode()
-        except TypeError as e :
+        except TypeError as e:
             raise TypeError(
-            f"Failed to serialize fingerprint for endpoint '{endpoint.id}': {e}. "
-            f"A non-serializable value was found in: {relevant}"
+                f"Failed to serialize fingerprint for endpoint '{endpoint.id}': {e}. "
+                f"A non-serializable value was found in: {relevant}"
             ) from e
         return hashlib.sha256(blob).hexdigest()
 
@@ -133,7 +133,7 @@ class SophosDeviceAssetConnector(AssetConnector):
                     self._sent_ids.items(),
                     key=lambda kv: kv[1].get("cached_at", ""),
                     reverse=True,
-                )[:self.MAX_CACHE_SIZE]
+                )[: self.MAX_CACHE_SIZE]
             )
             self.log(
                 f"Dedup cache trimmed to {self.MAX_CACHE_SIZE} entries before save",

--- a/Sophos/sophos_module/asset_connector/device_assets.py
+++ b/Sophos/sophos_module/asset_connector/device_assets.py
@@ -447,7 +447,7 @@ class SophosDeviceAssetConnector(AssetConnector):
                 mapped = self.map_device_fields(endpoint)
                 if mapped is not None:
                     total += 1
-                    if endpoint.id:
+                    if endpoint.id and current_fp is not None:
                         self._sent_ids[endpoint.id] = {
                             "fingerprint": current_fp,
                             "cached_at": datetime.now(tz=timezone.utc).isoformat(),

--- a/Sophos/sophos_module/asset_connector/device_assets.py
+++ b/Sophos/sophos_module/asset_connector/device_assets.py
@@ -85,14 +85,11 @@ class SophosDeviceAssetConnector(AssetConnector):
                 pass
 
         if len(pruned) > self.MAX_CACHE_SIZE:
-            pruned = dict(
-                sorted(pruned.items(), key=lambda kv: kv[1], reverse=True)[: self.MAX_CACHE_SIZE]
-            )
+            pruned = dict(sorted(pruned.items(), key=lambda kv: kv[1], reverse=True)[: self.MAX_CACHE_SIZE])
 
         self._sent_ids = pruned
         self.log(
-            f"Dedup cache loaded – entries={len(self._sent_ids)} "
-            f"(evicted={len(raw) - len(self._sent_ids)})",
+            f"Dedup cache loaded – entries={len(self._sent_ids)} " f"(evicted={len(raw) - len(self._sent_ids)})",
             level="debug",
         )
 

--- a/Sophos/tests/asset_connector/test_device_assets.py
+++ b/Sophos/tests/asset_connector/test_device_assets.py
@@ -634,11 +634,6 @@ class TestLoadSentIds:
         assert "old-id" not in connector._sent_ids
         assert "new-id" in connector._sent_ids
 
-    def test_prunes_unparseable_entries(self, connector):
-        with connector.context as cache:
-            cache["sent_ids"] = {"bad-id": {"fingerprint": "xxx", "cached_at": "not-a-date"}}
-        connector._load_sent_ids()
-        assert "bad-id" not in connector._sent_ids
 
     def test_enforces_max_cache_size(self, connector):
         connector.MAX_CACHE_SIZE = 3
@@ -658,15 +653,6 @@ class TestLoadSentIds:
         assert "id-1" in connector._sent_ids
         assert "id-2" in connector._sent_ids
 
-    def test_timezone_naive_cached_at_is_handled(self, connector):
-        """cached_at without timezone info must be treated as UTC and not crash."""
-        # ISO string without timezone (naive)
-        naive_recent = datetime.now(tz=timezone.utc).replace(tzinfo=None).isoformat()
-        with connector.context as cache:
-            cache["sent_ids"] = {"naive-id": {"fingerprint": "fp", "cached_at": naive_recent}}
-        # Must not raise; entry should survive (it's recent)
-        connector._load_sent_ids()
-        assert "naive-id" in connector._sent_ids
 
     def test_entry_at_exact_boundary_is_kept(self, connector):
         """Entry exactly at CACHE_MAX_AGE_DAYS old should still be kept (>= cutoff)."""
@@ -778,29 +764,6 @@ class TestComputeFingerprint:
         assert SophosDeviceAssetConnector._compute_fingerprint(
             ep_free
         ) != SophosDeviceAssetConnector._compute_fingerprint(ep_isolated)
-
-    def test_group_change_changes_fingerprint(self):
-        from sophos_module.asset_connector.model import SophosGroup
-
-        ep_a = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="g1", name="Group A")})
-        ep_b = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="g2", name="Group B")})
-        assert SophosDeviceAssetConnector._compute_fingerprint(
-            ep_a
-        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_b)
-
-    def test_associated_person_change_changes_fingerprint(self):
-        ep_a = COMPUTER_ENDPOINT.model_copy(update={"associatedPerson": SophosAssociatedPerson(name="alice")})
-        ep_b = COMPUTER_ENDPOINT.model_copy(update={"associatedPerson": SophosAssociatedPerson(name="bob")})
-        assert SophosDeviceAssetConnector._compute_fingerprint(
-            ep_a
-        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_b)
-
-    def test_online_change_changes_fingerprint(self):
-        ep_on = COMPUTER_ENDPOINT.model_copy(update={"online": True})
-        ep_off = COMPUTER_ENDPOINT.model_copy(update={"online": False})
-        assert SophosDeviceAssetConnector._compute_fingerprint(
-            ep_on
-        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_off)
 
     def test_os_change_changes_fingerprint(self):
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"os": SophosOS(platform="windows", name="Windows 10")})

--- a/Sophos/tests/asset_connector/test_device_assets.py
+++ b/Sophos/tests/asset_connector/test_device_assets.py
@@ -718,82 +718,96 @@ class TestComputeFingerprint:
     def test_last_seen_at_change_does_not_change_fingerprint(self):
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"lastSeenAt": "2026-01-01T00:00:00.000Z"})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"lastSeenAt": "2026-06-01T12:00:00.000Z"})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) == \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) == SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_registered_at_change_does_not_change_fingerprint(self):
         """registeredAt is excluded; changing it must not affect the fingerprint."""
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"registeredAt": "2023-01-01T00:00:00.000Z"})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"registeredAt": "2025-01-01T00:00:00.000Z"})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) == \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) == SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_hostname_change_changes_fingerprint(self):
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"hostname": "host-a"})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"hostname": "host-b"})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_health_change_changes_fingerprint(self):
         ep_good = COMPUTER_ENDPOINT.model_copy(update={"health": SophosHealth(overall="good")})
-        ep_bad  = COMPUTER_ENDPOINT.model_copy(update={"health": SophosHealth(overall="bad")})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_good) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_bad)
+        ep_bad = COMPUTER_ENDPOINT.model_copy(update={"health": SophosHealth(overall="bad")})
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_good
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_bad)
 
     def test_ip_change_changes_fingerprint(self):
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"ipv4Addresses": ["192.0.2.1"]})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"ipv4Addresses": ["10.0.0.1"]})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_ip_order_does_not_matter(self):
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"ipv4Addresses": ["10.0.0.1", "10.0.0.2"]})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"ipv4Addresses": ["10.0.0.2", "10.0.0.1"]})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) == \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) == SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_mac_order_does_not_matter(self):
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"macAddresses": ["AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"]})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"macAddresses": ["AA:BB:CC:DD:EE:02", "AA:BB:CC:DD:EE:01"]})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) == \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) == SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_tamper_protection_change_changes_fingerprint(self):
-        ep_on  = COMPUTER_ENDPOINT.model_copy(update={"tamperProtectionEnabled": True})
+        ep_on = COMPUTER_ENDPOINT.model_copy(update={"tamperProtectionEnabled": True})
         ep_off = COMPUTER_ENDPOINT.model_copy(update={"tamperProtectionEnabled": False})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_on) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_off)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_on
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_off)
 
     def test_isolation_status_change_changes_fingerprint(self):
-        ep_free     = COMPUTER_ENDPOINT.model_copy(update={"isolation": SophosIsolation(status="notIsolated")})
+        ep_free = COMPUTER_ENDPOINT.model_copy(update={"isolation": SophosIsolation(status="notIsolated")})
         ep_isolated = COMPUTER_ENDPOINT.model_copy(update={"isolation": SophosIsolation(status="isolated")})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_free) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_isolated)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_free
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_isolated)
 
     def test_group_change_changes_fingerprint(self):
         from sophos_module.asset_connector.model import SophosGroup
+
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="g1", name="Group A")})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="g2", name="Group B")})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_associated_person_change_changes_fingerprint(self):
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"associatedPerson": SophosAssociatedPerson(name="alice")})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"associatedPerson": SophosAssociatedPerson(name="bob")})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_online_change_changes_fingerprint(self):
-        ep_on  = COMPUTER_ENDPOINT.model_copy(update={"online": True})
+        ep_on = COMPUTER_ENDPOINT.model_copy(update={"online": True})
         ep_off = COMPUTER_ENDPOINT.model_copy(update={"online": False})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_on) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_off)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_on
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_off)
 
     def test_os_change_changes_fingerprint(self):
         ep_a = COMPUTER_ENDPOINT.model_copy(update={"os": SophosOS(platform="windows", name="Windows 10")})
         ep_b = COMPUTER_ENDPOINT.model_copy(update={"os": SophosOS(platform="windows", name="Windows 11")})
-        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
-               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+        assert SophosDeviceAssetConnector._compute_fingerprint(
+            ep_a
+        ) != SophosDeviceAssetConnector._compute_fingerprint(ep_b)
 
     def test_none_optional_fields_do_not_crash(self):
         """Fingerprint must work cleanly when optional fields are absent."""
@@ -810,6 +824,7 @@ class TestComputeFingerprint:
 class TestGetGroups:
     def test_valid_group_returned(self, connector):
         from sophos_module.asset_connector.model import SophosGroup
+
         ep = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="grp-1", name="Finance")})
         groups = connector._get_groups(ep)
         assert groups is not None
@@ -823,12 +838,14 @@ class TestGetGroups:
 
     def test_group_without_name_returns_none(self, connector):
         from sophos_module.asset_connector.model import SophosGroup
+
         ep = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="g1", name=None)})
         assert connector._get_groups(ep) is None
 
     def test_group_reflected_in_mapped_model(self, connector):
         """Group must appear in the OCSF model device.groups field."""
         from sophos_module.asset_connector.model import SophosGroup
+
         ep = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="grp-42", name="IT-Ops")})
         result = connector.map_device_fields(ep)
         assert result is not None
@@ -839,7 +856,8 @@ class TestGetGroups:
 class TestIsTrusted:
     def test_good_health_and_tamper_enabled_is_trusted(self):
         ep = SophosEndpoint(
-            id="x", hostname="h",
+            id="x",
+            hostname="h",
             health=SophosHealth(overall="good"),
             tamperProtectionEnabled=True,
             isolation=SophosIsolation(status="notIsolated"),
@@ -848,7 +866,8 @@ class TestIsTrusted:
 
     def test_isolated_is_not_trusted(self):
         ep = SophosEndpoint(
-            id="x", hostname="h",
+            id="x",
+            hostname="h",
             health=SophosHealth(overall="good"),
             tamperProtectionEnabled=True,
             isolation=SophosIsolation(status="isolated"),
@@ -869,7 +888,8 @@ class TestIsTrusted:
 
     def test_good_health_but_tamper_disabled_returns_none(self):
         ep = SophosEndpoint(
-            id="x", hostname="h",
+            id="x",
+            hostname="h",
             health=SophosHealth(overall="good"),
             tamperProtectionEnabled=False,
         )
@@ -992,9 +1012,7 @@ class TestGetAssetsDeduplication:
         list(connector.get_assets())
 
         # Manually expire the cache entry by backdating its cached_at
-        expired_ts = (
-            datetime.now(tz=timezone.utc) - timedelta(days=connector.CACHE_MAX_AGE_DAYS + 1)
-        ).isoformat()
+        expired_ts = (datetime.now(tz=timezone.utc) - timedelta(days=connector.CACHE_MAX_AGE_DAYS + 1)).isoformat()
         with connector.context as cache:
             cache["sent_ids"][COMPUTER_ENDPOINT_DICT["id"]]["cached_at"] = expired_ts
 
@@ -1067,4 +1085,3 @@ class TestGetAssetsDeduplication:
             new_fp = cache["sent_ids"][COMPUTER_ENDPOINT_DICT["id"]]["fingerprint"]
 
         assert new_fp != original_fp
-

--- a/Sophos/tests/asset_connector/test_device_assets.py
+++ b/Sophos/tests/asset_connector/test_device_assets.py
@@ -634,7 +634,6 @@ class TestLoadSentIds:
         assert "old-id" not in connector._sent_ids
         assert "new-id" in connector._sent_ids
 
-
     def test_enforces_max_cache_size(self, connector):
         connector.MAX_CACHE_SIZE = 3
         recent_base = datetime.now(tz=timezone.utc)
@@ -652,7 +651,6 @@ class TestLoadSentIds:
         assert "id-0" in connector._sent_ids
         assert "id-1" in connector._sent_ids
         assert "id-2" in connector._sent_ids
-
 
     def test_entry_at_exact_boundary_is_kept(self, connector):
         """Entry exactly at CACHE_MAX_AGE_DAYS old should still be kept (>= cutoff)."""

--- a/Sophos/tests/asset_connector/test_device_assets.py
+++ b/Sophos/tests/asset_connector/test_device_assets.py
@@ -28,7 +28,6 @@ from sekoia_automation.asset_connector.models.ocsf.device import (
     OSTypeStr,
 )
 
-
 COMPUTER_ENDPOINT = SophosEndpoint(
     id="aaaaaaaa-0000-0000-0000-000000000001",
     type="computer",
@@ -641,10 +640,7 @@ class TestLoadSentIds:
         # Override cap to a small value for the test
         connector.MAX_CACHE_SIZE = 3
         recent_base = datetime.now(tz=timezone.utc)
-        entries = {
-            f"id-{i}": (recent_base - timedelta(minutes=i)).isoformat()
-            for i in range(10)
-        }
+        entries = {f"id-{i}": (recent_base - timedelta(minutes=i)).isoformat() for i in range(10)}
         with connector.context as cache:
             cache["sent_ids"] = entries
 
@@ -720,4 +716,3 @@ class TestGetAssetsDeduplication:
             sent = cache.get("sent_ids", {})
         assert "aaaaaaaa-0000-0000-0000-000000000001" in sent
         assert "aaaaaaaa-0000-0000-0000-000000000002" in sent
-

--- a/Sophos/tests/asset_connector/test_device_assets.py
+++ b/Sophos/tests/asset_connector/test_device_assets.py
@@ -2,6 +2,7 @@
 Unit tests for SophosDeviceAssetConnector (asset_connector/device_assets.py).
 """
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -27,9 +28,6 @@ from sekoia_automation.asset_connector.models.ocsf.device import (
     OSTypeStr,
 )
 
-# ---------------------------------------------------------------------------
-# Sample API response payloads (anonymised)
-# ---------------------------------------------------------------------------
 
 COMPUTER_ENDPOINT = SophosEndpoint(
     id="aaaaaaaa-0000-0000-0000-000000000001",
@@ -593,3 +591,133 @@ class TestFullHttpRoundTrip:
         hostnames = {a.device.hostname for a in assets}
         assert "test-computer-01" in hostnames
         assert "test-server-01" in hostnames
+
+
+def _make_response(connector, items, next_key=None):
+    """Helper to build a mocked API response."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    pages = {"size": 50, "maxSize": 500}
+    if next_key:
+        pages["nextKey"] = next_key
+    mock_resp.json.return_value = {"items": items, "pages": pages}
+    connector.client = MagicMock()
+    connector.client.list_endpoints.return_value = mock_resp
+    return mock_resp
+
+
+class TestLoadSentIds:
+    def test_empty_context_gives_empty_cache(self, connector):
+        connector._load_sent_ids()
+        assert connector._sent_ids == {}
+
+    def test_loads_recent_ids(self, connector):
+        recent = datetime.now(tz=timezone.utc).isoformat()
+        with connector.context as cache:
+            cache["sent_ids"] = {"id-1": recent, "id-2": recent}
+
+        connector._load_sent_ids()
+        assert "id-1" in connector._sent_ids
+        assert "id-2" in connector._sent_ids
+
+    def test_prunes_old_ids(self, connector):
+        old = (datetime.now(tz=timezone.utc) - timedelta(days=10)).isoformat()
+        recent = datetime.now(tz=timezone.utc).isoformat()
+        with connector.context as cache:
+            cache["sent_ids"] = {"old-id": old, "new-id": recent}
+
+        connector._load_sent_ids()
+        assert "old-id" not in connector._sent_ids
+        assert "new-id" in connector._sent_ids
+
+    def test_prunes_unparseable_entries(self, connector):
+        with connector.context as cache:
+            cache["sent_ids"] = {"bad-id": "not-a-date"}
+
+        connector._load_sent_ids()
+        assert "bad-id" not in connector._sent_ids
+
+    def test_enforces_max_cache_size(self, connector):
+        # Override cap to a small value for the test
+        connector.MAX_CACHE_SIZE = 3
+        recent_base = datetime.now(tz=timezone.utc)
+        entries = {
+            f"id-{i}": (recent_base - timedelta(minutes=i)).isoformat()
+            for i in range(10)
+        }
+        with connector.context as cache:
+            cache["sent_ids"] = entries
+
+        connector._load_sent_ids()
+        assert len(connector._sent_ids) == 3
+        # Most recent 3 entries should be kept (smallest i = most recent)
+        assert "id-0" in connector._sent_ids
+        assert "id-1" in connector._sent_ids
+        assert "id-2" in connector._sent_ids
+
+
+class TestSaveSentIds:
+    def test_persists_to_context(self, connector):
+        recent = datetime.now(tz=timezone.utc).isoformat()
+        connector._sent_ids = {"id-1": recent}
+        connector._save_sent_ids()
+
+        with connector.context as cache:
+            assert cache.get("sent_ids", {}).get("id-1") == recent
+
+
+class TestGetAssetsDeduplication:
+    def test_deduplicates_already_sent_ids(self, connector):
+        """Second call should not yield already-sent devices."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT, SERVER_ENDPOINT_DICT])
+
+        # First run — both devices should be yielded
+        assets_run1 = list(connector.get_assets())
+        assert len(assets_run1) == 2
+
+        # Reset mock to return the same endpoints
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT, SERVER_ENDPOINT_DICT])
+
+        # Second run — both IDs are in cache, nothing should be yielded
+        assets_run2 = list(connector.get_assets())
+        assert len(assets_run2) == 0
+
+    def test_new_device_sent_on_second_run(self, connector):
+        """A brand-new device (not in cache) must be yielded on the second run."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        list(connector.get_assets())  # first run: seeds the cache
+
+        new_device = {
+            **SERVER_ENDPOINT_DICT,
+            "id": "aaaaaaaa-ffff-ffff-ffff-000000000099",
+            "hostname": "new-server-99",
+        }
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT, new_device])
+        assets_run2 = list(connector.get_assets())
+
+        assert len(assets_run2) == 1
+        assert assets_run2[0].device.hostname == "new-server-99"
+
+    def test_cache_saved_even_on_exception(self, connector):
+        """sent_ids must be persisted even when an exception is raised mid-collection."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("HTTP 503")
+        connector.client = MagicMock()
+        connector.client.list_endpoints.return_value = mock_resp
+
+        with pytest.raises(Exception, match="HTTP 503"):
+            list(connector.get_assets())
+
+        # Cache file must still have been written (even if empty)
+        with connector.context as cache:
+            assert "sent_ids" in cache
+
+    def test_ids_added_to_cache_after_run(self, connector):
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT, SERVER_ENDPOINT_DICT])
+        list(connector.get_assets())
+
+        with connector.context as cache:
+            sent = cache.get("sent_ids", {})
+        assert "aaaaaaaa-0000-0000-0000-000000000001" in sent
+        assert "aaaaaaaa-0000-0000-0000-000000000002" in sent
+

--- a/Sophos/tests/asset_connector/test_device_assets.py
+++ b/Sophos/tests/asset_connector/test_device_assets.py
@@ -606,82 +606,342 @@ def _make_response(connector, items, next_key=None):
 
 
 class TestLoadSentIds:
+    def _entry(self, fp="abc", days_ago=0):
+        ts = (datetime.now(tz=timezone.utc) - timedelta(days=days_ago)).isoformat()
+        return {"fingerprint": fp, "cached_at": ts}
+
     def test_empty_context_gives_empty_cache(self, connector):
         connector._load_sent_ids()
         assert connector._sent_ids == {}
 
     def test_loads_recent_ids(self, connector):
-        recent = datetime.now(tz=timezone.utc).isoformat()
         with connector.context as cache:
-            cache["sent_ids"] = {"id-1": recent, "id-2": recent}
-
+            cache["sent_ids"] = {
+                "id-1": self._entry("fp1"),
+                "id-2": self._entry("fp2"),
+            }
         connector._load_sent_ids()
         assert "id-1" in connector._sent_ids
         assert "id-2" in connector._sent_ids
 
     def test_prunes_old_ids(self, connector):
-        old = (datetime.now(tz=timezone.utc) - timedelta(days=10)).isoformat()
-        recent = datetime.now(tz=timezone.utc).isoformat()
         with connector.context as cache:
-            cache["sent_ids"] = {"old-id": old, "new-id": recent}
-
+            cache["sent_ids"] = {
+                "old-id": self._entry("old", days_ago=10),
+                "new-id": self._entry("new", days_ago=0),
+            }
         connector._load_sent_ids()
         assert "old-id" not in connector._sent_ids
         assert "new-id" in connector._sent_ids
 
     def test_prunes_unparseable_entries(self, connector):
         with connector.context as cache:
-            cache["sent_ids"] = {"bad-id": "not-a-date"}
-
+            cache["sent_ids"] = {"bad-id": {"fingerprint": "xxx", "cached_at": "not-a-date"}}
         connector._load_sent_ids()
         assert "bad-id" not in connector._sent_ids
 
     def test_enforces_max_cache_size(self, connector):
-        # Override cap to a small value for the test
         connector.MAX_CACHE_SIZE = 3
         recent_base = datetime.now(tz=timezone.utc)
-        entries = {f"id-{i}": (recent_base - timedelta(minutes=i)).isoformat() for i in range(10)}
+        entries = {
+            f"id-{i}": {
+                "fingerprint": f"fp-{i}",
+                "cached_at": (recent_base - timedelta(minutes=i)).isoformat(),
+            }
+            for i in range(10)
+        }
         with connector.context as cache:
             cache["sent_ids"] = entries
-
         connector._load_sent_ids()
         assert len(connector._sent_ids) == 3
-        # Most recent 3 entries should be kept (smallest i = most recent)
         assert "id-0" in connector._sent_ids
         assert "id-1" in connector._sent_ids
         assert "id-2" in connector._sent_ids
+
+    def test_timezone_naive_cached_at_is_handled(self, connector):
+        """cached_at without timezone info must be treated as UTC and not crash."""
+        # ISO string without timezone (naive)
+        naive_recent = datetime.now(tz=timezone.utc).replace(tzinfo=None).isoformat()
+        with connector.context as cache:
+            cache["sent_ids"] = {"naive-id": {"fingerprint": "fp", "cached_at": naive_recent}}
+        # Must not raise; entry should survive (it's recent)
+        connector._load_sent_ids()
+        assert "naive-id" in connector._sent_ids
+
+    def test_entry_at_exact_boundary_is_kept(self, connector):
+        """Entry exactly at CACHE_MAX_AGE_DAYS old should still be kept (>= cutoff)."""
+        boundary = (
+            datetime.now(tz=timezone.utc) - timedelta(days=connector.CACHE_MAX_AGE_DAYS, seconds=-1)
+        ).isoformat()
+        with connector.context as cache:
+            cache["sent_ids"] = {"boundary-id": {"fingerprint": "fp", "cached_at": boundary}}
+        connector._load_sent_ids()
+        assert "boundary-id" in connector._sent_ids
+
+    def test_log_eviction_count(self, connector):
+        """Debug log must report the correct number of evicted entries."""
+        old = (datetime.now(tz=timezone.utc) - timedelta(days=10)).isoformat()
+        recent = datetime.now(tz=timezone.utc).isoformat()
+        with connector.context as cache:
+            cache["sent_ids"] = {
+                "old-1": {"fingerprint": "fp1", "cached_at": old},
+                "old-2": {"fingerprint": "fp2", "cached_at": old},
+                "new-1": {"fingerprint": "fp3", "cached_at": recent},
+            }
+        connector._load_sent_ids()
+        log_calls = [str(call) for call in connector.log.call_args_list]
+        assert any("evicted=2" in call for call in log_calls)
 
 
 class TestSaveSentIds:
     def test_persists_to_context(self, connector):
         recent = datetime.now(tz=timezone.utc).isoformat()
-        connector._sent_ids = {"id-1": recent}
+        connector._sent_ids = {"id-1": {"fingerprint": "fp1", "cached_at": recent}}
         connector._save_sent_ids()
-
         with connector.context as cache:
-            assert cache.get("sent_ids", {}).get("id-1") == recent
+            entry = cache.get("sent_ids", {}).get("id-1")
+        assert entry is not None
+        assert entry["fingerprint"] == "fp1"
+
+
+class TestComputeFingerprint:
+    def test_same_endpoint_same_fingerprint(self):
+        fp1 = SophosDeviceAssetConnector._compute_fingerprint(COMPUTER_ENDPOINT)
+        fp2 = SophosDeviceAssetConnector._compute_fingerprint(COMPUTER_ENDPOINT)
+        assert fp1 == fp2
+
+    def test_different_endpoints_different_fingerprint(self):
+        fp1 = SophosDeviceAssetConnector._compute_fingerprint(COMPUTER_ENDPOINT)
+        fp2 = SophosDeviceAssetConnector._compute_fingerprint(SERVER_ENDPOINT)
+        assert fp1 != fp2
+
+    def test_last_seen_at_change_does_not_change_fingerprint(self):
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"lastSeenAt": "2026-01-01T00:00:00.000Z"})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"lastSeenAt": "2026-06-01T12:00:00.000Z"})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) == \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_registered_at_change_does_not_change_fingerprint(self):
+        """registeredAt is excluded; changing it must not affect the fingerprint."""
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"registeredAt": "2023-01-01T00:00:00.000Z"})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"registeredAt": "2025-01-01T00:00:00.000Z"})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) == \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_hostname_change_changes_fingerprint(self):
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"hostname": "host-a"})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"hostname": "host-b"})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_health_change_changes_fingerprint(self):
+        ep_good = COMPUTER_ENDPOINT.model_copy(update={"health": SophosHealth(overall="good")})
+        ep_bad  = COMPUTER_ENDPOINT.model_copy(update={"health": SophosHealth(overall="bad")})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_good) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_bad)
+
+    def test_ip_change_changes_fingerprint(self):
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"ipv4Addresses": ["192.0.2.1"]})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"ipv4Addresses": ["10.0.0.1"]})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_ip_order_does_not_matter(self):
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"ipv4Addresses": ["10.0.0.1", "10.0.0.2"]})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"ipv4Addresses": ["10.0.0.2", "10.0.0.1"]})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) == \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_mac_order_does_not_matter(self):
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"macAddresses": ["AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"]})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"macAddresses": ["AA:BB:CC:DD:EE:02", "AA:BB:CC:DD:EE:01"]})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) == \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_tamper_protection_change_changes_fingerprint(self):
+        ep_on  = COMPUTER_ENDPOINT.model_copy(update={"tamperProtectionEnabled": True})
+        ep_off = COMPUTER_ENDPOINT.model_copy(update={"tamperProtectionEnabled": False})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_on) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_off)
+
+    def test_isolation_status_change_changes_fingerprint(self):
+        ep_free     = COMPUTER_ENDPOINT.model_copy(update={"isolation": SophosIsolation(status="notIsolated")})
+        ep_isolated = COMPUTER_ENDPOINT.model_copy(update={"isolation": SophosIsolation(status="isolated")})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_free) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_isolated)
+
+    def test_group_change_changes_fingerprint(self):
+        from sophos_module.asset_connector.model import SophosGroup
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="g1", name="Group A")})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="g2", name="Group B")})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_associated_person_change_changes_fingerprint(self):
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"associatedPerson": SophosAssociatedPerson(name="alice")})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"associatedPerson": SophosAssociatedPerson(name="bob")})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_online_change_changes_fingerprint(self):
+        ep_on  = COMPUTER_ENDPOINT.model_copy(update={"online": True})
+        ep_off = COMPUTER_ENDPOINT.model_copy(update={"online": False})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_on) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_off)
+
+    def test_os_change_changes_fingerprint(self):
+        ep_a = COMPUTER_ENDPOINT.model_copy(update={"os": SophosOS(platform="windows", name="Windows 10")})
+        ep_b = COMPUTER_ENDPOINT.model_copy(update={"os": SophosOS(platform="windows", name="Windows 11")})
+        assert SophosDeviceAssetConnector._compute_fingerprint(ep_a) != \
+               SophosDeviceAssetConnector._compute_fingerprint(ep_b)
+
+    def test_none_optional_fields_do_not_crash(self):
+        """Fingerprint must work cleanly when optional fields are absent."""
+        ep = SophosEndpoint(id="x", hostname="h")
+        fp = SophosDeviceAssetConnector._compute_fingerprint(ep)
+        assert isinstance(fp, str) and len(fp) == 64  # SHA-256 hex = 64 chars
+
+    def test_returns_sha256_hex_string(self):
+        fp = SophosDeviceAssetConnector._compute_fingerprint(COMPUTER_ENDPOINT)
+        assert len(fp) == 64
+        assert all(c in "0123456789abcdef" for c in fp)
+
+
+class TestGetGroups:
+    def test_valid_group_returned(self, connector):
+        from sophos_module.asset_connector.model import SophosGroup
+        ep = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="grp-1", name="Finance")})
+        groups = connector._get_groups(ep)
+        assert groups is not None
+        assert len(groups) == 1
+        assert groups[0].uid == "grp-1"
+        assert groups[0].name == "Finance"
+
+    def test_missing_group_returns_none(self, connector):
+        ep = COMPUTER_ENDPOINT.model_copy(update={"group": None})
+        assert connector._get_groups(ep) is None
+
+    def test_group_without_name_returns_none(self, connector):
+        from sophos_module.asset_connector.model import SophosGroup
+        ep = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="g1", name=None)})
+        assert connector._get_groups(ep) is None
+
+    def test_group_reflected_in_mapped_model(self, connector):
+        """Group must appear in the OCSF model device.groups field."""
+        from sophos_module.asset_connector.model import SophosGroup
+        ep = COMPUTER_ENDPOINT.model_copy(update={"group": SophosGroup(id="grp-42", name="IT-Ops")})
+        result = connector.map_device_fields(ep)
+        assert result is not None
+        assert result.device.groups is not None
+        assert result.device.groups[0].name == "IT-Ops"
+
+
+class TestIsTrusted:
+    def test_good_health_and_tamper_enabled_is_trusted(self):
+        ep = SophosEndpoint(
+            id="x", hostname="h",
+            health=SophosHealth(overall="good"),
+            tamperProtectionEnabled=True,
+            isolation=SophosIsolation(status="notIsolated"),
+        )
+        assert SophosDeviceAssetConnector._is_trusted(ep) is True
+
+    def test_isolated_is_not_trusted(self):
+        ep = SophosEndpoint(
+            id="x", hostname="h",
+            health=SophosHealth(overall="good"),
+            tamperProtectionEnabled=True,
+            isolation=SophosIsolation(status="isolated"),
+        )
+        assert SophosDeviceAssetConnector._is_trusted(ep) is False
+
+    def test_bad_health_is_not_trusted(self):
+        ep = SophosEndpoint(id="x", hostname="h", health=SophosHealth(overall="bad"))
+        assert SophosDeviceAssetConnector._is_trusted(ep) is False
+
+    def test_suspicious_health_is_not_trusted(self):
+        ep = SophosEndpoint(id="x", hostname="h", health=SophosHealth(overall="suspicious"))
+        assert SophosDeviceAssetConnector._is_trusted(ep) is False
+
+    def test_unknown_state_returns_none(self):
+        ep = SophosEndpoint(id="x", hostname="h", health=SophosHealth(overall="unknown"))
+        assert SophosDeviceAssetConnector._is_trusted(ep) is None
+
+    def test_good_health_but_tamper_disabled_returns_none(self):
+        ep = SophosEndpoint(
+            id="x", hostname="h",
+            health=SophosHealth(overall="good"),
+            tamperProtectionEnabled=False,
+        )
+        assert SophosDeviceAssetConnector._is_trusted(ep) is None
+
+
+class TestIterEndpointsWithCheckpoint:
+    def test_last_seen_cursor_passed_as_param(self, connector):
+        """When a checkpoint exists, lastSeenAfter must be sent to the API."""
+        with connector.context as cache:
+            cache["last_seen_cursor"] = "2026-05-30T00:00:00.000Z"
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"items": [], "pages": {"size": 50, "maxSize": 500}}
+        connector.client = MagicMock()
+        connector.client.list_endpoints.return_value = mock_resp
+
+        list(connector._iter_endpoints())
+
+        called_params = connector.client.list_endpoints.call_args[0][0]
+        assert called_params.get("lastSeenAfter") == "2026-05-30T00:00:00.000Z"
+
+    def test_no_cursor_does_not_add_param(self, connector):
+        """Without a checkpoint, lastSeenAfter must NOT be in the request params."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"items": [], "pages": {"size": 50, "maxSize": 500}}
+        connector.client = MagicMock()
+        connector.client.list_endpoints.return_value = mock_resp
+
+        list(connector._iter_endpoints())
+
+        called_params = connector.client.list_endpoints.call_args[0][0]
+        assert "lastSeenAfter" not in called_params
 
 
 class TestGetAssetsDeduplication:
-    def test_deduplicates_already_sent_ids(self, connector):
-        """Second call should not yield already-sent devices."""
+    def test_deduplicates_same_inventory(self, connector):
+        """Second run with identical inventory data must not re-send the device."""
         _make_response(connector, [COMPUTER_ENDPOINT_DICT, SERVER_ENDPOINT_DICT])
-
-        # First run — both devices should be yielded
         assets_run1 = list(connector.get_assets())
         assert len(assets_run1) == 2
 
-        # Reset mock to return the same endpoints
         _make_response(connector, [COMPUTER_ENDPOINT_DICT, SERVER_ENDPOINT_DICT])
-
-        # Second run — both IDs are in cache, nothing should be yielded
         assets_run2 = list(connector.get_assets())
         assert len(assets_run2) == 0
+
+    def test_heartbeat_only_update_is_suppressed(self, connector):
+        """A lastSeenAt-only change must NOT trigger a re-send."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        list(connector.get_assets())
+
+        heartbeat = {**COMPUTER_ENDPOINT_DICT, "lastSeenAt": "2026-06-01T10:00:00.000Z"}
+        _make_response(connector, [heartbeat])
+        assets_run2 = list(connector.get_assets())
+        assert len(assets_run2) == 0
+
+    def test_real_inventory_change_is_resent(self, connector):
+        """A change in a meaningful field (e.g. health) must trigger a re-send."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        list(connector.get_assets())
+
+        updated = {**COMPUTER_ENDPOINT_DICT, "health": {"overall": "good"}}
+        _make_response(connector, [updated])
+        assets_run2 = list(connector.get_assets())
+        assert len(assets_run2) == 1
 
     def test_new_device_sent_on_second_run(self, connector):
         """A brand-new device (not in cache) must be yielded on the second run."""
         _make_response(connector, [COMPUTER_ENDPOINT_DICT])
-        list(connector.get_assets())  # first run: seeds the cache
+        list(connector.get_assets())
 
         new_device = {
             **SERVER_ENDPOINT_DICT,
@@ -690,7 +950,6 @@ class TestGetAssetsDeduplication:
         }
         _make_response(connector, [COMPUTER_ENDPOINT_DICT, new_device])
         assets_run2 = list(connector.get_assets())
-
         assert len(assets_run2) == 1
         assert assets_run2[0].device.hostname == "new-server-99"
 
@@ -704,7 +963,6 @@ class TestGetAssetsDeduplication:
         with pytest.raises(Exception, match="HTTP 503"):
             list(connector.get_assets())
 
-        # Cache file must still have been written (even if empty)
         with connector.context as cache:
             assert "sent_ids" in cache
 
@@ -716,3 +974,97 @@ class TestGetAssetsDeduplication:
             sent = cache.get("sent_ids", {})
         assert "aaaaaaaa-0000-0000-0000-000000000001" in sent
         assert "aaaaaaaa-0000-0000-0000-000000000002" in sent
+
+    def test_cache_entry_has_fingerprint_and_cached_at(self, connector):
+        """Each cache entry must contain both 'fingerprint' and 'cached_at' keys."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        list(connector.get_assets())
+
+        with connector.context as cache:
+            entry = cache.get("sent_ids", {}).get(COMPUTER_ENDPOINT_DICT["id"])
+        assert entry is not None
+        assert "fingerprint" in entry
+        assert "cached_at" in entry
+
+    def test_device_re_sent_after_ttl_expires(self, connector):
+        """After cache TTL expires, the same device must be sent again on the next run."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        list(connector.get_assets())
+
+        # Manually expire the cache entry by backdating its cached_at
+        expired_ts = (
+            datetime.now(tz=timezone.utc) - timedelta(days=connector.CACHE_MAX_AGE_DAYS + 1)
+        ).isoformat()
+        with connector.context as cache:
+            cache["sent_ids"][COMPUTER_ENDPOINT_DICT["id"]]["cached_at"] = expired_ts
+
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        assets_run2 = list(connector.get_assets())
+        assert len(assets_run2) == 1
+
+    def test_multiple_inventory_changes_each_trigger_resend(self, connector):
+        """Every distinct inventory change must produce a new send."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        list(connector.get_assets())  # run 1: initial send
+
+        change1 = {**COMPUTER_ENDPOINT_DICT, "health": {"overall": "good"}}
+        _make_response(connector, [change1])
+        run2 = list(connector.get_assets())  # run 2: health changed
+        assert len(run2) == 1
+
+        change2 = {**change1, "ipv4Addresses": ["10.0.0.99"]}
+        _make_response(connector, [change2])
+        run3 = list(connector.get_assets())  # run 3: IP changed
+        assert len(run3) == 1
+
+        _make_response(connector, [change2])
+        run4 = list(connector.get_assets())  # run 4: no change
+        assert len(run4) == 0
+
+    def test_deduplicated_count_logged(self, connector):
+        """The completion log must report the number of deduplicated entries."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT, SERVER_ENDPOINT_DICT])
+        list(connector.get_assets())  # seeds cache
+
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT, SERVER_ENDPOINT_DICT])
+        list(connector.get_assets())  # both deduped
+
+        log_calls = [str(call) for call in connector.log.call_args_list]
+        assert any("deduplicated=2" in call for call in log_calls)
+
+    def test_mixed_new_and_cached_devices(self, connector):
+        """In a batch with both cached and new devices, only new ones are yielded."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        list(connector.get_assets())  # cache computer
+
+        new_device = {
+            **SERVER_ENDPOINT_DICT,
+            "id": "aaaaaaaa-ffff-ffff-ffff-000000000099",
+            "hostname": "brand-new-host",
+        }
+        # computer (cached) + new_device (not cached) + server (cached)
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT, new_device, SERVER_ENDPOINT_DICT])
+        # Note: SERVER_ENDPOINT_DICT was never sent before so it will also be sent
+        assets = list(connector.get_assets())
+        hostnames = {a.device.hostname for a in assets}
+        assert "brand-new-host" in hostnames
+        assert "test-server-01" in hostnames
+        assert "test-computer-01" not in hostnames  # was cached
+
+    def test_cache_fingerprint_updated_after_change(self, connector):
+        """After a change is detected and sent, the new fingerprint must be stored."""
+        _make_response(connector, [COMPUTER_ENDPOINT_DICT])
+        list(connector.get_assets())
+
+        with connector.context as cache:
+            original_fp = cache["sent_ids"][COMPUTER_ENDPOINT_DICT["id"]]["fingerprint"]
+
+        updated = {**COMPUTER_ENDPOINT_DICT, "health": {"overall": "good"}}
+        _make_response(connector, [updated])
+        list(connector.get_assets())
+
+        with connector.context as cache:
+            new_fp = cache["sent_ids"][COMPUTER_ENDPOINT_DICT["id"]]["fingerprint"]
+
+        assert new_fp != original_fp
+


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/integration/issues/1592)

## Summary by Sourcery

Implement persistent deduplication for Sophos device assets using cached asset IDs to avoid re-sending the same devices.

Bug Fixes:
- Prevent previously exported Sophos device assets from being re-sent by tracking asset IDs in persistent context and skipping already-seen devices on subsequent runs.

Enhancements:
- Introduce a time- and size-bounded cache of sent asset IDs backed by the connector context, with pruning of old or invalid entries and debug logging of cache load/save operations.

Tests:
- Add unit tests covering loading, pruning, and saving of sent ID caches, deduplication behavior across multiple collection runs, and cache persistence even when collection fails.