### PR TITLE
fix : fixed bugs in list_queries and create_dataset

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-04 - 2.72.1
+
+### Fixed
+
+- Fixed the `List Queries` action to include the correct `is_shared` parameter in the request parameters rather that the incorrect `is_shared_run` parameter.
+- Fixed the `Create a Dataset` action to include the `community_uuid` parameter in the request data as it is required.
+  - The community UUID is taken from the action's `community_uuid` property.
+
 ## 2026-05-07 - 2.72.0
 
 ### Added

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.72.0",
+  "version": "2.72.1",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/create_dataset.py
+++ b/Sekoia.io/sekoiaio/operation_center/create_dataset.py
@@ -56,7 +56,7 @@ class CreateDataset(BaseSolAction):
         """
         response_create = self.http_session.post(
             self.dataset_api_path,
-            data={"name": name},
+            data={"name": name, "community_uuid": self.community_uuid},
             files={"file": ("dataset.csv", dataset, "text/csv")},
             timeout=60,
         )

--- a/Sekoia.io/sekoiaio/operation_center/list_queries.py
+++ b/Sekoia.io/sekoiaio/operation_center/list_queries.py
@@ -79,7 +79,7 @@ class ListQueries(BaseSolAction):
                     "match[uuid]": argument.match_uuid,
                     "match[name]": argument.match_name,
                     "match[visualization]": argument.match_visualization,
-                    "match[is_shared_run]": bool_to_param(argument.match_isshared),
+                    "match[is_shared]": bool_to_param(argument.match_isshared),
                     "match[created_by]": argument.match_created_by,
                     "parameters": argument.parameters,
                 },

--- a/Sekoia.io/tests/operation_center_action/test_action_create_dataset.py
+++ b/Sekoia.io/tests/operation_center_action/test_action_create_dataset.py
@@ -17,6 +17,7 @@ CREATED_BY_UUID = str(uuid4())
 def make_action() -> CreateDataset:
     action = CreateDataset()
     action.module.configuration = {"base_url": BASE_URL, "api_key": API_KEY}
+    action.community_uuid = COMMUNITY_UUID
     return action
 
 

--- a/Sekoia.io/tests/operation_center_action/test_action_list_queries.py
+++ b/Sekoia.io/tests/operation_center_action/test_action_list_queries.py
@@ -174,7 +174,7 @@ def test_list_queries_filters(requests_mock):
         assert params["match[uuid]"] == ["some-uuid"]
         assert params["match[name]"] == ["some-name"]
         assert params["match[visualization]"] == ["some-vis"]
-        assert params["match[is_shared_run]"] == ["true"]
+        assert params["match[is_shared]"] == ["true"]
         assert params["match[created_by]"] == ["creator-uuid"]
         assert params["parameters"] == ["username"]
         return True


### PR DESCRIPTION
Fixed the bug found in the beta version :



`List_query` : 

- Corrected one of the filter : `is_shared_run` didn't exist and was replaced by `is_shared`



`Create_dataset`:

- The API needs the community UUID, The `community_uuid`  propriety was used.



The test were modifed to correspond to the new functions.

## Summary by Sourcery

Fix query listing and dataset creation to use correct API parameters and ensure tests reflect the updated behavior.

Bug Fixes:
- Use the correct is-shared filter key when listing queries.
- Include the required community UUID when creating datasets so the API call succeeds.

Tests:
- Update list-queries tests to assert the corrected is-shared filter key.
- Set community UUID in create-dataset tests to cover the new request parameter.