### PR TITLE
Salesforce: allow setting thresholds from env variables

### DIFF
--- a/Salesforce/CHANGELOG.md
+++ b/Salesforce/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-05-04 - 1.8.2
+
+### Changed
+
+- Allow setting file processing thresholds from env variables
+
 ## 2026-02-06 - 1.8.1
 
 ### Fixed

--- a/Salesforce/CHANGELOG.md
+++ b/Salesforce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Allow setting file processing thresholds from env variables
+- Allow setting file processing thresholds from environment variables
 
 ## 2026-02-06 - 1.8.1
 

--- a/Salesforce/manifest.json
+++ b/Salesforce/manifest.json
@@ -39,7 +39,7 @@
   "name": "Salesforce",
   "uuid": "f811e134-2548-11ee-be56-0242ac120002",
   "slug": "salesforce",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "categories": [
     "Applicative"
   ]

--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -54,7 +54,7 @@ class SalesforceConnector(AsyncConnector):
     # 100 is more then enough because we persist log file ids and not event ids itself
     LOG_FILE_CACHE_SIZE = 100
 
-    # Treshold for log processing
+    # Threshold for log processing
     SIZE_TO_PROCESS_DEFAULT = 20 * 1024 * 1024  # 20MB
     CHUNK_SIZE_DEFAULT = 1024 * 1024  # 1MB
 

--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -54,7 +54,7 @@ class SalesforceConnector(AsyncConnector):
     # 100 is more then enough because we persist log file ids and not event ids itself
     LOG_FILE_CACHE_SIZE = 100
 
-    # Threshold for log processing
+    # Thresholds for log processing
     SIZE_TO_PROCESS_DEFAULT = 20 * 1024 * 1024  # 20MB
     CHUNK_SIZE_DEFAULT = 1024 * 1024  # 1MB
 

--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -54,6 +54,10 @@ class SalesforceConnector(AsyncConnector):
     # 100 is more then enough because we persist log file ids and not event ids itself
     LOG_FILE_CACHE_SIZE = 100
 
+    # Treshold for log processing
+    SIZE_TO_PROCESS_DEFAULT = 20 * 1024 * 1024  # 20MB
+    CHUNK_SIZE_DEFAULT = 1024 * 1024  # 1MB
+
     def __init__(self, *args: Any, **kwargs: Optional[Any]) -> None:
         """Init SalesforceConnector."""
         super().__init__(*args, **kwargs)
@@ -61,6 +65,9 @@ class SalesforceConnector(AsyncConnector):
 
         log_file_cache_size = int(os.getenv("LOG_FILE_CACHE_SIZE", 100))
         self.log_file_cache: Cache[str, bool] = self._load_log_file_cache(log_file_cache_size)
+
+        self.size_to_process = int(os.getenv("SIZE_TO_PROCESS", self.SIZE_TO_PROCESS_DEFAULT))
+        self.chunk_size = int(os.getenv("CHUNK_SIZE", self.CHUNK_SIZE_DEFAULT))
 
     @property
     def stepper(self) -> TimeStepper:
@@ -219,6 +226,8 @@ class SalesforceConnector(AsyncConnector):
 
             records, csv_path = await self.salesforce_client.get_log_file_content(
                 log_file=log_file,
+                size_to_process=self.size_to_process,
+                chunk_size=self.chunk_size,
             )
 
             if records is not None:


### PR DESCRIPTION
## Summary by Sourcery

Allow configuring Salesforce log file processing thresholds via environment variables and bump the connector version.

New Features:
- Add environment-configurable defaults for log file processing size and chunk size thresholds in the Salesforce connector.

Enhancements:
- Pass configured processing size and chunk size thresholds to the Salesforce client when retrieving log file content.

Build:
- Bump the Salesforce connector manifest version from 1.8.1 to 1.8.2.

Documentation:
- Update the Salesforce changelog with a new 1.8.2 release entry describing the threshold configurability change.