### PR TITLE
fix(salesforce): change the run to async

### DIFF
--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -254,19 +254,20 @@ class SalesforceConnector(AsyncConnector):
 
         return result
 
-    def run(self) -> None:  # pragma: no cover
-        """Runs Salesforce connector with timestepper."""
+    async def async_run(self) -> None:  # pragma: no cover
+        """Runs Salesforce connector with timestepper asynchronously."""
         while self.running:
             try:
-                loop = asyncio.get_event_loop()
-
                 for start, end in self.stepper.ranges():
                     if not self.running:
                         break
 
+                    if self.stepper.sleep_duration > 0:
+                        await asyncio.sleep(self.stepper.sleep_duration)
+
                     processing_start = time.time()
 
-                    message_ids: list[str] = loop.run_until_complete(self.get_salesforce_events(start, end))
+                    message_ids: list[str] = await self.get_salesforce_events(start, end)
 
                     processing_end = time.time()
                     OUTCOMING_EVENTS.labels(intake_key=self.configuration.intake_key).inc(len(message_ids))
@@ -292,3 +293,14 @@ class SalesforceConnector(AsyncConnector):
             except Exception as error:
                 logger.error("Error while running Salesforce", error=error)
                 self.log_exception(error, message="Failed to forward events")
+
+        if self._session:
+            await self._session.close()
+
+        await self.on_shutdown()
+
+    def run(self) -> None:  # pragma: no cover
+        """Runs Salesforce connector."""
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.async_run())
+

--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -303,4 +303,3 @@ class SalesforceConnector(AsyncConnector):
         """Runs Salesforce connector."""
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.async_run())
-

--- a/Salesforce/salesforce/timestepper.py
+++ b/Salesforce/salesforce/timestepper.py
@@ -1,7 +1,6 @@
 """Timestepper for orchestrating event collection with configurable time windows."""
 
 import datetime
-import time
 from collections.abc import Generator
 
 from sekoia_automation.aio.connector import AsyncConnector
@@ -48,15 +47,12 @@ class TimeStepper:
         Yield time windows for event collection.
 
         Continuously yields (start, end) tuples, setting sleep_duration when approaching real-time.
