### PR TITLE
prevent system log re-ingestion after connector restart

### DIFF
--- a/Okta/okta_modules/asset_connector/user_assets.py
+++ b/Okta/okta_modules/asset_connector/user_assets.py
@@ -11,9 +11,9 @@ from typing import Any, Optional
 
 from dateutil.parser import isoparse
 from okta.client import Client as OktaClient
-from okta.models.user import User as OktaUser
 from okta.models.role import Role as OktaRole
 from okta.models.role_status import RoleStatus as OktaRoleStatus
+from okta.models.user import User as OktaUser
 from okta.models.user_status import UserStatus as OktaUserStatus
 from sekoia_automation.asset_connector import AsyncAssetConnector
 from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product

--- a/Okta/okta_modules/system_log_trigger.py
+++ b/Okta/okta_modules/system_log_trigger.py
@@ -236,8 +236,10 @@ class SystemLogConnector(Connector):
 
             # if the batch is full, push it
             if len(serialized_events) > 0:
-                # Update cache BEFORE pushing events (better atomicity)
-                # This prevents duplicates if process crashes during/after push
+                # Push first to preserve at-least-once delivery guarantees.
+                self.push_events_to_intakes(events=serialized_events)
+
+                # Update and persist cache only after successful push.
                 for event in pushed_events:
                     event_uuid = event.get("uuid")
 
@@ -248,19 +250,17 @@ class SystemLogConnector(Connector):
                         event_checksum = compute_event_checksum(event)
                         self.events_cache[event_checksum] = True
 
-                # Persist cache to disk before pushing events
                 self.save_events_cache()
+
+                # Advance checkpoint only after successful push.
+                # This prevents replay storms on restart while keeping at-least-once delivery semantics.
+                self._update_checkpoint(pushed_events)
 
                 self.log(
                     message=f"Forwarded {len(serialized_events)} events to the intake",
                     level="info",
                 )
                 OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(serialized_events))
-                self.push_events_to_intakes(events=serialized_events)
-
-                # Advance checkpoint only after successful push.
-                # This prevents replay storms on restart while keeping at-least-once delivery semantics.
-                self._update_checkpoint(pushed_events)
             else:
                 self.log(
                     message="No events to forward",

--- a/Okta/okta_modules/system_log_trigger.py
+++ b/Okta/okta_modules/system_log_trigger.py
@@ -51,7 +51,7 @@ def compute_event_checksum(event: dict[str, Any]) -> str:
     }
 
     event_json = orjson.dumps(event_hash_input, default=str)
-    return hashlib.sha256(event_json).hexdigest()[:16]  # Use first 16 chars for storage efficiency
+    return hashlib.sha256(event_json).hexdigest()
 
 
 class SystemLogConnectorConfiguration(DefaultConnectorConfiguration):
@@ -172,28 +172,20 @@ class SystemLogConnector(Connector):
             # get events from the response
             events = response.json()
 
-            # Filter events that have already been processed
-            # Uses both UUID (primary) and content checksum (fallback) for robust deduplication
+            # Filter events that have already been processed.
+            # Prefer UUID when available, fallback to checksum otherwise.
             filtered_events = []
             for event in events:
                 event_uuid = event.get("uuid")
-
-                # Generate cache keys for deduplication
-                cache_keys_to_check = []
-
-                # Primary cache key: UUID (preferred if present)
                 if event_uuid is not None:
-                    cache_keys_to_check.append(event_uuid)
+                    if event_uuid not in self.events_cache:
+                        filtered_events.append(event)
+                else:
+                    event_checksum = compute_event_checksum(event)
+                    if event_checksum not in self.events_cache:
+                        filtered_events.append(event)
 
-                # Secondary cache key: content checksum (for events without UUID or as fallback)
-                event_checksum = compute_event_checksum(event)
-                cache_keys_to_check.append(event_checksum)
-
-                # Only include event if NONE of its cache keys exist in cache
-                if not any(key in self.events_cache for key in cache_keys_to_check):
-                    filtered_events.append(event)
-
-            # yielding events if defined
+            # Only include events that are not present in cache.
             if filtered_events:
                 INCOMING_MESSAGES.labels(intake_key=self.configuration.intake_key).inc(len(filtered_events))
 
@@ -239,37 +231,36 @@ class SystemLogConnector(Connector):
 
         # Fetch next batch
         for events in self.fetch_events():
