### PR TITLE
fix/ubika_cloud_protector_next_gen_client_closed_error

### DIFF
--- a/Ubika/CHANGELOG.md
+++ b/Ubika/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-03 - 1.1.1
+
+### Fixed
+
+- Recreate the cached NextGen HTTP client after shutdown to prevent closed-client request failures on connector restart
+
+
 ## 2026-05-22 - 1.1.0
 
 ### Added

--- a/Ubika/CHANGELOG.md
+++ b/Ubika/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2026-06-03 - 1.1.1
+## 2026-06-04 - 1.1.1
 
 ### Fixed
 
-- Recreate the cached NextGen HTTP client after shutdown to prevent closed-client request failures on connector restart
+- Refactor NextGen HTTP client lifecycle: change from `@cached_property` to explicit `@property` with `_client` state management, ensuring proper cleanup and preventing closed-client reuse errors on connector restart
 
 
 ## 2026-05-22 - 1.1.0

--- a/Ubika/manifest.json
+++ b/Ubika/manifest.json
@@ -11,7 +11,7 @@
   "name": "Ubika",
   "uuid": "0c82ee9b-f645-47f9-8e16-a689cfc246c4",
   "slug": "ubika",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "categories": [
     "Network"
   ]

--- a/Ubika/tests/test_ubika_cloud_protector_next_gen_alerts.py
+++ b/Ubika/tests/test_ubika_cloud_protector_next_gen_alerts.py
@@ -428,3 +428,47 @@ def test_run_breaks_on_next_batch_exception(monkeypatch, trigger):
     args, kwargs = trigger.log_exception.call_args
     assert args[0] is exc
     assert kwargs.get("message") == "Failed to fetch events"
+
+
+def test_run_invalidates_client_cache_after_exception(monkeypatch, trigger):
+    """
+    After run() exits (via exception), the cached 'client' property must be
+    removed from the instance dict so the next run() call gets a fresh client
+    instead of the already-closed one (prevents "Cannot send a request, as the
+    client has been closed." errors on framework restarts).
+    """
+    now = datetime.now(timezone.utc)
+    w1 = (now, now + timedelta(minutes=1))
+    trigger.stepper = MagicMock(ranges=MagicMock(return_value=[w1]))
+
+    mock_client = MagicMock()
+    trigger.__dict__["client"] = mock_client  # pre-populate the cached property
+
+    trigger.next_batch = MagicMock(side_effect=RuntimeError("boom"))
+    trigger.log_exception = MagicMock()
+
+    trigger.run()
+
+    # The client should have been closed…
+    mock_client.close.assert_called_once()
+    # …and removed from the instance dict so the next run creates a fresh one
+    assert "client" not in trigger.__dict__
+
+
+def test_run_invalidates_client_cache_on_clean_stop(monkeypatch, trigger):
+    """
+    After a clean run() (stop event set, no exception), the cached 'client'
+    property must also be removed from the instance dict.
+    """
+    trigger._stop_event.set()
+    trigger.stepper = MagicMock(ranges=MagicMock(return_value=[]))
+
+    mock_client = MagicMock()
+    trigger.__dict__["client"] = mock_client
+
+    trigger.next_batch = MagicMock()
+
+    trigger.run()
+
+    mock_client.close.assert_called_once()
+    assert "client" not in trigger.__dict__

--- a/Ubika/tests/test_ubika_cloud_protector_next_gen_alerts.py
+++ b/Ubika/tests/test_ubika_cloud_protector_next_gen_alerts.py
@@ -432,17 +432,17 @@ def test_run_breaks_on_next_batch_exception(monkeypatch, trigger):
 
 def test_run_invalidates_client_cache_after_exception(monkeypatch, trigger):
     """
-    After run() exits (via exception), the cached 'client' property must be
-    removed from the instance dict so the next run() call gets a fresh client
-    instead of the already-closed one (prevents "Cannot send a request, as the
-    client has been closed." errors on framework restarts).
+    After run() exits (via exception), the _client should be closed and reset to None
+    so the next run() call gets a fresh client instead of the already-closed one
+    (prevents "Cannot send a request, as the client has been closed." errors on
+    framework restarts).
     """
     now = datetime.now(timezone.utc)
     w1 = (now, now + timedelta(minutes=1))
     trigger.stepper = MagicMock(ranges=MagicMock(return_value=[w1]))
 
     mock_client = MagicMock()
-    trigger.__dict__["client"] = mock_client  # pre-populate the cached property
+    trigger._client = mock_client  # pre-populate the private _client
 
     trigger.next_batch = MagicMock(side_effect=RuntimeError("boom"))
     trigger.log_exception = MagicMock()
@@ -451,24 +451,24 @@ def test_run_invalidates_client_cache_after_exception(monkeypatch, trigger):
 
     # The client should have been closed…
     mock_client.close.assert_called_once()
-    # …and removed from the instance dict so the next run creates a fresh one
-    assert "client" not in trigger.__dict__
+    # …and reset to None so the next run creates a fresh one
+    assert trigger._client is None
 
 
 def test_run_invalidates_client_cache_on_clean_stop(monkeypatch, trigger):
     """
-    After a clean run() (stop event set, no exception), the cached 'client'
-    property must also be removed from the instance dict.
+    After a clean run() (stop event set, no exception), the _client should also
+    be closed and reset to None.
     """
     trigger._stop_event.set()
     trigger.stepper = MagicMock(ranges=MagicMock(return_value=[]))
 
     mock_client = MagicMock()
