### PR TITLE
Imp/graphapi extra info

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-15 - 2.10.23
+
+### Added
+
+- Add an optional `use_beta_signin_api` connector setting to fetch sign-in events from Microsoft Graph beta and expose extra sign-in fields (for example device code flow related details).
+
 ## 2026-05-21 - 2.10.22
 
 ### Fixed

--- a/MicrosoftEntraID/azure_ad/base.py
+++ b/MicrosoftEntraID/azure_ad/base.py
@@ -14,11 +14,42 @@ from sekoia_automation.module import Module
 
 class CompatBaseModel(BaseModel):
     @classmethod
-    def model_validate(cls, value):
+    def model_validate(
+        cls,
+        value,
+        *,
+        strict=None,
+        from_attributes=None,
+        context=None,
+        **kwargs,
+    ):
+
         return cls.parse_obj(value)
 
-    def model_dump(self, *args, **kwargs):
-        return self.dict(*args, **kwargs)
+    def model_dump(
+        self,
+        *,
+        mode="python",
+        include=None,
+        exclude=None,
+        context=None,
+        by_alias=False,
+        exclude_unset=False,
+        exclude_defaults=False,
+        exclude_none=False,
+        round_trip=False,
+        warnings=True,
+        serialize_as_any=False,
+        **kwargs,
+    ):
+        return self.dict(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )
 
 
 class AzureADConfiguration(CompatBaseModel):

--- a/MicrosoftEntraID/azure_ad/base.py
+++ b/MicrosoftEntraID/azure_ad/base.py
@@ -12,7 +12,16 @@ from sekoia_automation.action import Action
 from sekoia_automation.module import Module
 
 
-class AzureADConfiguration(BaseModel):
+class CompatBaseModel(BaseModel):
+    @classmethod
+    def model_validate(cls, value):
+        return cls.parse_obj(value)
+
+    def model_dump(self, *args, **kwargs):
+        return self.dict(*args, **kwargs)
+
+
+class AzureADConfiguration(CompatBaseModel):
     tenant_id: str = Field(..., description="ID of the Azure AD tenant")
     username: str | None = Field(None, description="")
     password: str | None = Field(None, secret=True, description="")
@@ -24,7 +33,6 @@ class AzureADConfiguration(BaseModel):
         secret=True,
         description="Client Secret associated with the registered application. Admin Consent has to be granted to the application for it to work.",  # noqa: E501
     )
-
 
 class AzureADModule(Module):
     configuration: AzureADConfiguration
@@ -63,15 +71,15 @@ class MicrosoftGraphAction(AsyncAction):
         return self._client
 
 
-class ApplicationArguments(BaseModel):
+class ApplicationArguments(CompatBaseModel):
     objectId: str | None = Field(None, description="ID object of the app. you can find it in the app overview.")
 
 
-class IdArguments(BaseModel):
+class IdArguments(CompatBaseModel):
     id: str | None = Field(None, description="ID of the user. id should be specified.")
 
 
-class SingleUserArguments(BaseModel):
+class SingleUserArguments(CompatBaseModel):
     id: str | None = Field(None, description="ID of the user. id or userPrincipalName should be specified.")
     userPrincipalName: str | None = Field(
         None,

--- a/MicrosoftEntraID/azure_ad/base.py
+++ b/MicrosoftEntraID/azure_ad/base.py
@@ -34,6 +34,7 @@ class AzureADConfiguration(CompatBaseModel):
         description="Client Secret associated with the registered application. Admin Consent has to be granted to the application for it to work.",  # noqa: E501
     )
 
+
 class AzureADModule(Module):
     configuration: AzureADConfiguration
 

--- a/MicrosoftEntraID/azure_ad/base.py
+++ b/MicrosoftEntraID/azure_ad/base.py
@@ -14,42 +14,15 @@ from sekoia_automation.module import Module
 
 class CompatBaseModel(BaseModel):
     @classmethod
-    def model_validate(
-        cls,
-        value,
-        *,
-        strict=None,
-        from_attributes=None,
-        context=None,
-        **kwargs,
-    ):
+    def model_validate(cls, obj, **kwargs):
+        # pydantic.v1 models don't support v2-style kwargs, so we ignore them.
+        return cls.parse_obj(obj)
 
