### PR TITLE
fix filter request

### DIFF
--- a/MicrosoftDefender/CHANGELOG.md
+++ b/MicrosoftDefender/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-06-02 - 1.2.2
+
+### Fixed
+
+- Fix device asset connector checkpoint filter: use `lastSeen` instead of `firstSeen` (not filterable by Defender API), encode datetime as UTC with `Z` suffix to avoid `+00:00` breaking URL query strings
+
 ## 2026-05-26 - 1.2.1
 
 ### Fixed

--- a/MicrosoftDefender/asset_connector/device_assets.py
+++ b/MicrosoftDefender/asset_connector/device_assets.py
@@ -1,7 +1,7 @@
 from collections.abc import AsyncGenerator
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cached_property
-from urllib.parse import urljoin
+from urllib.parse import urlencode, urljoin
 
 from azure.identity.aio import ClientSecretCredential
 from dateutil.parser import isoparse
@@ -342,9 +342,8 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
         machines: list[DefenderMachine] = []
         endpoint = self.MACHINES_ENDPOINT
         if self.most_recent_date_seen:
-            endpoint = f"{endpoint}?$filter=firstSeen+ge+{self.most_recent_date_seen}&$orderby=firstSeen+asc"
-        else:
-            endpoint = f"{endpoint}?$orderby=firstSeen+asc"
+            params = urlencode({"$filter": f"lastSeen ge {self.most_recent_date_seen}"})
+            endpoint = f"{endpoint}?{params}"
         url: str | None = urljoin(self.defender_client.base_url, endpoint)
 
         while url and self.running:
@@ -407,11 +406,11 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
                 )
                 continue
 
-            # Track most recent firstSeen for checkpoint
-            if machine.firstSeen:
-                first_seen_dt = isoparse(machine.firstSeen)
-                if most_recent is None or first_seen_dt > most_recent:
-                    most_recent = first_seen_dt
+            # Track most recent lastSeen for checkpoint
+            if machine.lastSeen:
+                last_seen_dt = isoparse(machine.lastSeen)
+                if most_recent is None or last_seen_dt > most_recent:
+                    most_recent = last_seen_dt
 
             yield ocsf_device
 
@@ -419,5 +418,6 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
 
     async def update_checkpoint(self) -> None:
         if self._latest_time:
+            dt_utc = self._latest_time.astimezone(timezone.utc).replace(tzinfo=None)
             with self.context as cache:
-                cache["most_recent_date_seen"] = self._latest_time.isoformat()
+                cache["most_recent_date_seen"] = dt_utc.isoformat(timespec="milliseconds") + "Z"

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -50,6 +50,6 @@
   "categories": [
     "Endpoint"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "supports_validation": true
 }

--- a/MicrosoftDefender/tests/asset_connector/test_device_assets.py
+++ b/MicrosoftDefender/tests/asset_connector/test_device_assets.py
@@ -325,7 +325,7 @@ class TestFetchMachines:
             connector._fetch_machines()
             called_url = mock_client.get.call_args[0][0]
 
-        assert "$filter=firstSeen+ge+2024-01-01T00:00:00+00:00" in called_url
+        assert "%24filter=lastSeen+ge+2024-01-01T00%3A00%3A00%2B00%3A00" in called_url
 
     def test_no_filter_without_checkpoint(self, connector, sample_defender_machine):
         mock_response = MagicMock()
@@ -339,6 +339,7 @@ class TestFetchMachines:
             connector._fetch_machines()
             called_url = mock_client.get.call_args[0][0]
 
+        assert "%24filter" not in called_url
         assert "$filter" not in called_url
 
 
@@ -459,7 +460,7 @@ class TestUpdateCheckpoint:
         await connector.update_checkpoint()
 
         with connector.context as cache:
-            assert cache["most_recent_date_seen"] == "2025-04-20T14:22:00+00:00"
+            assert cache["most_recent_date_seen"] == "2025-04-20T14:22:00.000Z"
 
     @pytest.mark.asyncio
     async def test_no_update_when_no_latest(self, connector):


### PR DESCRIPTION
## Summary by Sourcery

Fix device asset checkpoint handling to use a valid, URL-safe last-seen timestamp filter and update stored checkpoint format.

Bug Fixes:
- Use the Defender machine lastSeen field instead of firstSeen for incremental checkpoint filtering in the device asset connector.
- Store checkpoints as UTC timestamps with millisecond precision and Z suffix to avoid URL query string issues when building filter parameters.

Build:
- Bump the Microsoft Defender integration manifest version to 1.2.2.

Documentation:
- Document the device asset connector checkpoint filter fix and timestamp encoding details in the changelog.

Tests:
- Update device asset connector tests to validate URL-encoded lastSeen filter usage, absence of filters without checkpoints, and the new checkpoint timestamp format.