-    trigger.__dict__["client"] = mock_client
+    trigger._client = mock_client
 
     trigger.next_batch = MagicMock()
 
     trigger.run()
 
     mock_client.close.assert_called_once()
-    assert "client" not in trigger.__dict__
+    assert trigger._client is None

--- a/Ubika/tests/test_ubika_cloud_protector_next_gen_base.py
+++ b/Ubika/tests/test_ubika_cloud_protector_next_gen_base.py
@@ -28,7 +28,7 @@ def trigger(data_storage):
         chunk_size=100,
     )
     # Make client.get a MagicMock so we can stub pagination calls
-    trigger.client = MagicMock()
+    trigger._client = MagicMock()
     yield trigger
 
 

--- a/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen_base.py
+++ b/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen_base.py
@@ -358,10 +358,9 @@ class UbikaCloudProtectorNextGenBaseConnector(Connector):
 
         finally:
             # Cleanup on stop or fatal error
-            self.client.close()
-            # Invalidate the cached client so a fresh one is created on the next run,
-            # preventing "Cannot send a request, as the client has been closed." errors
-            # when the framework restarts run() on the same instance.
-            self.__dict__.pop("client", None)
+            client = self.__dict__.pop("client", None)
+            if client is not None:
+                # Close + invalidate cached client to avoid reusing a closed client across runs.
+                client.close()
             self.save_events_cache()
             self.log(message=f"Stopped fetching {self.NAME} events", level="info")

--- a/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen_base.py
+++ b/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen_base.py
@@ -359,5 +359,9 @@ class UbikaCloudProtectorNextGenBaseConnector(Connector):
         finally:
             # Cleanup on stop or fatal error
             self.client.close()
+            # Invalidate the cached client so a fresh one is created on the next run,
+            # preventing "Cannot send a request, as the client has been closed." errors
+            # when the framework restarts run() on the same instance.
+            self.__dict__.pop("client", None)
             self.save_events_cache()
             self.log(message=f"Stopped fetching {self.NAME} events", level="info")

--- a/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen_base.py
+++ b/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen_base.py
@@ -70,6 +70,8 @@ class UbikaCloudProtectorNextGenBaseConnector(Connector):
         # Cache context for storing event hashes
         self.cache_context = PersistentJSON("cache.json", self.data_path)
         self.events_cache: Cache = self.load_events_cache()
+        # HTTP client for API requests (lazily initialized)
+        self._client: UbikaCloudProtectorNextGenApiClient | None = None
 
     def load_events_cache(self) -> Cache:
         """
@@ -94,12 +96,15 @@ class UbikaCloudProtectorNextGenBaseConnector(Connector):
             # save the events cache to the context
             context["events_cache"] = list(self.events_cache.keys())
 
-    @cached_property
+    @property
     def client(self) -> UbikaCloudProtectorNextGenApiClient:
         """
         HTTP client that automatically injects tokens and handles rate‐limits.
+        Lazily initialized on first access; use _client to manage lifecycle.
         """
-        return UbikaCloudProtectorNextGenApiClient(refresh_token=self.configuration.refresh_token)
+        if self._client is None:
+            self._client = UbikaCloudProtectorNextGenApiClient(refresh_token=self.configuration.refresh_token)
+        return self._client
 
     @cached_property
     def stepper(self) -> TimeStepper:
@@ -358,9 +363,12 @@ class UbikaCloudProtectorNextGenBaseConnector(Connector):
 
         finally:
             # Cleanup on stop or fatal error
-            client = self.__dict__.pop("client", None)
-            if client is not None:
-                # Close + invalidate cached client to avoid reusing a closed client across runs.
-                client.close()
+            if self._client is not None:
+                # Use _client directly to close only an already-instantiated client,
+                # avoiding lazy creation of a fresh client just to immediately close it.
+                # Reset to None forces the property to create a new one on next run,
+                # preventing "Cannot send a request, as the client has been closed." errors.
+                self._client.close()
+                self._client = None
             self.save_events_cache()
             self.log(message=f"Stopped fetching {self.NAME} events", level="info")


### PR DESCRIPTION
## Description

Fixes https://github.com/SekoiaLab/integration/issues/1631

### Fixed

- Recreate the cached NextGen HTTP client after shutdown to prevent closed-client request failures on connector restart

## Summary by Sourcery

Ensure the Ubika Cloud Protector NextGen connector recreates its HTTP client after shutdown to avoid using a closed client across runs.

Bug Fixes:
- Invalidate the cached NextGen HTTP client after each run so subsequent runs create a fresh client instead of reusing a closed one, preventing closed-client request failures on connector restarts.

Build:
- Bump the Ubika integration manifest version from 1.1.0 to 1.1.1.

Documentation:
- Update the changelog with a 1.1.1 release entry describing the HTTP client shutdown fix.

Tests:
- Add tests verifying that the connector run invalidates the cached client both on exceptions and on clean shutdowns.