-            batch_of_events = [orjson.dumps(event).decode("utf-8") for event in events]
+            pushed_events = events
+            serialized_events = [orjson.dumps(event).decode("utf-8") for event in pushed_events]
 
             # if the batch is full, push it
-            if len(batch_of_events) > 0:
+            if len(serialized_events) > 0:
                 # Update cache BEFORE pushing events (better atomicity)
                 # This prevents duplicates if process crashes during/after push
-                for event in events:
+                for event in pushed_events:
                     event_uuid = event.get("uuid")
 
-                    # Cache UUID if available (primary key)
+                    # Cache UUID when available to maximize LRU coverage.
                     if event_uuid is not None:
                         self.events_cache[event_uuid] = True
-
-                    # Always cache event checksum (fallback key)
-                    # This ensures deduplication even if UUID is missing or changes
-                    event_checksum = compute_event_checksum(event)
-                    self.events_cache[event_checksum] = True
+                    else:
+                        event_checksum = compute_event_checksum(event)
+                        self.events_cache[event_checksum] = True
 
                 # Persist cache to disk before pushing events
                 self.save_events_cache()
 
                 self.log(
-                    message=f"Forwarded {len(batch_of_events)} events to the intake",
+                    message=f"Forwarded {len(serialized_events)} events to the intake",
                     level="info",
                 )
-                OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(batch_of_events))
-                self.push_events_to_intakes(events=batch_of_events)
+                OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(serialized_events))
+                self.push_events_to_intakes(events=serialized_events)
 
                 # Advance checkpoint only after successful push.
                 # This prevents replay storms on restart while keeping at-least-once delivery semantics.
-                self._update_checkpoint(events)
+                self._update_checkpoint(pushed_events)
             else:
                 self.log(
                     message="No events to forward",

--- a/Okta/okta_modules/system_log_trigger.py
+++ b/Okta/okta_modules/system_log_trigger.py
@@ -1,3 +1,4 @@
+import hashlib
 import signal
 import time
 from collections.abc import Generator
@@ -28,6 +29,31 @@ class FetchEventsException(Exception):
     pass
 
 
+def compute_event_checksum(event: dict[str, Any]) -> str:
+    """
+    Compute a checksum of event content to detect duplicates even if UUID is missing.
+    Uses key fields that uniquely identify an event occurrence.
+    """
+    target = event.get("target")
+    target_id = None
+    if isinstance(target, dict):
+        target_id = target.get("id")
+    elif isinstance(target, list) and target:
+        first_target = target[0]
+        if isinstance(first_target, dict):
+            target_id = first_target.get("id")
+
+    event_hash_input = {
+        "eventType": event.get("eventType"),
+        "published": event.get("published"),
+        "actor_id": event.get("actor", {}).get("id"),
+        "target_id": target_id,
+    }
+
+    event_json = orjson.dumps(event_hash_input, default=str)
+    return hashlib.sha256(event_json).hexdigest()[:16]  # Use first 16 chars for storage efficiency
+
+
 class SystemLogConnectorConfiguration(DefaultConnectorConfiguration):
     frequency: int = 60
     ratelimit_per_minute: int = 20
@@ -55,7 +81,6 @@ class SystemLogConnector(Connector):
             ignore_older_than=timedelta(days=7),
         )
 
-        # Put cache size to 2000 in order to
         self.cache_size = 2000
         self.events_cache: Cache[str, bool] = self.load_events_cache()
 
@@ -65,25 +90,27 @@ class SystemLogConnector(Connector):
 
     def load_events_cache(self) -> Cache[str, bool]:
         """
-        Load the events cache.
+        Load the events cache from persistent storage.
+        Cache stores both UUIDs and event checksums for robust deduplication.
         """
         cache: Cache[str, bool] = LRUCache(maxsize=self.cache_size)
 
         with self.context as context:
-            # load the cache from the context
+            # load the cache from the context - includes both UUIDs and checksums
             events_cache = context.get("events_cache", [])
 
-        for uuid in events_cache:
-            cache[uuid] = True
+        for cache_key in events_cache:
+            cache[cache_key] = True
 
         return cache
 
     def save_events_cache(self) -> None:
         """
-        Save the events cache.
+        Persist the events cache to disk.
+        Stores both UUIDs and checksums for robust deduplication across restarts.
         """
         with self.context as context:
-            # save the events cache to the context
+            # save the events cache to the context - includes both UUIDs and checksums
             context["events_cache"] = list(self.events_cache.keys())
 
     def exit(self, _: Any, __: Optional[Any]) -> None:
@@ -145,9 +172,26 @@ class SystemLogConnector(Connector):
             # get events from the response
             events = response.json()
 
-            filtered_events = [
-                event for event in events if event.get("uuid") is not None and event["uuid"] not in self.events_cache
-            ]
+            # Filter events that have already been processed
+            # Uses both UUID (primary) and content checksum (fallback) for robust deduplication
+            filtered_events = []
+            for event in events:
+                event_uuid = event.get("uuid")
+
+                # Generate cache keys for deduplication
+                cache_keys_to_check = []
+
+                # Primary cache key: UUID (preferred if present)
+                if event_uuid is not None:
+                    cache_keys_to_check.append(event_uuid)
+
+                # Secondary cache key: content checksum (for events without UUID or as fallback)
+                event_checksum = compute_event_checksum(event)
+                cache_keys_to_check.append(event_checksum)
+
+                # Only include event if NONE of its cache keys exist in cache
+                if not any(key in self.events_cache for key in cache_keys_to_check):
+                    filtered_events.append(event)
 
             # yielding events if defined
             if filtered_events:
@@ -166,34 +210,27 @@ class SystemLogConnector(Connector):
             if url is None:
                 return
 
+    def _compute_batch_checkpoint(self, events: list[dict[str, Any]]) -> datetime | None:
+        events_date: list[str] = sorted(x["published"] for x in events if x.get("published") is not None)
+        if len(events_date) == 0:
+            return None
+
+        return get_upper_second(isoparse(events_date[-1]))
+
+    def _update_checkpoint(self, events: list[dict[str, Any]]) -> None:
+        next_checkpoint = self._compute_batch_checkpoint(events)
+        if next_checkpoint is not None and next_checkpoint > self.cursor.offset:
+            self.cursor.offset = next_checkpoint
+
     def fetch_events(self) -> Generator[list[dict[str, Any]], None, None]:
-        most_recent_date_seen = self.cursor.offset
+        from_date = self.cursor.offset
 
-        try:
-            for next_events in self.__fetch_next_events(most_recent_date_seen):
-                if next_events:
-                    # get the greater date seen in this list of events
-                    events_date: list[str] = sorted(
-                        x["published"] for x in next_events if x.get("published") is not None
-                    )
-
-                    last_event_date = isoparse(events_date[-1])
-
-                    # save the greater date ever seen
-                    if last_event_date > most_recent_date_seen:
-                        most_recent_date_seen = get_upper_second(
-                            last_event_date
-                        )  # get the upper second to exclude the most recent event seen
-
-                    # forward current events
-                    yield next_events
-        finally:
-            # save the most recent date
-            if most_recent_date_seen > self.cursor.offset:
-                self.cursor.offset = most_recent_date_seen
+        for next_events in self.__fetch_next_events(from_date):
+            if next_events:
+                yield next_events
 
         now = datetime.now(timezone.utc)
-        current_lag = now - most_recent_date_seen
+        current_lag = now - self.cursor.offset
         EVENTS_LAG.labels(intake_key=self.configuration.intake_key).set(int(current_lag.total_seconds()))
 
     def next_batch(self) -> None:
@@ -206,6 +243,23 @@ class SystemLogConnector(Connector):
 
             # if the batch is full, push it
             if len(batch_of_events) > 0:
+                # Update cache BEFORE pushing events (better atomicity)
+                # This prevents duplicates if process crashes during/after push
+                for event in events:
+                    event_uuid = event.get("uuid")
+
+                    # Cache UUID if available (primary key)
+                    if event_uuid is not None:
+                        self.events_cache[event_uuid] = True
+
+                    # Always cache event checksum (fallback key)
+                    # This ensures deduplication even if UUID is missing or changes
+                    event_checksum = compute_event_checksum(event)
+                    self.events_cache[event_checksum] = True
+
+                # Persist cache to disk before pushing events
+                self.save_events_cache()
+
                 self.log(
                     message=f"Forwarded {len(batch_of_events)} events to the intake",
                     level="info",
@@ -213,11 +267,9 @@ class SystemLogConnector(Connector):
                 OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(batch_of_events))
                 self.push_events_to_intakes(events=batch_of_events)
 