-        The connector is responsible for sleeping based on sleep_duration.
+        The connector is responsible for sleeping (asynchronously) based on sleep_duration.
 
         Yields:
             Tuple of (start, end) datetimes for each time window
         """
         while True:
-            # Sleep if the stepper indicates we need to wait
-            if self.sleep_duration > 0:
-                time.sleep(self.sleep_duration)
 
             # Return the current time range
             yield self.start, self.end

--- a/Salesforce/tests/salesforce/test_connector.py
+++ b/Salesforce/tests/salesforce/test_connector.py
@@ -768,4 +768,3 @@ async def test_salesforce_connector_async_run_handles_generic_error(connector):
     connector.log_exception.assert_called_once()
     _, kwargs = connector.log_exception.call_args
     assert kwargs.get("message") == "Failed to forward events"
-

--- a/Salesforce/tests/salesforce/test_connector.py
+++ b/Salesforce/tests/salesforce/test_connector.py
@@ -3,13 +3,14 @@
 from datetime import datetime, timedelta, timezone
 from shutil import rmtree
 from tempfile import mkdtemp
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aioresponses import aioresponses
 from sekoia_automation import constants
 
 from client.schemas.log_file import EventLogFile, SalesforceEventLogFilesResponse
+from client.token_refresher import RefreshTokenException
 from salesforce import SalesforceModule
 from salesforce.connector import SalesforceConnector, SalesforceConnectorConfig
 from salesforce.models import SalesforceModuleConfig
@@ -624,3 +625,147 @@ async def test_salesforce_connector_skips_processed_log_files(
 
         # Should return empty list since log file was skipped
         assert result == []
+
+
+def _make_window(offset_minutes: int = 0):
+    """Helper to build a (start, end) time window."""
+    start = datetime.now(timezone.utc) - timedelta(minutes=20 - offset_minutes)
+    end = start + timedelta(minutes=10)
+    return start, end
+
+
+@pytest.mark.asyncio
+async def test_salesforce_connector_async_run_processes_windows(connector, pushed_events_ids):
+    """
+    Test that async_run iterates over the stepper windows asynchronously and saves progress.
+
+    Args:
+        connector: SalesforceConnector
+        pushed_events_ids: list[str]
+    """
+    window_1 = _make_window(0)
+    window_2 = _make_window(10)
+
+    # Replace the stepper with a controlled mock yielding two windows
+    mock_stepper = MagicMock()
+    mock_stepper.sleep_duration = 0
+    mock_stepper.ranges.return_value = iter([window_1, window_2])
+    connector._stepper = mock_stepper
+
+    processed_windows = []
+
+    async def fake_get_events(start, end):
+        processed_windows.append((start, end))
+        # Stop the connector once both windows are processed
+        if len(processed_windows) >= 2:
+            connector._stop_event.set()
+
+        return pushed_events_ids
+
+    connector.get_salesforce_events = AsyncMock(side_effect=fake_get_events)
+    connector.update_stepper = MagicMock()
+    connector._save_log_file_cache = MagicMock()
+
+    await connector.async_run()
+
+    # Both windows have been processed in order
+    assert processed_windows == [window_1, window_2]
+    assert connector.get_salesforce_events.await_count == 2
+
+    # Progress is saved after each window
+    assert connector.update_stepper.call_count == 2
+    connector.update_stepper.assert_any_call(window_1[1])
+    connector.update_stepper.assert_any_call(window_2[1])
+    assert connector._save_log_file_cache.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_salesforce_connector_async_run_waits_when_caught_up(connector, pushed_events_ids):
+    """
+    Test that async_run awaits asyncio.sleep (non-blocking) when the stepper indicates a wait.
+
+    Args:
+        connector: SalesforceConnector
+        pushed_events_ids: list[str]
+    """
+    window = _make_window(0)
+
+    mock_stepper = MagicMock()
+    mock_stepper.sleep_duration = 5
+    mock_stepper.ranges.return_value = iter([window])
+    connector._stepper = mock_stepper
+
+    async def fake_get_events(start, end):
+        connector._stop_event.set()
+
+        return pushed_events_ids
+
+    connector.get_salesforce_events = AsyncMock(side_effect=fake_get_events)
+    connector.update_stepper = MagicMock()
+    connector._save_log_file_cache = MagicMock()
+
+    with patch("salesforce.connector.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await connector.async_run()
+
+    # The wait is delegated to asyncio.sleep (non-blocking) with the stepper duration
+    mock_sleep.assert_awaited_once_with(5)
+
+
+@pytest.mark.asyncio
+async def test_salesforce_connector_async_run_handles_refresh_token_error(connector):
+    """
+    Test that async_run handles RefreshTokenException with a critical log.
+
+    Args:
+        connector: SalesforceConnector
+    """
+    window = _make_window(0)
+
+    mock_stepper = MagicMock()
+    mock_stepper.sleep_duration = 0
+    mock_stepper.ranges.return_value = iter([window])
+    connector._stepper = mock_stepper
+
+    async def fake_get_events(start, end):
+        connector._stop_event.set()
+
+        raise RefreshTokenException("invalid credentials")
+
+    connector.get_salesforce_events = AsyncMock(side_effect=fake_get_events)
+
+    await connector.async_run()
+
+    connector.log.assert_any_call(
+        message="Using refresh token failed. Please check the credentials",
+        level="critical",
+    )
+
+
+@pytest.mark.asyncio
+async def test_salesforce_connector_async_run_handles_generic_error(connector):
+    """
+    Test that async_run handles unexpected exceptions via log_exception.
+
+    Args:
+        connector: SalesforceConnector
+    """
+    window = _make_window(0)
+
+    mock_stepper = MagicMock()
+    mock_stepper.sleep_duration = 0
+    mock_stepper.ranges.return_value = iter([window])
+    connector._stepper = mock_stepper
+
+    async def fake_get_events(start, end):
+        connector._stop_event.set()
+
+        raise ValueError("boom")
+
+    connector.get_salesforce_events = AsyncMock(side_effect=fake_get_events)
+
+    await connector.async_run()
+
+    connector.log_exception.assert_called_once()
+    _, kwargs = connector.log_exception.call_args
+    assert kwargs.get("message") == "Failed to forward events"
+

--- a/Salesforce/tests/salesforce/test_timestepper.py
+++ b/Salesforce/tests/salesforce/test_timestepper.py
@@ -1,6 +1,7 @@
 """Tests for the TimeStepper class."""
 
 import datetime
+import time
 from datetime import timezone
 from unittest.mock import MagicMock
 
@@ -123,3 +124,34 @@ def test_timestepper_sleep_duration(mock_connector):
 
     # sleep_duration should be set since we're approaching real-time
     assert stepper.sleep_duration > 0
+
+
+def test_timestepper_ranges_does_not_block(mock_connector):
+    """
+    Test that ranges() never sleeps itself.
+
+    Waiting is now the connector's responsibility (done asynchronously via
+    asyncio.sleep), so even a large sleep_duration must not block the generator.
+    """
+    start = datetime.datetime.now(timezone.utc) - datetime.timedelta(hours=2)
+    end = start + datetime.timedelta(minutes=10)
+
+    stepper = TimeStepper(
+        mock_connector,
+        start,
+        end,
+        datetime.timedelta(minutes=10),
+        datetime.timedelta(minutes=15),
+    )
+
+    # A large value that would block for an hour if the generator slept internally
+    stepper.sleep_duration = 3600
+
+    started = time.monotonic()
+    ranges_gen = stepper.ranges()
+    next(ranges_gen)
+    elapsed = time.monotonic() - started
+
+    # The generator returns immediately instead of sleeping
+    assert elapsed < 1
+

--- a/Salesforce/tests/salesforce/test_timestepper.py
+++ b/Salesforce/tests/salesforce/test_timestepper.py
@@ -154,4 +154,3 @@ def test_timestepper_ranges_does_not_block(mock_connector):
 
     # The generator returns immediately instead of sleeping
     assert elapsed < 1
-


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/platform/issues/89977)

## Summary by Sourcery

Make the Salesforce connector run loop fully asynchronous and delegate waiting to the connector instead of the timestepper.

New Features:
- Introduce an async_run entry point on the Salesforce connector and wrap it with the existing synchronous run method.

Bug Fixes:
- Ensure the Salesforce connector waits asynchronously when caught up instead of blocking the event loop within the timestepper ranges generator.
- Prevent the timestepper ranges generator from sleeping internally so it no longer blocks when a large sleep_duration is configured.
- Close the HTTP session and execute shutdown hooks when the connector stops running.

Tests:
- Add async_run tests for the Salesforce connector covering window iteration, non-blocking waits, and error handling for refresh token and generic exceptions.
- Add a timestepper test verifying that ranges() does not block even when sleep_duration is large.