### PR TITLE
accept 8-digit account IDs for Cato SASE intake

### DIFF
--- a/CatoNetwork/CHANGELOG.md
+++ b/CatoNetwork/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2024-07-08 - 1.5.2
-
 ### Fixed
 
 - Accept Cato account IDs from 4 to 8 digits in module configuration

--- a/CatoNetwork/CHANGELOG.md
+++ b/CatoNetwork/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2024-07-08 - 1.5.2
+
+### Fixed
+
+- Accept Cato account IDs from 4 to 8 digits in module configuration
+
 ## 2024-07-08 - 1.5.1
 
 ### Fixed

--- a/CatoNetwork/cato/metrics.py
+++ b/CatoNetwork/cato/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Counter, Histogram, Gauge
+from prometheus_client import Counter, Gauge, Histogram
 
 # Declare common prometheus metrics
 prom_namespace = "symphony_module_common"

--- a/CatoNetwork/cato/metrics.py
+++ b/CatoNetwork/cato/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Histogram, Gauge
 
 # Declare common prometheus metrics
 prom_namespace = "symphony_module_common"

--- a/CatoNetwork/client/schemas/events_feed.py
+++ b/CatoNetwork/client/schemas/events_feed.py
@@ -10,8 +10,7 @@ from pydantic import BaseModel
 class EventsFeedQueries(Enum):
     """EventsFeedQueries."""
 
-    GET_EVENTS_FEED = gql(
-        """
+    GET_EVENTS_FEED = gql("""
             query($accountIds: [ID!], $lastEventId: String) {
                 eventsFeed(accountIDs: $accountIds, marker: $lastEventId) {
                     marker
@@ -24,8 +23,7 @@ class EventsFeedQueries(Enum):
                     }
                   }
             }
-        """
-    )
+        """)
 
 
 class EventsFeedRecordSchema(BaseModel):

--- a/CatoNetwork/manifest.json
+++ b/CatoNetwork/manifest.json
@@ -7,8 +7,8 @@
         "type": "string"
       },
       "account_id": {
-        "description": "Account Id (4 or 5 digits) to work with Cato API",
-        "pattern": "^[0-9]{4,5}$",
+        "description": "Account Id (4 to 8 digits) to work with Cato API",
+        "pattern": "^[0-9]{4,8}$",
         "type": "string"
       }
     },

--- a/CatoNetwork/tests/test_manifest.py
+++ b/CatoNetwork/tests/test_manifest.py
@@ -1,0 +1,15 @@
+"""Tests for connector manifest configuration schema."""
+
+import json
+import re
+from pathlib import Path
+
+
+def test_manifest_account_id_accepts_8_digits() -> None:
+    """Ensure the account_id schema accepts full 8-digit account identifiers."""
+    manifest_path = Path(__file__).resolve().parents[1] / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+
+    account_id_pattern = manifest["configuration"]["properties"]["account_id"]["pattern"]
+
+    assert re.match(account_id_pattern, "10001292")

--- a/CatoNetwork/tests/test_manifest.py
+++ b/CatoNetwork/tests/test_manifest.py
@@ -4,12 +4,24 @@ import json
 import re
 from pathlib import Path
 
+import pytest
 
-def test_manifest_account_id_accepts_8_digits() -> None:
-    """Ensure the account_id schema accepts full 8-digit account identifiers."""
+
+@pytest.mark.parametrize(
+    "account_id",
+    [
+        "1000",
+        "10000",
+        "100000",
+        "1000000",
+        "10001292",
+    ],
+)
+def test_manifest_account_id_accepts_valid_lengths(account_id: str) -> None:
+    """Ensure the account_id schema accepts all valid 4-8 digit account identifiers."""
     manifest_path = Path(__file__).resolve().parents[1] / "manifest.json"
-    manifest = json.loads(manifest_path.read_text())
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     account_id_pattern = manifest["configuration"]["properties"]["account_id"]["pattern"]
 
-    assert re.match(account_id_pattern, "10001292")
+    assert re.fullmatch(account_id_pattern, account_id)


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1701

## Summary by Sourcery

Extend Cato SASE connector configuration to support longer account IDs and document the change.

Bug Fixes:
- Allow Cato account IDs from 4 to 8 digits in the connector manifest configuration schema.

Documentation:
- Document the new account ID length support in the Cato connector changelog.

Tests:
- Add a manifest schema test to validate acceptance of 8-digit Cato account IDs.