-                # Persist cache of event UUIDs after pushing to intake
-                for event in events:
-                    self.events_cache[event["uuid"]] = True
-
-                self.save_events_cache()
+                # Advance checkpoint only after successful push.
+                # This prevents replay storms on restart while keeping at-least-once delivery semantics.
+                self._update_checkpoint(events)
             else:
                 self.log(
                     message="No events to forward",

--- a/Okta/tests/test_system_log_trigger.py
+++ b/Okta/tests/test_system_log_trigger.py
@@ -237,9 +237,10 @@ def test_fetch_events(trigger, message1, message2):
     with requests_mock.Mocker() as mock_requests:
         mock_requests.get("https://tenant_id.okta.com/api/v1/logs", status_code=200, json=messages)
         events = trigger.fetch_events()
+        initial_offset = trigger.cursor.offset
 
         assert list(events) == [messages]
-        assert trigger.cursor.offset.isoformat() == get_upper_second(recent_date).isoformat()
+        assert trigger.cursor.offset == initial_offset
 
 
 def test_fetch_events_with_pagination(trigger, message1, message2):
@@ -259,9 +260,10 @@ def test_fetch_events_with_pagination(trigger, message1, message2):
         )
         mock_requests.get("https://tenant_id.okta.com/api/v1/logs?after=1111111", status_code=200, json=[message2])
         events = trigger.fetch_events()
+        initial_offset = trigger.cursor.offset
 
         assert list(events) == [response_1, [message2]]
-        assert trigger.cursor.offset.isoformat() == get_upper_second(recent_date).isoformat()
+        assert trigger.cursor.offset == initial_offset
 
 
 def test_fetch_events_with_pagination_2(trigger, message1, message2):
@@ -299,10 +301,44 @@ def test_fetch_events_with_pagination_2(trigger, message1, message2):
         for event in first_response + second_response:
             trigger.events_cache[event["uuid"]] = True
 
+        initial_offset = trigger.cursor.offset
         events = list(trigger.fetch_events())
 
         assert events == [[result_message_1], [result_message_2]]
-        assert trigger.cursor.offset.isoformat() == get_upper_second(expected_new_checkpoint_time).isoformat()
+        assert trigger.cursor.offset == initial_offset
+
+
+def test_next_batch_updates_checkpoint_after_push(trigger, message1, message2):
+    now = datetime.now(timezone.utc)
+    recent_date = now - timedelta(seconds=20)
+    messages = [
+        {**message1, "published": recent_date.isoformat()},
+        {**message2, "published": recent_date.isoformat()},
+    ]
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get("https://tenant_id.okta.com/api/v1/logs", status_code=200, json=messages)
+        trigger.next_batch()
+
+        assert trigger.push_events_to_intakes.call_count == 1
+        assert trigger.cursor.offset.isoformat() == get_upper_second(recent_date).isoformat()
+
+
+def test_next_batch_does_not_update_checkpoint_if_push_fails(trigger, message1):
+    now = datetime.now(timezone.utc)
+    recent_date = now - timedelta(seconds=20)
+    message = {**message1, "published": recent_date.isoformat()}
+    initial_offset = trigger.cursor.offset
+
+    trigger.push_events_to_intakes = MagicMock(side_effect=RuntimeError("push failed"))
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get("https://tenant_id.okta.com/api/v1/logs", status_code=200, json=[message])
+
+        with pytest.raises(RuntimeError, match="push failed"):
+            trigger.next_batch()
+
+        assert trigger.cursor.offset == initial_offset
 
 
 def test_next_batch_sleep_until_next_round(trigger, message1, message2):
@@ -388,3 +424,36 @@ def test_handle_response_error(data_storage):
         trigger._handle_response_error(response)
 
     assert str(m.value) == "Request on Okta API to fetch events failed with status 500 - Internal Error"
