### PR TITLE
Sekoia.io: fix Create Dataset

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-04 - 2.72.2
+
+### Fixed
+
+- Fix the `Create a Dataset` action to get the community uuid form the module, not the action
+
 ## 2026-06-04 - 2.72.1
 
 ### Fixed

--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix the `Create a Dataset` action to get the community uuid form the module, not the action
+- Fix the `Create a Dataset` action to get the community uuid from the module, not the action
 
 ## 2026-06-04 - 2.72.1
 

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.72.1",
+  "version": "2.72.2",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/create_dataset.py
+++ b/Sekoia.io/sekoiaio/operation_center/create_dataset.py
@@ -56,7 +56,7 @@ class CreateDataset(BaseSolAction):
         """
         response_create = self.http_session.post(
             self.dataset_api_path,
-            data={"name": name, "community_uuid": self.community_uuid},
+            data={"name": name, "community_uuid": self.module.community_uuid},
             files={"file": ("dataset.csv", dataset, "text/csv")},
             timeout=60,
         )


### PR DESCRIPTION
- Fix the way to get the community uuid in the Create Dataset action

## Summary by Sourcery

Fix community UUID source in the Sekoia.io Create Dataset action and bump the integration version.

Bug Fixes:
- Correct the Create Dataset action to read the community UUID from the module instead of the action context.

Build:
- Bump the Sekoia.io integration manifest version from 2.72.1 to 2.72.2.

Documentation:
- Update the changelog with a new 2.72.2 release entry describing the Create Dataset fix.