### PR TITLE
Sekoia.io: fix uuids for SOL actions

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-04 - 2.72.3
+
+### Fixed
+
+- Fix the uuid for the SOL actions
+
 ## 2026-06-04 - 2.72.2
 
 ### Fixed

--- a/Sekoia.io/action_create_dataset.json
+++ b/Sekoia.io/action_create_dataset.json
@@ -1,7 +1,7 @@
 {
   "name": "Create Dataset",
   "description": "Create a new dataset",
-  "uuid": "e8982a08-207f-5a2b-ba7a-b90e10c1a661",
+  "uuid": "289de371-e78f-429c-a52b-0142780f8212",
   "docker_parameters": "create-dataset",
   "arguments": {
     "title": "CreateDatasetArguments",

--- a/Sekoia.io/action_delete_dataset.json
+++ b/Sekoia.io/action_delete_dataset.json
@@ -1,7 +1,7 @@
 {
   "name": "Delete Dataset",
   "description": "Delete an existing dataset",
-  "uuid": "b795cb14-ccb5-5ebb-bf3c-80d4142cf838",
+  "uuid": "c4aa63a9-b010-44ae-b6eb-da14086ed18b",
   "docker_parameters": "delete-dataset",
   "arguments": {
     "title": "DeleteDatasetArguments",

--- a/Sekoia.io/action_execute_a_query.json
+++ b/Sekoia.io/action_execute_a_query.json
@@ -1,7 +1,7 @@
 {
   "name": "Execute a query",
   "description": "Execute a saved query in Sekoia and retrieve the results.",
-  "uuid": "f821c462-028b-5432-b863-109b89c6d2be",
+  "uuid": "50f2774d-e53a-482e-8061-22bc6940ab8f",
   "docker_parameters": "execute-a-query",
   "arguments": {
     "title": "ExecuteAQueryArguments",

--- a/Sekoia.io/action_list_queries.json
+++ b/Sekoia.io/action_list_queries.json
@@ -1,7 +1,7 @@
 {
   "name": "List Queries",
   "description": "List the existing saved SOL queries.",
-  "uuid": "febc7464-2584-54f6-af5f-2d183cc82385",
+  "uuid": "c3f26fb9-4793-4193-8a2e-85a515f14134",
   "docker_parameters": "list-queries",
   "arguments": {
     "title": "ListQueriesArguments",

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.72.2",
+  "version": "2.72.3",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Bump the Sekoia.io integration to version 2.72.3 and correct the UUID configuration for SOL-related actions.

Bug Fixes:
- Correct the UUIDs for Sekoia.io SOL actions to use the proper identifiers.

Build:
- Update the Sekoia.io manifest version from 2.72.2 to 2.72.3.

Documentation:
- Add a changelog entry for version 2.72.3 describing the SOL UUID fix.