+
+
+def test_high_volume_events_does_not_lose_deduplication(trigger, message1, message2):
+    """Test that cache size is set to the connector default."""
+    assert trigger.cache_size == 2000, f"Cache size should be 2000, got {trigger.cache_size}"
+
+
+def test_checksum_deduplication_without_uuid(trigger, message1, message2):
+    """Test that compute_event_checksum function exists and works."""
+    # Import and verify the function exists
+    from okta_modules.system_log_trigger import compute_event_checksum
+
+    # Verify checksum is computed consistently
+    checksum1 = compute_event_checksum(message1)
+    checksum2 = compute_event_checksum(message1)
+
+    assert checksum1 == checksum2, "Checksum should be deterministic"
+    assert isinstance(checksum1, str), "Checksum should be a string"
+    assert len(checksum1) <= 16, "Checksum should be reasonably short"
+
+
+def test_timestamp_boundary_deduplication(trigger, message1, message2):
+    """Test that cache persists and survives across next_batch calls."""
+    # Verify cache persistence mechanism works
+    test_uuid = str(uuid.uuid4())
+    trigger.events_cache[test_uuid] = True
+    trigger.save_events_cache()
+
+    # Create a fresh cache from stored context
+    fresh_cache = trigger.load_events_cache()
+
+    assert test_uuid in fresh_cache, "Cache should persist after save/load"
+    assert len(fresh_cache) > 0, "Loaded cache should not be empty"

--- a/Okta/tests/test_system_log_trigger.py
+++ b/Okta/tests/test_system_log_trigger.py
@@ -11,7 +11,7 @@ from requests import Response
 
 from okta_modules import OktaModule
 from okta_modules.helpers import get_upper_second
-from okta_modules.system_log_trigger import FetchEventsException, SystemLogConnector
+from okta_modules.system_log_trigger import FetchEventsException, SystemLogConnector, compute_event_checksum
 
 
 @pytest.fixture
@@ -457,3 +457,103 @@ def test_events_cache_persists_across_save_and_load(trigger):
 
     assert test_uuid in fresh_cache, "Cache should persist after save/load"
     assert len(fresh_cache) > 0, "Loaded cache should not be empty"
+
+
+def test_compute_event_checksum_with_target_dict(message1):
+    event = {**message1, "target": {"id": "target-dict-id"}}
+
+    checksum = compute_event_checksum(event)
+
+    assert isinstance(checksum, str)
+    assert len(checksum) == 64
+
+
+def test_exit_sets_stop_event_and_logs(trigger):
+    trigger.exit(None, None)
+
+    trigger.log.assert_called_once_with(message="Stopping OKTA system logs connector", level="info")
+    assert trigger._stop_event.is_set()
+
+
+def test_handle_response_error_with_api_details(data_storage):
+    module = OktaModule()
+    trigger = SystemLogConnector(module=module, data_path=data_storage)
+    response = Response()
+    response.status_code = 400
+    response.reason = "Bad Request"
+    response._content = b'{"errorCode":"E0000001","errorSummary":"Api validation failed"}'
+    response.headers["Content-Type"] = "application/json"
+
+    with pytest.raises(FetchEventsException) as exc_info:
+        trigger._handle_response_error(response)
+
+    assert "E0000001" in str(exc_info.value)
+    assert "Api validation failed" in str(exc_info.value)
+
+
+def test_fetch_events_with_filter_and_q_params(trigger, message1):
+    trigger.configuration = {
+        "intake_key": "intake_key",
+        "filter": 'eventType eq "user.session.start"',
+        "q": "mfa",
+    }
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get("https://tenant_id.okta.com/api/v1/logs", status_code=200, json=[message1])
+
+        events = list(trigger.fetch_events())
+
+        assert events == [[message1]]
+        assert len(mock_requests.request_history) == 1
+        request = mock_requests.request_history[0]
+        assert request.qs["filter"][0].lower() == 'eventtype eq "user.session.start"'
+        assert request.qs["q"][0] == "mfa"
+
+
+def test_fetch_events_empty_page_sleeps_when_all_events_filtered(trigger, message1):
+    trigger.events_cache[message1["uuid"]] = True
+
+    with patch("okta_modules.system_log_trigger.time.sleep") as mock_sleep, requests_mock.Mocker() as mock_requests:
+        mock_requests.get("https://tenant_id.okta.com/api/v1/logs", status_code=200, json=[message1])
+
+        assert list(trigger.fetch_events()) == []
+        mock_sleep.assert_called_once_with(trigger.configuration.frequency)
+
+
+def test_compute_batch_checkpoint_returns_none_when_missing_published(trigger):
+    assert trigger._compute_batch_checkpoint([{"uuid": "without-published"}]) is None
+
+
+def test_next_batch_caches_checksum_for_events_without_uuid(trigger, message1):
+    event_without_uuid = {**message1, "uuid": None}
+    checksum = compute_event_checksum(event_without_uuid)
+
+    with requests_mock.Mocker() as mock_requests:
+        mock_requests.get("https://tenant_id.okta.com/api/v1/logs", status_code=200, json=[event_without_uuid])
+        trigger.next_batch()
+
+    assert checksum in trigger.events_cache
+
+
+def test_next_batch_logs_no_events_when_empty_batch(trigger):
+    trigger.fetch_events = MagicMock(return_value=iter([[]]))
+
+    with patch("okta_modules.system_log_trigger.time.sleep"):
+        trigger.next_batch()
+
+    trigger.log.assert_any_call(message="No events to forward", level="info")
+
+
+def test_run_logs_exception_and_continues(trigger):
+    def failing_then_stop() -> None:
+        if not hasattr(failing_then_stop, "called"):
+            failing_then_stop.called = True  # type: ignore[attr-defined]
+            raise RuntimeError("boom")
+
+        trigger._stop_event.set()
+
+    trigger.next_batch = MagicMock(side_effect=failing_then_stop)
+
+    trigger.run()
+
+    trigger.log_exception.assert_called_once()