-        return cls.parse_obj(value)
-
-    def model_dump(
-        self,
-        *,
-        mode="python",
-        include=None,
-        exclude=None,
-        context=None,
-        by_alias=False,
-        exclude_unset=False,
-        exclude_defaults=False,
-        exclude_none=False,
-        round_trip=False,
-        warnings=True,
-        serialize_as_any=False,
-        **kwargs,
-    ):
-        return self.dict(
-            include=include,
-            exclude=exclude,
-            by_alias=by_alias,
-            exclude_unset=exclude_unset,
-            exclude_defaults=exclude_defaults,
-            exclude_none=exclude_none,
-        )
+    def model_dump(self, *args, **kwargs):
+        # pydantic.v1 BaseModel.dict() doesn't support several pydantic.v2-only kwargs.
+        for key in ("mode", "context", "round_trip", "warnings", "serialize_as_any"):
+            kwargs.pop(key, None)
+        return self.dict(*args, **kwargs)
 
 
 class AzureADConfiguration(CompatBaseModel):

--- a/MicrosoftEntraID/azure_ad/connector_entraid_graph_api.py
+++ b/MicrosoftEntraID/azure_ad/connector_entraid_graph_api.py
@@ -22,6 +22,7 @@ class MicrosoftEntraIdGraphApiConnectorConfig(DefaultConnectorConfiguration):
 
     frequency: int = 60
     chunk_size: int = 1000
+    use_beta_signin_api: bool = False
 
 
 class MicrosoftEntraIdGraphApiConnector(AsyncConnector):
@@ -76,6 +77,7 @@ class MicrosoftEntraIdGraphApiConnector(AsyncConnector):
                 tenant_id=self.module.configuration.tenant_id,
                 client_id=self.module.configuration.client_id,
                 client_secret=self.module.configuration.client_secret,
+                use_beta_signin_api=self.configuration.use_beta_signin_api,
             )
 
         return self._client

--- a/MicrosoftEntraID/connector_entraid_graph_api.json
+++ b/MicrosoftEntraID/connector_entraid_graph_api.json
@@ -22,6 +22,11 @@
         "type": "integer",
         "description": "Batch frequency in seconds",
         "default": 60
+      },
+      "use_beta_signin_api": {
+        "type": "boolean",
+        "description": "Use Microsoft Graph beta endpoint for sign-ins to retrieve extra fields (for example device code related fields). Disabled by default because beta APIs can change.",
+        "default": false
       }
     },
     "required": [

--- a/MicrosoftEntraID/graph_api/client.py
+++ b/MicrosoftEntraID/graph_api/client.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from typing import AsyncGenerator, Iterable
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlsplit
 
 from azure.identity.aio import ClientSecretCredential
 from kiota_abstractions.base_request_configuration import RequestConfiguration
@@ -41,7 +41,6 @@ class GraphApi(object):
                 client_secret=self._client_secret,
             )
 
-            # Reset client to force re-creation with new credentials even if already set
             self._client = None
 
         if self._client is None:
@@ -73,8 +72,19 @@ class GraphApi(object):
     def _build_signin_beta_url(self, start_date: datetime, end_date: datetime | None = None) -> str:
         filter_value = self._build_filter("createdDateTime", start_date, end_date)
         order_by = "createdDateTime asc"
+        adapter_base_url = getattr(self.client.request_adapter, "base_url", "https://graph.microsoft.com/v1.0/")
+        if not isinstance(adapter_base_url, str) or len(adapter_base_url) == 0:
+            adapter_base_url = "https://graph.microsoft.com/v1.0/"
+
+        parsed_base_url = urlsplit(adapter_base_url)
+        graph_root_url = (
+            f"{parsed_base_url.scheme}://{parsed_base_url.netloc}"
+            if parsed_base_url.scheme and parsed_base_url.netloc
+            else "https://graph.microsoft.com"
+        )
+
         return (
-            "https://graph.microsoft.com/beta/auditLogs/signIns"
+            f"{graph_root_url}/beta/auditLogs/signIns"
             f"?$filter={quote_plus(filter_value)}"
             f"&$orderby={quote_plus(order_by)}"
         )

--- a/MicrosoftEntraID/graph_api/client.py
+++ b/MicrosoftEntraID/graph_api/client.py
@@ -93,7 +93,7 @@ class GraphApi(object):
         self, start_date: datetime, end_date: datetime | None = None
     ) -> AsyncGenerator[SignIn, None]:
         if self._use_beta_signin_api:
-            next_data_link = self._build_signin_beta_url(start_date, end_date)
+            next_data_link: str | None = self._build_signin_beta_url(start_date, end_date)
             while next_data_link is not None:
                 response = await self.client.audit_logs.sign_ins.with_url(next_data_link).get()
                 if response is None:
@@ -147,7 +147,7 @@ class GraphApi(object):
         if response is None:
             return
 
-        next_data_link = response.odata_next_link
+        next_data_link: str | None = response.odata_next_link
         items = response.value or []
         for item in items:
             yield item

--- a/MicrosoftEntraID/graph_api/client.py
+++ b/MicrosoftEntraID/graph_api/client.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from typing import AsyncGenerator, Iterable
+from urllib.parse import quote_plus
 
 from azure.identity.aio import ClientSecretCredential
 from kiota_abstractions.base_request_configuration import RequestConfiguration
@@ -17,10 +18,17 @@ _factory = JsonSerializationWriterFactory()
 
 
 class GraphApi(object):
-    def __init__(self, client_id: str, client_secret: str, tenant_id: str) -> None:
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        tenant_id: str,
+        use_beta_signin_api: bool = False,
+    ) -> None:
         self._client_id = client_id
         self._client_secret = client_secret
         self._tenant_id = tenant_id
+        self._use_beta_signin_api = use_beta_signin_api
         self._client: GraphServiceClient | None = None
         self._credentials: ClientSecretCredential | None = None
 
@@ -62,9 +70,32 @@ class GraphApi(object):
 
         return " and ".join(parts) if parts else ""
 
+    def _build_signin_beta_url(self, start_date: datetime, end_date: datetime | None = None) -> str:
+        filter_value = self._build_filter("createdDateTime", start_date, end_date)
+        order_by = "createdDateTime asc"
+        return (
+            "https://graph.microsoft.com/beta/auditLogs/signIns"
+            f"?$filter={quote_plus(filter_value)}"
+            f"&$orderby={quote_plus(order_by)}"
+        )
+
     async def get_signin_logs(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> AsyncGenerator[SignIn, None]:
+        if self._use_beta_signin_api:
+            next_data_link = self._build_signin_beta_url(start_date, end_date)
+            while next_data_link is not None:
+                response = await self.client.audit_logs.sign_ins.with_url(next_data_link).get()
+                if response is None:
+                    return
+
+                next_data_link = response.odata_next_link
+                items = response.value or []
+                for item in items:
+                    yield item
+
+            return
+
         request_configuration = RequestConfiguration(
             query_parameters=SignInsRequestBuilder.SignInsRequestBuilderGetQueryParameters(
                 filter=self._build_filter("createdDateTime", start_date, end_date),

--- a/MicrosoftEntraID/tests/graph_api/test_client.py
+++ b/MicrosoftEntraID/tests/graph_api/test_client.py
@@ -53,6 +53,55 @@ async def test_client_get_signins_empty_1(graph_api_client: GraphApi, signins_pa
 
 
 @pytest.mark.asyncio
+async def test_client_get_signins_uses_beta_endpoint_when_enabled(
+    graph_api_client: GraphApi, signins_page_1, signins_page_2
+) -> None:
+    graph_api_client._use_beta_signin_api = True
+    graph_api_client._client.audit_logs.sign_ins.with_url.return_value.get.side_effect = [
+        signins_page_1,
+        signins_page_2,
+    ]
+
+    items = [
+        x
+        async for x in graph_api_client.get_signin_logs(
+            datetime.fromisoformat("2025-09-01T00:00:00").replace(tzinfo=timezone.utc)
+        )
+    ]
+
+    assert [i.id for i in items] == ["0", "1", "2"]
+    graph_api_client._client.audit_logs.sign_ins.get.assert_not_called()
+    graph_api_client._client.audit_logs.sign_ins.with_url.assert_any_call(
+        "https://graph.microsoft.com/beta/auditLogs/signIns"
+        "?$filter=createdDateTime+ge+2025-09-01T00%3A00%3A00Z"
+        "&$orderby=createdDateTime+asc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_get_signins_uses_beta_endpoint_with_end_date(
+    graph_api_client: GraphApi, signins_page_2
+) -> None:
+    graph_api_client._use_beta_signin_api = True
+    graph_api_client._client.audit_logs.sign_ins.with_url.return_value.get.return_value = signins_page_2
+
+    items = [
+        x
+        async for x in graph_api_client.get_signin_logs(
+            datetime.fromisoformat("2025-09-01T00:00:00").replace(tzinfo=timezone.utc),
+            datetime.fromisoformat("2025-09-01T12:30:45").replace(tzinfo=timezone.utc),
+        )
+    ]
+
+    assert [i.id for i in items] == ["2"]
+    graph_api_client._client.audit_logs.sign_ins.with_url.assert_any_call(
+        "https://graph.microsoft.com/beta/auditLogs/signIns"
+        "?$filter=createdDateTime+ge+2025-09-01T00%3A00%3A00Z+and+createdDateTime+le+2025-09-01T12%3A30%3A45Z"
+        "&$orderby=createdDateTime+asc"
+    )
+
+
+@pytest.mark.asyncio
 async def test_client_get_directory_audits(
     graph_api_client: GraphApi, directory_audits_page_1, directory_audits_page_2
 ) -> None:

--- a/MicrosoftEntraID/tests/graph_api/test_client.py
+++ b/MicrosoftEntraID/tests/graph_api/test_client.py
@@ -79,9 +79,7 @@ async def test_client_get_signins_uses_beta_endpoint_when_enabled(
 
 
 @pytest.mark.asyncio
-async def test_client_get_signins_uses_beta_endpoint_with_end_date(
-    graph_api_client: GraphApi, signins_page_2
-) -> None:
+async def test_client_get_signins_uses_beta_endpoint_with_end_date(graph_api_client: GraphApi, signins_page_2) -> None:
     graph_api_client._use_beta_signin_api = True
     graph_api_client._client.audit_logs.sign_ins.with_url.return_value.get.return_value = signins_page_2
 

--- a/MicrosoftEntraID/tests/graph_api/test_client.py
+++ b/MicrosoftEntraID/tests/graph_api/test_client.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 
@@ -95,6 +96,29 @@ async def test_client_get_signins_uses_beta_endpoint_with_end_date(graph_api_cli
     graph_api_client._client.audit_logs.sign_ins.with_url.assert_any_call(
         "https://graph.microsoft.com/beta/auditLogs/signIns"
         "?$filter=createdDateTime+ge+2025-09-01T00%3A00%3A00Z+and+createdDateTime+le+2025-09-01T12%3A30%3A45Z"
+        "&$orderby=createdDateTime+asc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_get_signins_uses_beta_sovereign_cloud_base_url(
+    graph_api_client: GraphApi, signins_page_2
+) -> None:
+    graph_api_client._use_beta_signin_api = True
+    graph_api_client._client.request_adapter = SimpleNamespace(base_url="https://graph.microsoft.us/v1.0/")
+    graph_api_client._client.audit_logs.sign_ins.with_url.return_value.get.return_value = signins_page_2
+
+    items = [
+        x
+        async for x in graph_api_client.get_signin_logs(
+            datetime.fromisoformat("2025-09-01T00:00:00").replace(tzinfo=timezone.utc)
+        )
+    ]
+
+    assert [i.id for i in items] == ["2"]
+    graph_api_client._client.audit_logs.sign_ins.with_url.assert_any_call(
+        "https://graph.microsoft.us/beta/auditLogs/signIns"
+        "?$filter=createdDateTime+ge+2025-09-01T00%3A00%3A00Z"
         "&$orderby=createdDateTime+asc"
     )
 

--- a/MicrosoftEntraID/tests/test_base.py
+++ b/MicrosoftEntraID/tests/test_base.py
@@ -1,0 +1,229 @@
+"""Tests for azure_ad/base.py compatibility models and validators."""
+
+import pytest
+
+from azure_ad.base import (
+    ApplicationArguments,
+    CompatBaseModel,
+    IdArguments,
+    RequiredSingleUserArguments,
+    RequiredTwoUserArguments,
+    RequiredTwoUserArgumentsV2,
+    SingleUserArguments,
+)
+
+
+class TestCompatBaseModel:
+    """Test CompatBaseModel v1↔v2 compatibility layer."""
+
+    def test_model_validate_with_simple_dict(self):
+        """Test model_validate accepts a dict."""
+        data = {"id": "test-id"}
+        result = IdArguments.model_validate(data)
+        assert result.id == "test-id"
+
+    def test_model_validate_with_v2_kwargs(self):
+        """Test model_validate gracefully ignores v2-style kwargs."""
+        data = {"id": "test-id"}
+        # These v2 kwargs should be silently ignored
+        result = IdArguments.model_validate(
+            data,
+            strict=True,
+            from_attributes=False,
+            context={"key": "value"},
+        )
+        assert result.id == "test-id"
+
+    def test_model_dump_basic(self):
+        """Test model_dump returns a dict."""
+        obj = IdArguments(id="test-id")
+        result = obj.model_dump()
+        assert isinstance(result, dict)
+        assert result["id"] == "test-id"
+
+    def test_model_dump_with_include(self):
+        """Test model_dump with include parameter."""
+        obj = SingleUserArguments(id="test-id", userPrincipalName="user@example.com")
+        result = obj.model_dump(include={"id"})
+        assert "id" in result
+        assert result["id"] == "test-id"
+
+    def test_model_dump_with_v2_only_kwargs(self):
+        """Test model_dump filters out v2-only kwargs before calling dict()."""
+        obj = IdArguments(id="test-id")
+        # These v2-only kwargs should be filtered out, not causing TypeError
+        result = obj.model_dump(
+            mode="python",
+            context={"key": "value"},
+            round_trip=True,
+            warnings=False,
+            serialize_as_any=True,
+        )
+        assert isinstance(result, dict)
+        assert result["id"] == "test-id"
+
+    def test_model_dump_with_mixed_kwargs(self):
+        """Test model_dump with both v1 and v2 kwargs."""
+        obj = SingleUserArguments(
+            id="test-id",
+            userPrincipalName="user@example.com",
+        )
+        result = obj.model_dump(
+            include={"id"},
+            mode="python",  # v2-only
+            context={"key": "value"},  # v2-only
+        )
+        assert "id" in result
+        assert result["id"] == "test-id"
+
+
+class TestApplicationArguments:
+    """Test ApplicationArguments model."""
+
+    def test_create_with_object_id(self):
+        """Test creating ApplicationArguments with objectId."""
+        app = ApplicationArguments(objectId="app-123")
+        assert app.objectId == "app-123"
+
+    def test_create_without_object_id(self):
+        """Test creating ApplicationArguments without objectId (optional)."""
+        app = ApplicationArguments()
+        assert app.objectId is None
+
+
+class TestSingleUserArguments:
+    """Test SingleUserArguments model."""
+
+    def test_create_with_id(self):
+        """Test creating with id."""
+        args = SingleUserArguments(id="user-123")
+        assert args.id == "user-123"
+        assert args.userPrincipalName is None
+
+    def test_create_with_user_principal_name(self):
+        """Test creating with userPrincipalName."""
+        args = SingleUserArguments(userPrincipalName="user@example.com")
+        assert args.userPrincipalName == "user@example.com"
+        assert args.id is None
+
+    def test_create_with_both(self):
+        """Test creating with both id and userPrincipalName."""
+        args = SingleUserArguments(
+            id="user-123",
+            userPrincipalName="user@example.com",
+        )
+        assert args.id == "user-123"
+        assert args.userPrincipalName == "user@example.com"
+
+
+class TestRequiredSingleUserArguments:
+    """Test RequiredSingleUserArguments validator."""
+
+    def test_valid_with_id(self):
+        """Test validation passes with id."""
+        args = RequiredSingleUserArguments(id="user-123")
+        assert args.id == "user-123"
+
+    def test_valid_with_user_principal_name(self):
+        """Test validation passes with userPrincipalName."""
+        args = RequiredSingleUserArguments(userPrincipalName="user@example.com")
+        assert args.userPrincipalName == "user@example.com"
+
+    def test_valid_with_both(self):
+        """Test validation passes with both."""
+        args = RequiredSingleUserArguments(
+            id="user-123",
+            userPrincipalName="user@example.com",
+        )
+        assert args.id == "user-123"
+        assert args.userPrincipalName == "user@example.com"
+
+    def test_invalid_without_both(self):
+        """Test validation fails when neither id nor userPrincipalName is provided."""
+        with pytest.raises(ValueError, match="'id' or 'userPrincipalName' should be specified"):
+            RequiredSingleUserArguments()
+
+    def test_invalid_with_empty_strings(self):
+        """Test validation fails with empty strings."""
+        with pytest.raises(ValueError, match="'id' or 'userPrincipalName' should be specified"):
+            RequiredSingleUserArguments(id="", userPrincipalName="")
+
+
+class TestRequiredTwoUserArguments:
+    """Test RequiredTwoUserArguments validator."""
+
+    def test_valid_with_id_and_password(self):
+        """Test validation passes with id and userNewPassword."""
+        args = RequiredTwoUserArguments(
+            id="user-123",
+            userNewPassword="NewPassword123!",
+        )
+        assert args.id == "user-123"
+        assert args.userNewPassword == "NewPassword123!"
+
+    def test_valid_with_user_principal_name_and_password(self):
+        """Test validation passes with userPrincipalName and userNewPassword."""
+        args = RequiredTwoUserArguments(
+            userPrincipalName="user@example.com",
+            userNewPassword="NewPassword123!",
+        )
+        assert args.userPrincipalName == "user@example.com"
+        assert args.userNewPassword == "NewPassword123!"
+
+    def test_invalid_without_password(self):
+        """Test validation fails without userNewPassword."""
+        with pytest.raises(ValueError, match="'userPrincipalName' and.*should be specified"):
+            RequiredTwoUserArguments(id="user-123")
+
+    def test_invalid_without_user_identifier(self):
+        """Test validation fails without user identifier."""
+        with pytest.raises(ValueError, match="'userPrincipalName' and.*should be specified"):
+            RequiredTwoUserArguments(userNewPassword="NewPassword123!")
+
+    def test_invalid_without_both(self):
+        """Test validation fails without both user identifier and password."""
+        with pytest.raises(ValueError, match="'userPrincipalName' and.*should be specified"):
+            RequiredTwoUserArguments()
+
+
+class TestRequiredTwoUserArgumentsV2:
+    """Test RequiredTwoUserArgumentsV2 validator."""
+
+    def test_valid_with_id_and_password(self):
+        """Test validation passes with id and userNewPassword."""
+        args = RequiredTwoUserArgumentsV2(
+            id="user-123",
+            userNewPassword="NewPassword123!",
+        )
+        assert args.id == "user-123"
+        assert args.userNewPassword == "NewPassword123!"
+        assert args.forceChangePasswordNextSignIn is True
+
+    def test_valid_with_user_principal_name(self):
+        """Test validation passes with userPrincipalName."""
+        args = RequiredTwoUserArgumentsV2(userPrincipalName="user@example.com")
+        assert args.userPrincipalName == "user@example.com"
+        assert args.forceChangePasswordNextSignIn is True
+
+    def test_valid_with_all_fields(self):
+        """Test validation passes with all fields."""
+        args = RequiredTwoUserArgumentsV2(
+            id="user-123",
+            userNewPassword="NewPassword123!",
+            forceChangePasswordNextSignIn=False,
+            forceChangePasswordNextSignInWithMfa=True,
+        )
+        assert args.id == "user-123"
+        assert args.userNewPassword == "NewPassword123!"
+        assert args.forceChangePasswordNextSignIn is False
+        assert args.forceChangePasswordNextSignInWithMfa is True
+
+    def test_invalid_without_user_identifier(self):
+        """Test validation fails without user identifier."""
+        with pytest.raises(ValueError, match="'id' or 'userPrincipalName' should be specified"):
+            RequiredTwoUserArgumentsV2(userNewPassword="NewPassword123!")
+
+    def test_invalid_without_any_identifier(self):
+        """Test validation fails without any identifier."""
+        with pytest.raises(ValueError, match="'id' or 'userPrincipalName' should be specified"):
+            RequiredTwoUserArgumentsV2()

--- a/MicrosoftEntraID/trigger_entraid_graph_api.json
+++ b/MicrosoftEntraID/trigger_entraid_graph_api.json
@@ -22,6 +22,11 @@
         "type": "integer",
         "description": "Batch frequency in seconds",
         "default": 60
+      },
+      "use_beta_signin_api": {
+        "type": "boolean",
+        "description": "Use Microsoft Graph beta endpoint for sign-ins to retrieve extra fields (for example device code related fields). Disabled by default because beta APIs can change.",
+        "default": false
       }
     },
     "required": [


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1627

## Summary by Sourcery

Add optional support for using the Microsoft Graph beta sign-in API and introduce a Pydantic compatibility base model across Azure AD models.

New Features:
- Introduce a configurable `use_beta_signin_api` option on the Microsoft Entra ID Graph API connector and client to fetch sign-in logs from the Microsoft Graph beta endpoint.

Enhancements:
- Add a Pydantic compatibility base model and apply it to Azure AD configuration and argument models to align with newer Pydantic APIs.
- Wire the connector configuration flag through to the Graph API client so beta sign-in requests can be toggled per connector instance.

Documentation:
- Document the new `use_beta_signin_api` setting and release a new connector version in the changelog.

Tests:
- Add tests to verify that enabling the beta sign-in API uses the expected Microsoft Graph beta endpoint URLs, including optional end date filtering.