### PR TITLE
fix(salesforce): bump the version

### DIFF
--- a/Salesforce/CHANGELOG.md
+++ b/Salesforce/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-05-04 - 1.8.3
+
+### Changed
+
+- Make the Salesforce connector run loop fully asynchronous
+
 ## 2026-05-04 - 1.8.2
 
 ### Changed

--- a/Salesforce/manifest.json
+++ b/Salesforce/manifest.json
@@ -39,7 +39,7 @@
   "name": "Salesforce",
   "uuid": "f811e134-2548-11ee-be56-0242ac120002",
   "slug": "salesforce",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "categories": [
     "Applicative"
   ]


### PR DESCRIPTION
Main issue: [issue](https://github.com/SekoiaLab/platform/issues/89977)

## Summary by Sourcery

Bump the Salesforce connector to version 1.8.3 and document the change.

Enhancements:
- Make the Salesforce connector run loop fully asynchronous.

Documentation:
- Add a 1.8.3 changelog entry describing the asynchronous run loop change.