### PR TITLE
fix(EntraID): account validator checks

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-16 - 2.10.23
+
+### Fixed
+
+- Fix Account validator to check all permissions needed for the asset connector
+
 ## 2026-05-21 - 2.10.22
 
 ### Fixed

--- a/MicrosoftEntraID/azure_ad/account_validator.py
+++ b/MicrosoftEntraID/azure_ad/account_validator.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.users.users_request_builder import UsersRequestBuilder
 from sekoia_automation.account_validator import AccountValidator
 
 from azure_ad.base import AzureADModule
@@ -21,11 +23,65 @@ class AzureADAccountValidator(AccountValidator):
 
         return self._client
 
+    async def _check_list_users(self) -> str | None:
+        query_params = UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
+            select=["id", "signInActivity"],
+            top=1,
+        )
+        config = RequestConfiguration(query_parameters=query_params)
+        users = await self.client.client.users.get(request_configuration=config)
+        if users and users.value:
+            return users.value[0].id
+        return None
+
+    async def _check_user_member_of(self, user_id: str) -> None:
+        await self.client.client.users.by_user_id(user_id).member_of.get()
+
+    async def _check_user_admin_roles(self, user_id: str) -> None:
+        await self.client.client.users.by_user_id(user_id).transitive_member_of.graph_directory_role.get()
+
+    async def _check_user_auth_methods(self, user_id: str) -> None:
+        await self.client.client.users.by_user_id(user_id).authentication.methods.get()
+
+    async def _run_all_checks(self) -> bool:
+        try:
+            user_id = await self._check_list_users()
+        except Exception as e:
+            self.error(
+                f"Permission check failed — List users with signInActivity "
+                f"(User.Read.All + AuditLog.Read.All): {e}"
+            )
+            return False
+
+        if not user_id:
+            return True
+
+        per_user_checks = [
+            ("List user group memberships (Directory.Read.All)", self._check_user_member_of(user_id)),
+            ("List user admin roles (Directory.Read.All)", self._check_user_admin_roles(user_id)),
+            (
+                "List user authentication methods (UserAuthenticationMethod.Read.All)",
+                self._check_user_auth_methods(user_id),
+            ),
+        ]
+
+        labels = [label for label, _ in per_user_checks]
+        coroutines = [coro for _, coro in per_user_checks]
+
+        results = await asyncio.gather(*coroutines, return_exceptions=True)
+
+        all_passed = True
+        for label, result in zip(labels, results):
+            if isinstance(result, Exception):
+                self.error(f"Permission check failed — {label}: {result}")
+                all_passed = False
+
+        return all_passed
+
     def validate(self) -> bool:
         try:
             loop = asyncio.get_event_loop()
-            loop.run_until_complete(self.client.client.users.get())
+            return loop.run_until_complete(self._run_all_checks())
         except Exception as e:
             self.error(f"Impossible to connect to the Azure AD tenant: {e}")
             return False
-        return True

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.10.22",
+  "version": "2.10.23",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftEntraID/tests/test_account_validator.py
+++ b/MicrosoftEntraID/tests/test_account_validator.py
@@ -36,11 +36,6 @@ def test_configuration(test_azure_ad_account_validator):
     assert test_azure_ad_account_validator.module.configuration["client_secret"] == "fake_client_secret"
 
 
-# ---------------------------------------------------------------------------
-# validate() — integration with the event loop
-# ---------------------------------------------------------------------------
-
-
 @patch("azure_ad.account_validator.asyncio.get_event_loop")
 def test_validate_all_checks_pass(mock_get_event_loop, test_azure_ad_account_validator):
     """validate() returns True when _run_all_checks succeeds."""
