### PR TITLE
fix(okta): Fix the deplucation of events

### DIFF
--- a/Okta/CHANGELOG.md
+++ b/Okta/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-16 - 2.10.4
+
+### Fixed
+
+- Fix duplicated events in the system logs connector: the dedup cache and the checkpoint were sharing the same `context.json` file and overwriting each other on disk, causing one of them to be lost on restart. The dedup cache is now stored in a dedicated `events_cache.json` file (with backward-compatible migration from `context.json`).
+
 ## 2026-04-24 - 2.10.3
 
 ### Fixed
 
 - Fix account validator to detect authentication failures.
+
 ## 2026-04-21 - 2.10.2
 
 ### Changed

--- a/Okta/manifest.json
+++ b/Okta/manifest.json
@@ -26,7 +26,7 @@
   "name": "Okta",
   "uuid": "4ef895d1-3f21-4678-8d0a-5c39c37210fe",
   "slug": "okta",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "categories": [
     "IAM"
   ],

--- a/Okta/okta_modules/system_log_trigger.py
+++ b/Okta/okta_modules/system_log_trigger.py
@@ -46,7 +46,7 @@ class SystemLogConnector(Connector):
     def __init__(self, *args: Any, **kwargs: Optional[Any]) -> None:
         super().__init__(*args, **kwargs)
         self._stop_event = Event()
-        self.context = PersistentJSON("context.json", self._data_path)
+        self.context = PersistentJSON("events_cache.json", self._data_path)
         self.fetch_events_limit = 1000
 
         self.cursor = CheckpointDatetime(
@@ -72,6 +72,10 @@ class SystemLogConnector(Connector):
         with self.context as context:
             # load the cache from the context
             events_cache = context.get("events_cache", [])
+
+        if not events_cache:
+            with PersistentJSON("context.json", self._data_path) as legacy_context:
+                events_cache = legacy_context.get("events_cache", [])
 
         for uuid in events_cache:
             cache[uuid] = True

--- a/Okta/tests/test_system_log_trigger.py
+++ b/Okta/tests/test_system_log_trigger.py
@@ -378,6 +378,30 @@ def test_run_integration(data_storage):
         assert len(calls) > 0
 
 
+def test_cache_and_checkpoint_survive_restart(data_storage, patch_datetime_now, message1):
+    module = OktaModule()
+    module.configuration = {"apikey": "myapikey", "base_url": "https://tenant_id.okta.com"}
+
+    first = SystemLogConnector(module=module, data_path=data_storage)
+    first.configuration = {"intake_key": "intake_key"}
+
+    # persist a checkpoint
+    checkpoint = (datetime.now(timezone.utc) - timedelta(seconds=30)).replace(microsecond=0)
+    first.cursor.offset = checkpoint
+
+    # persist the events cache
+    first.events_cache[message1["uuid"]] = True
+    first.save_events_cache()
+
+    # simulate a restart: brand new instances reading from the same data path
+    second = SystemLogConnector(module=module, data_path=data_storage)
+    second.configuration = {"intake_key": "intake_key"}
+
+    # both the checkpoint and the cache must have survived
+    assert second.cursor.offset == checkpoint
+    assert message1["uuid"] in second.events_cache
+
+
 def test_handle_response_error(data_storage):
     module = OktaModule()
     trigger = SystemLogConnector(module=module, data_path=data_storage)


### PR DESCRIPTION
Main issue : [Issue](https://github.com/SekoiaLab/integration/issues/1683)

## Summary by Sourcery

Prevent duplicated Okta system log events by separating the events deduplication cache from the checkpoint state and ensuring both persist across connector restarts.

Bug Fixes:
- Store the system log events deduplication cache in its own persistent file so it no longer overwrites the checkpoint state on disk.
- Add backward-compatible loading of the events cache from the legacy context file to preserve existing deployments.

Documentation:
- Update the Okta changelog with a 2.10.4 release entry describing the system log deduplication fix.

Tests:
- Add a regression test to verify that both the checkpoint and events cache survive connector restarts using the shared data path.

Chores:
- Bump the Okta integration version from 2.10.3 to 2.10.4 in the manifest.