--- a/Okta/tests/test_system_log_trigger.py
+++ b/Okta/tests/test_system_log_trigger.py
@@ -339,6 +339,7 @@ def test_next_batch_does_not_update_checkpoint_if_push_fails(trigger, message1):
             trigger.next_batch()
 
         assert trigger.cursor.offset == initial_offset
+        assert message["uuid"] not in trigger.events_cache
 
 
 def test_next_batch_sleep_until_next_round(trigger, message1, message2):
@@ -426,19 +427,18 @@ def test_handle_response_error(data_storage):
     assert str(m.value) == "Request on Okta API to fetch events failed with status 500 - Internal Error"
 
 
-def test_high_volume_events_does_not_lose_deduplication(trigger, message1, message2):
+def test_default_cache_size_is_2000(trigger):
     """Test that cache size is set to the connector default."""
     assert trigger.cache_size == 2000, f"Cache size should be 2000, got {trigger.cache_size}"
 
 
-def test_checksum_deduplication_without_uuid(trigger, message1, message2):
-    """Test that compute_event_checksum function exists and works."""
-    # Import and verify the function exists
-    from okta_modules.system_log_trigger import compute_event_checksum
+def test_checksum_deduplication_without_uuid(trigger, message1):
+    """Test that compute_event_checksum works for events without UUID."""
+    event_without_uuid = {**message1, "uuid": None}
 
     # Verify checksum is computed consistently
-    checksum1 = compute_event_checksum(message1)
-    checksum2 = compute_event_checksum(message1)
+    checksum1 = compute_event_checksum(event_without_uuid)
+    checksum2 = compute_event_checksum(event_without_uuid)
 
     assert checksum1 == checksum2, "Checksum should be deterministic"
     assert isinstance(checksum1, str), "Checksum should be a string"

--- a/Okta/tests/test_system_log_trigger.py
+++ b/Okta/tests/test_system_log_trigger.py
@@ -442,10 +442,10 @@ def test_checksum_deduplication_without_uuid(trigger, message1, message2):
 
     assert checksum1 == checksum2, "Checksum should be deterministic"
     assert isinstance(checksum1, str), "Checksum should be a string"
-    assert len(checksum1) <= 16, "Checksum should be reasonably short"
+    assert len(checksum1) == 64, "Checksum should be a full SHA-256 hex digest"
 
 
-def test_timestamp_boundary_deduplication(trigger, message1, message2):
+def test_events_cache_persists_across_save_and_load(trigger):
     """Test that cache persists and survives across next_batch calls."""
     # Verify cache persistence mechanism works
     test_uuid = str(uuid.uuid4())


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1683

## Summary by Sourcery

Improve Okta System Log connector deduplication and checkpoint handling to avoid event re-ingestion across restarts while keeping at-least-once delivery.

Bug Fixes:
- Prevent re-ingestion of previously processed Okta System Log events after connector restarts by persisting and consulting a robust deduplication cache.
- Ensure checkpoints are only advanced after successful event push so failed pushes do not skip or lose events.

Enhancements:
- Introduce checksum-based deduplication as a fallback for Okta System Log events without stable UUIDs, using key event attributes.
- Persist and reuse both event UUIDs and content checksums in the events cache to make deduplication resilient across restarts.
- Refine checkpoint computation into dedicated helpers for clarity and more predictable offset handling.

Tests:
- Extend System Log connector tests to cover checkpoint updates on success/failure, checksum-based deduplication behavior, cache persistence across batches, and cache sizing.