@@ -68,11 +63,6 @@ def test_validate_fatal_connection_error(mock_get_event_loop, test_azure_ad_acco
     test_azure_ad_account_validator.error.assert_called_once_with(
         "Impossible to connect to the Azure AD tenant: Connection failed"
     )
-
-
-# ---------------------------------------------------------------------------
-# _run_all_checks() — step 1: list users with signInActivity
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -117,11 +107,6 @@ async def test_run_all_checks_no_users_in_tenant(test_azure_ad_account_validator
     test_azure_ad_account_validator._check_user_member_of.assert_not_called()
     test_azure_ad_account_validator._check_user_admin_roles.assert_not_called()
     test_azure_ad_account_validator._check_user_auth_methods.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# _run_all_checks() — step 2: per-user permission checks
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/MicrosoftEntraID/tests/test_account_validator.py
+++ b/MicrosoftEntraID/tests/test_account_validator.py
@@ -22,6 +22,13 @@ def test_azure_ad_account_validator(symphony_storage):
     yield validator
 
 
+def _mock_per_user_checks_ok(validator: AzureADAccountValidator) -> None:
+    """Patch all per-user check methods to succeed."""
+    validator._check_user_member_of = AsyncMock()
+    validator._check_user_admin_roles = AsyncMock()
+    validator._check_user_auth_methods = AsyncMock()
+
+
 def test_configuration(test_azure_ad_account_validator):
     """Test that the validator has the correct configuration."""
     assert test_azure_ad_account_validator.module.configuration["tenant_id"] == "fake_tenant_id"
@@ -29,140 +36,166 @@ def test_configuration(test_azure_ad_account_validator):
     assert test_azure_ad_account_validator.module.configuration["client_secret"] == "fake_client_secret"
 
 
+# ---------------------------------------------------------------------------
+# validate() — integration with the event loop
+# ---------------------------------------------------------------------------
+
+
 @patch("azure_ad.account_validator.asyncio.get_event_loop")
-def test_validate_success(mock_get_event_loop, test_azure_ad_account_validator):
-    """Test that validate returns True when the API call succeeds."""
-    # Arrange
+def test_validate_all_checks_pass(mock_get_event_loop, test_azure_ad_account_validator):
+    """validate() returns True when _run_all_checks succeeds."""
     mock_loop = Mock()
     mock_get_event_loop.return_value = mock_loop
+    mock_loop.run_until_complete.return_value = True
 
-    # Mock the GraphApi client and its client property
-    mock_graph_api = Mock()
-    mock_graph_service_client = Mock()
-    mock_users = Mock()
-    mock_users.get = AsyncMock()
-    mock_graph_service_client.users = mock_users
-    mock_graph_api.client = mock_graph_service_client
-    test_azure_ad_account_validator._client = mock_graph_api
-
-    # Act
     result = test_azure_ad_account_validator.validate()
 
-    # Assert
     assert result is True
     mock_loop.run_until_complete.assert_called_once()
     test_azure_ad_account_validator.error.assert_not_called()
 
 
 @patch("azure_ad.account_validator.asyncio.get_event_loop")
-def test_validate_failure_connection_error(mock_get_event_loop, test_azure_ad_account_validator):
-    """Test that validate returns False when there's a connection error."""
-    # Arrange
+def test_validate_fatal_connection_error(mock_get_event_loop, test_azure_ad_account_validator):
+    """validate() returns False and logs an error when the event loop raises."""
     mock_loop = Mock()
     mock_get_event_loop.return_value = mock_loop
-
-    # Mock the GraphApi client and its client property
-    mock_graph_api = Mock()
-    mock_graph_service_client = Mock()
-    mock_users = Mock()
-    mock_users.get = AsyncMock(side_effect=Exception("Connection failed"))
-    mock_graph_service_client.users = mock_users
-    mock_graph_api.client = mock_graph_service_client
-    test_azure_ad_account_validator._client = mock_graph_api
-
-    # Configure run_until_complete to raise the exception
     mock_loop.run_until_complete.side_effect = Exception("Connection failed")
 
-    # Act
     result = test_azure_ad_account_validator.validate()
 
-    # Assert
     assert result is False
     test_azure_ad_account_validator.error.assert_called_once_with(
         "Impossible to connect to the Azure AD tenant: Connection failed"
     )
 
 
-@patch("azure_ad.account_validator.asyncio.get_event_loop")
-def test_validate_failure_authentication_error(mock_get_event_loop, test_azure_ad_account_validator):
-    """Test that validate returns False when there's an authentication error."""
-    # Arrange
-    mock_loop = Mock()
-    mock_get_event_loop.return_value = mock_loop
-
-    # Mock the GraphApi client and its client property
-    mock_graph_api = Mock()
-    mock_graph_service_client = Mock()
-    mock_users = Mock()
-    mock_users.get = AsyncMock(side_effect=Exception("Invalid credentials"))
-    mock_graph_service_client.users = mock_users
-    mock_graph_api.client = mock_graph_service_client
-    test_azure_ad_account_validator._client = mock_graph_api
-
-    # Configure run_until_complete to raise the exception
-    mock_loop.run_until_complete.side_effect = Exception("Invalid credentials")
-
-    # Act
-    result = test_azure_ad_account_validator.validate()
-
-    # Assert
-    assert result is False
-    test_azure_ad_account_validator.error.assert_called_once_with(
-        "Impossible to connect to the Azure AD tenant: Invalid credentials"
-    )
+# ---------------------------------------------------------------------------
+# _run_all_checks() — step 1: list users with signInActivity
+# ---------------------------------------------------------------------------
 
 
-@patch("azure_ad.account_validator.asyncio.get_event_loop")
-def test_validate_failure_network_error(mock_get_event_loop, test_azure_ad_account_validator):
-    """Test that validate returns False when there's a network error."""
-    # Arrange
-    mock_loop = Mock()
-    mock_get_event_loop.return_value = mock_loop
+@pytest.mark.asyncio
+async def test_run_all_checks_all_pass(test_azure_ad_account_validator):
+    """Returns True when listing users succeeds and all per-user checks pass."""
+    test_azure_ad_account_validator._check_list_users = AsyncMock(return_value="user-id-1")
+    _mock_per_user_checks_ok(test_azure_ad_account_validator)
 
-    # Mock the GraphApi client and its client property
-    mock_graph_api = Mock()
-    mock_graph_service_client = Mock()
-    mock_users = Mock()
-    mock_users.get = AsyncMock(side_effect=Exception("Network timeout"))
-    mock_graph_service_client.users = mock_users
-    mock_graph_api.client = mock_graph_service_client
-    test_azure_ad_account_validator._client = mock_graph_api
+    result = await test_azure_ad_account_validator._run_all_checks()
 
-    # Configure run_until_complete to raise the exception
-    mock_loop.run_until_complete.side_effect = Exception("Network timeout")
-
-    # Act
-    result = test_azure_ad_account_validator.validate()
-
-    # Assert
-    assert result is False
-    test_azure_ad_account_validator.error.assert_called_once_with(
-        "Impossible to connect to the Azure AD tenant: Network timeout"
-    )
-
-
-@patch("azure_ad.account_validator.asyncio.get_event_loop")
-def test_validate_uses_cached_client(mock_get_event_loop, test_azure_ad_account_validator):
-    """Test that validate uses the cached client property."""
-    # Arrange
-    mock_loop = Mock()
-    mock_get_event_loop.return_value = mock_loop
-
-    # Mock the GraphApi client and its client property
-    mock_graph_api = Mock()
-    mock_graph_service_client = Mock()
-    mock_users = Mock()
-    mock_users.get = AsyncMock()
-    mock_graph_service_client.users = mock_users
-    mock_graph_api.client = mock_graph_service_client
-
-    # Set the cached client directly
-    test_azure_ad_account_validator._client = mock_graph_api
-
-    # Act
-    result = test_azure_ad_account_validator.validate()
-
-    # Assert
     assert result is True
-    mock_users.get.assert_called_once()
     test_azure_ad_account_validator.error.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_all_checks_list_users_fails(test_azure_ad_account_validator):
+    """Returns False immediately with one error when listing users (step 1) fails."""
+    test_azure_ad_account_validator._check_list_users = AsyncMock(side_effect=Exception("Insufficient privileges"))
+    _mock_per_user_checks_ok(test_azure_ad_account_validator)
+
+    result = await test_azure_ad_account_validator._run_all_checks()
+
+    assert result is False
+    assert test_azure_ad_account_validator.error.call_count == 1
+    error_msg = test_azure_ad_account_validator.error.call_args[0][0]
+    assert "User.Read.All" in error_msg
+    assert "AuditLog.Read.All" in error_msg
+    assert "Insufficient privileges" in error_msg
+
+
+@pytest.mark.asyncio
+async def test_run_all_checks_no_users_in_tenant(test_azure_ad_account_validator):
+    """Returns True without running per-user checks when the tenant has no users."""
+    test_azure_ad_account_validator._check_list_users = AsyncMock(return_value=None)
+    _mock_per_user_checks_ok(test_azure_ad_account_validator)
+
+    result = await test_azure_ad_account_validator._run_all_checks()
+
+    assert result is True
+    test_azure_ad_account_validator.error.assert_not_called()
+    # Per-user checks must NOT be called when there is no user ID
+    test_azure_ad_account_validator._check_user_member_of.assert_not_called()
+    test_azure_ad_account_validator._check_user_admin_roles.assert_not_called()
+    test_azure_ad_account_validator._check_user_auth_methods.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _run_all_checks() — step 2: per-user permission checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_all_checks_member_of_fails(test_azure_ad_account_validator):
+    """Returns False and logs an error when the memberOf check fails."""
+    test_azure_ad_account_validator._check_list_users = AsyncMock(return_value="user-id-1")
+    _mock_per_user_checks_ok(test_azure_ad_account_validator)
+    test_azure_ad_account_validator._check_user_member_of = AsyncMock(side_effect=Exception("Access denied"))
+
+    result = await test_azure_ad_account_validator._run_all_checks()
+
+    assert result is False
+    assert test_azure_ad_account_validator.error.call_count == 1
+    error_msg = test_azure_ad_account_validator.error.call_args[0][0]
+    assert "Directory.Read.All" in error_msg
+    assert "Access denied" in error_msg
+
+
+@pytest.mark.asyncio
+async def test_run_all_checks_admin_roles_fails(test_azure_ad_account_validator):
+    """Returns False and logs an error when the admin roles check fails."""
+    test_azure_ad_account_validator._check_list_users = AsyncMock(return_value="user-id-1")
+    _mock_per_user_checks_ok(test_azure_ad_account_validator)
+    test_azure_ad_account_validator._check_user_admin_roles = AsyncMock(side_effect=Exception("Forbidden"))
+
+    result = await test_azure_ad_account_validator._run_all_checks()
+
+    assert result is False
+    assert test_azure_ad_account_validator.error.call_count == 1
+    error_msg = test_azure_ad_account_validator.error.call_args[0][0]
+    assert "Directory.Read.All" in error_msg
+    assert "Forbidden" in error_msg
+
+
+@pytest.mark.asyncio
+async def test_run_all_checks_auth_methods_fails(test_azure_ad_account_validator):
+    """Returns False and logs an error when the auth methods check fails."""
+    test_azure_ad_account_validator._check_list_users = AsyncMock(return_value="user-id-1")
+    _mock_per_user_checks_ok(test_azure_ad_account_validator)
+    test_azure_ad_account_validator._check_user_auth_methods = AsyncMock(
+        side_effect=Exception("UserAuthenticationMethod.Read.All missing")
+    )
+
+    result = await test_azure_ad_account_validator._run_all_checks()
+
+    assert result is False
+    assert test_azure_ad_account_validator.error.call_count == 1
+    error_msg = test_azure_ad_account_validator.error.call_args[0][0]
+    assert "UserAuthenticationMethod.Read.All" in error_msg
+
+
+@pytest.mark.asyncio
+async def test_run_all_checks_all_per_user_fail(test_azure_ad_account_validator):
+    """Returns False and logs one error per failing per-user check."""
+    test_azure_ad_account_validator._check_list_users = AsyncMock(return_value="user-id-1")
+    error = Exception("Unauthorized")
+    test_azure_ad_account_validator._check_user_member_of = AsyncMock(side_effect=error)
+    test_azure_ad_account_validator._check_user_admin_roles = AsyncMock(side_effect=error)
+    test_azure_ad_account_validator._check_user_auth_methods = AsyncMock(side_effect=error)
+
+    result = await test_azure_ad_account_validator._run_all_checks()
+
+    assert result is False
+    assert test_azure_ad_account_validator.error.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_run_all_checks_per_user_checks_use_returned_user_id(test_azure_ad_account_validator):
+    """Per-user checks are called with the user ID returned by _check_list_users."""
+    test_azure_ad_account_validator._check_list_users = AsyncMock(return_value="specific-user-id")
+    _mock_per_user_checks_ok(test_azure_ad_account_validator)
+
+    await test_azure_ad_account_validator._run_all_checks()
+
+    test_azure_ad_account_validator._check_user_member_of.assert_called_once_with("specific-user-id")
+    test_azure_ad_account_validator._check_user_admin_roles.assert_called_once_with("specific-user-id")
+    test_azure_ad_account_validator._check_user_auth_methods.assert_called_once_with("specific-user-id")


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/integration/issues/1615)

## Summary by Sourcery

Update the Microsoft Entra ID account validator to perform explicit permission checks via Graph API and tighten validation behavior.

Bug Fixes:
- Ensure the account validator verifies all required Microsoft Graph permissions, including listing users, group memberships, admin roles, and authentication methods, and correctly reports missing permissions.

Enhancements:
- Refactor validation logic into dedicated async helper methods and a consolidated _run_all_checks workflow that coordinates user listing and per-user permission checks.

Documentation:
- Add a changelog entry documenting the updated account validator behavior and version bump.

Tests:
- Replace previous validator tests with comprehensive coverage for _run_all_checks and validate(), including success, no-user, and multiple failure scenarios.

Chores:
- Bump the Microsoft Entra ID integration version in the manifest to 2.10.23.