### PR TITLE
fix version

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2026-06-10 - 2.73.1
+## 2026-06-10 - 2.73.2
 
 ### Changed
 

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.73.1",
+  "version": "2.73.2",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Bump the Sekoia.io integration version to 2.73.2 across changelog and manifest metadata.

Documentation:
- Update changelog entry to reflect version 2.73.2.

Chores:
- Align manifest version with the new 2.73.2 release.