### PR TITLE
fix(Sophos): naming convention

### DIFF
--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-29 - 1.19.2
+
+### Fixed
+
+- Fix naming convention of the Sophos asset connectors.
+
 ## 2026-06-29 - 1.19.1
 
 ### Fixed

--- a/Sophos/connector_sophos_device_assets.json
+++ b/Sophos/connector_sophos_device_assets.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sophos EDR Device Assets",
+  "name": "Sophos EDR Devices",
   "description": "Fetch Sophos EDR endpoint device assets from the Sophos Central API",
   "uuid": "b3f7a1c2-4e8d-4b5a-9c6f-1d2e3f4a5b6c",
   "docker_parameters": "sophos_device_asset_connector",

--- a/Sophos/connector_sophos_user_assets.json
+++ b/Sophos/connector_sophos_user_assets.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sophos User Assets",
+  "name": "Sophos EDR Users",
   "description": "Fetch Sophos directory user assets from the Sophos Central API",
   "uuid": "e2a716a2-82fd-4e1e-92ef-b07704446ee4",
   "docker_parameters": "sophos_user_asset_connector",

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,7 +38,7 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "categories": [
     "Endpoint",
     "Network"


### PR DESCRIPTION
## Summary by Sourcery

Update Sophos integration to fix asset connector naming conventions and release version 1.19.2.

Bug Fixes:
- Correct naming convention for Sophos device and user asset connectors.

Build:
- Bump Sophos manifest version from 1.19.1 to 1.19.2.

Documentation:
- Add changelog entry documenting the Sophos asset connector naming convention fix and version 1.19.2 release.