### PR TITLE
fix(sekoia_modules): update deprecated from description to name

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-10 - 2.73.1
+
+### Changed
+
+- Change Deprecate `List Assets` from description to name
+
 ## 2026-06-10 - 2.73.0
 
 ### Changed

--- a/Sekoia.io/action_list_assets.json
+++ b/Sekoia.io/action_list_assets.json
@@ -1,8 +1,8 @@
 {
   "uuid": "37782dd7-1308-4cd4-a73d-0a6cc69661e3",
-  "name": "List Assets",
+  "name": "[DEPRECATED] List Assets",
   "docker_parameters": "get-assets",
-  "description": "[DEPRECATED] Return a list of assets according to the filters",
+  "description": "Return a list of assets according to the filters",
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.73.0",
+  "version": "2.73.1",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Bump the Sekoia.io module version and adjust the List Assets action deprecation metadata.

Bug Fixes:
- Correct the placement of the deprecation marker for the List Assets action from the description to the action name.

Documentation:
- Add a 2.73.1 entry to the changelog describing the List Assets deprecation metadata change.