### PR TITLE
Imperva: revert renaming

### DIFF
--- a/Imperva/CHANGELOG.md
+++ b/Imperva/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-08 - 1.21.5
+
+### Fixed
+
+- Revert the renaming of the `private` field to `private_key_pem`, in order to avoid breaking existing configuration.
+
 ## 2026-06-08 - 1.21.4
 
 ### Changed

--- a/Imperva/imperva/fetch_logs_v2.py
+++ b/Imperva/imperva/fetch_logs_v2.py
@@ -180,7 +180,7 @@ class ImpervaLogsConnector(Connector):
             checksum = file_header_content.split("checksum:")[1].splitlines()[0]
 
             # get the private key
-            private_key = bytes(keys["private_key_pem"], "utf-8")
+            private_key = bytes(keys["private"], "utf-8")
             iv = 16 * b"\x00"
 
             try:

--- a/Imperva/manifest.json
+++ b/Imperva/manifest.json
@@ -39,7 +39,7 @@
     ],
     "secrets": [
       "api_key",
-      "private_key_pem"
+      "private"
     ]
   },
   "description": "Imperva is a cybersecurity company focused on protecting data and applications, offering solutions like web application firewalls and DDoS protection. It helps safeguard digital assets from cyber threats through comprehensive security and risk management tools.",

--- a/Imperva/manifest.json
+++ b/Imperva/manifest.json
@@ -46,7 +46,7 @@
   "name": "Imperva",
   "uuid": "ee0e5c81-5410-48d4-b155-135679c5ebb8",
   "slug": "imperva",
-  "version": "1.21.4",
+  "version": "1.21.5",
   "categories": [
     "Network"
   ]

--- a/Imperva/manifest.json
+++ b/Imperva/manifest.json
@@ -23,7 +23,7 @@
           "<public key id>": {
             "type": "object",
             "properties": {
-              "private_key_pem": {
+              "private": {
                 "description": "RSA private key in PEM format used to decrypt the AES symmetric key embedded in each log file",
                 "type": "string"
               }

--- a/Imperva/tests/test_fetch_logs_v2.py
+++ b/Imperva/tests/test_fetch_logs_v2.py
@@ -73,7 +73,7 @@ def trigger(data_storage, secret_key_pem):
         "api_id": "123",
         "api_key": "myapikey",
         "base_url": "https://example.com",
-        "keys": {"1": {"private_key_pem": secret_key_pem}},
+        "keys": {"1": {"private": secret_key_pem}},
     }
     trigger.configuration = {
         "intake_key": "intake_key",


### PR DESCRIPTION
rename back the `private` module configuration field in order to avoid breaking existing configuration.

## Summary by Sourcery

Revert a breaking configuration field rename in the Imperva integration and bump the package version.

Bug Fixes:
- Restore the `private` configuration field name in the Imperva integration to maintain backward compatibility with existing configs.

Build:
- Bump the Imperva integration version from 1.21.4 to 1.21.5.

Documentation:
- Document the restoration of the `private` configuration field and the associated patch release in the changelog.

Tests:
- Update log decryption tests to use the restored `private` configuration field name instead of `private_key_pem`.