### PR TITLE
Office 365 - add retries for context

### DIFF
--- a/Office365/CHANGELOG.md
+++ b/Office365/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-01 - 2.20.6
+
+### Changed
+
+- Add retries for reading and writing context file
+
 ## 2026-06-01 - 2.20.5
 
 ### Fixed

--- a/Office365/manifest.json
+++ b/Office365/manifest.json
@@ -8,7 +8,7 @@
   "name": "Microsoft Office365",
   "uuid": "2dc2855e-3f9a-441c-af2a-30c64e0d0f4a",
   "slug": "office365",
-  "version": "2.20.5",
+  "version": "2.20.6",
   "categories": [
     "Email"
   ]

--- a/Office365/office365/management_api/checkpoint.py
+++ b/Office365/office365/management_api/checkpoint.py
@@ -50,9 +50,7 @@ class Checkpoint:
         if not filepath.is_file():
             return None
 
-        with filepath.open("rt") as file:
-            result = file.read()
-
+        result = filepath.read_text()
         return result
 
     @retry(
@@ -61,9 +59,5 @@ class Checkpoint:
         stop=stop_after_attempt(10),
         retry_error_callback=capture_retry_error,
     )
-    def write(self, filepath: Path, data: bytes | str) -> None:
-        if isinstance(data, str):
-            data = data.encode("utf-8")
-
-        with filepath.open("wb") as out:
-            out.write(data)
+    def write(self, filepath: Path, data: str) -> None:
+        filepath.write_text(data)

--- a/Office365/office365/management_api/checkpoint.py
+++ b/Office365/office365/management_api/checkpoint.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from dateutil.parser import isoparse
+from sekoia_automation.utils import capture_retry_error
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 
 class Checkpoint:
@@ -14,12 +16,11 @@ class Checkpoint:
         now = datetime.now(UTC)
 
         if self._most_recent_date_seen is None:
-
-            try:
-                # read the most recent date seen from the context
-                most_recent_date_seen_str = self._context.read_text()
+            most_recent_date_seen_str: str | None = self.read(filepath=self._context)
+            if most_recent_date_seen_str:
                 most_recent_date_seen = isoparse(most_recent_date_seen_str)
-            except Exception:
+
+            else:
                 # if not defined, set the most recent date seen to now
                 most_recent_date_seen = now
 
@@ -37,4 +38,32 @@ class Checkpoint:
         if last_message_date is not None:
             if self.offset is None or last_message_date > self.offset:
                 self._most_recent_date_seen = last_message_date
-                self._context.write_text(last_message_date.isoformat())
+                self.write(filepath=self._context, data=last_message_date.isoformat())
+
+    @retry(
+        reraise=True,
+        wait=wait_exponential(max=6),
+        stop=stop_after_attempt(10),
+        retry_error_callback=capture_retry_error,
+    )
+    def read(self, filepath: Path) -> str | None:
+        if not filepath.is_file():
+            return None
+
+        with filepath.open("rt") as file:
+            result = file.read()
+
+        return result
+
+    @retry(
+        reraise=True,
+        wait=wait_exponential(max=6),
+        stop=stop_after_attempt(10),
+        retry_error_callback=capture_retry_error,
+    )
+    def write(self, filepath: Path, data: bytes | str) -> None:
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+
+        with filepath.open("wb") as out:
+            out.write(data)

--- a/Office365/office365/management_api/connector.py
+++ b/Office365/office365/management_api/connector.py
@@ -210,6 +210,7 @@ class Office365Connector(AsyncConnector):
                     return
                 self.log_exception(
                     message="Office365 client session was closed unexpectedly; rebuilding client and continuing.",
+                    exception=exp,
                 )
                 self._reset_client()
                 if self.running:
@@ -238,7 +239,7 @@ class Office365Connector(AsyncConnector):
         loop.add_signal_handler(signal.SIGINT, self._handle_stop_signal, loop)
 
         # Initialize the checkpoint
-        checkpoint = Checkpoint(self._data_path, self.configuration.intake_key)
+        checkpoint = Checkpoint(self.data_path, self.configuration.intake_key)
 
         try:
             await self.activate_subscriptions()

--- a/Office365/tests/management_api/test_checkpoint.py
+++ b/Office365/tests/management_api/test_checkpoint.py
@@ -89,3 +89,72 @@ def test_checkpoint_save_last_date(symphony_storage, checkpoint, intake_key):
 
     # assert that the checkpoint was updated to the new observed date
     assert checkpoint.offset == new_observed_date
+
+
+def test_read_retries_on_transient_error_then_succeeds(symphony_storage, checkpoint):
+    context = symphony_storage / f"o365_{intake_key}_last_pull"
+    saved_data = datetime.now(UTC).isoformat()
+    context.write_text(saved_data)
+
+    calls = {"n": 0}
+
+    real_open = Path.open
+
+    def flaky_open(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise OSError("Can't access the file")
+
+        return real_open(self, *args, **kwargs)
+
+    with patch.object(Path, "open", flaky_open), patch("time.sleep") as mock_sleep:
+        result = checkpoint.read(context)
+
+    assert result == saved_data
+    assert calls["n"] == 3  # two failures + one success
+
+
+def test_read_exhausts_retries_and_invokes_error_callback(symphony_storage, checkpoint):
+    context = symphony_storage / f"o365_{intake_key}_last_pull"
+    saved_data = datetime.now(UTC).isoformat()
+    context.write_text(saved_data)
+
+    with (
+        patch.object(Path, "open", side_effect=OSError("permanent failure")),
+        patch("time.sleep") as mock_sleep,
+        pytest.raises(OSError),
+    ):
+        checkpoint.read(context)
+
+
+def test_write_retries_on_transient_error_then_succeeds(symphony_storage, checkpoint):
+    context = symphony_storage / f"o365_{intake_key}_last_pull"
+    saved_data = datetime.now(UTC).isoformat()
+
+    calls = {"n": 0}
+
+    real_open = Path.open
+
+    def flaky_open(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise OSError("Can't access the file")
+
+        return real_open(self, *args, **kwargs)
+
+    with patch.object(Path, "open", flaky_open), patch("time.sleep") as mock_sleep:
+        checkpoint.write(context, saved_data)
+
+    assert calls["n"] == 3  # two failures + one success
+
+
+def test_write_exhausts_retries_and_invokes_error_callback(symphony_storage, checkpoint):
+    context = symphony_storage / f"o365_{intake_key}_last_pull"
+    saved_data = datetime.now(UTC).isoformat()
+
+    with (
+        patch.object(Path, "open", side_effect=OSError("permanent failure")),
+        patch("time.sleep") as mock_sleep,
+        pytest.raises(OSError),
+    ):
+        checkpoint.write(context, saved_data)

--- a/Office365/tests/management_api/test_checkpoint.py
+++ b/Office365/tests/management_api/test_checkpoint.py
@@ -114,7 +114,7 @@ def test_read_retries_on_transient_error_then_succeeds(symphony_storage, checkpo
     assert calls["n"] == 3  # two failures + one success
 
 
-def test_read_exhausts_retries_and_invokes_error_callback(symphony_storage, checkpoint):
+def test_read_exhausts_retries(symphony_storage, checkpoint):
     context = symphony_storage / f"o365_{intake_key}_last_pull"
     saved_data = datetime.now(UTC).isoformat()
     context.write_text(saved_data)
@@ -148,7 +148,7 @@ def test_write_retries_on_transient_error_then_succeeds(symphony_storage, checkp
     assert calls["n"] == 3  # two failures + one success
 
 
-def test_write_exhausts_retries_and_invokes_error_callback(symphony_storage, checkpoint):
+def test_write_exhausts_retries(symphony_storage, checkpoint):
     context = symphony_storage / f"o365_{intake_key}_last_pull"
     saved_data = datetime.now(UTC).isoformat()
 

--- a/Office365/tests/management_api/test_checkpoint.py
+++ b/Office365/tests/management_api/test_checkpoint.py
@@ -91,7 +91,7 @@ def test_checkpoint_save_last_date(symphony_storage, checkpoint, intake_key):
     assert checkpoint.offset == new_observed_date
 
 
-def test_read_retries_on_transient_error_then_succeeds(symphony_storage, checkpoint):
+def test_read_retries_on_transient_error_then_succeeds(symphony_storage, checkpoint, intake_key):
     context = symphony_storage / f"o365_{intake_key}_last_pull"
     saved_data = datetime.now(UTC).isoformat()
     context.write_text(saved_data)
@@ -114,7 +114,7 @@ def test_read_retries_on_transient_error_then_succeeds(symphony_storage, checkpo
     assert calls["n"] == 3  # two failures + one success
 
 
-def test_read_exhausts_retries(symphony_storage, checkpoint):
+def test_read_exhausts_retries(symphony_storage, checkpoint, intake_key):
     context = symphony_storage / f"o365_{intake_key}_last_pull"
     saved_data = datetime.now(UTC).isoformat()
     context.write_text(saved_data)
@@ -127,7 +127,7 @@ def test_read_exhausts_retries(symphony_storage, checkpoint):
         checkpoint.read(context)
 
 
-def test_write_retries_on_transient_error_then_succeeds(symphony_storage, checkpoint):
+def test_write_retries_on_transient_error_then_succeeds(symphony_storage, checkpoint, intake_key):
     context = symphony_storage / f"o365_{intake_key}_last_pull"
     saved_data = datetime.now(UTC).isoformat()
 
@@ -148,7 +148,7 @@ def test_write_retries_on_transient_error_then_succeeds(symphony_storage, checkp
     assert calls["n"] == 3  # two failures + one success
 
 
-def test_write_exhausts_retries(symphony_storage, checkpoint):
+def test_write_exhausts_retries(symphony_storage, checkpoint, intake_key):
     context = symphony_storage / f"o365_{intake_key}_last_pull"
     saved_data = datetime.now(UTC).isoformat()
 

--- a/Office365/tests/management_api/test_checkpoint.py
+++ b/Office365/tests/management_api/test_checkpoint.py
@@ -29,7 +29,7 @@ def test_non_existing_checkpoint(checkpoint):
         mock_datetime.now.return_value = now
         mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
 
-        # Timedelta is sligthly less than 7 days since a few microseconds elapsed between `now`
+        # Timedelta is slightly less than 7 days since a few microseconds elapsed between `now`
         # and the moment `last_pull_date` is generated
         assert now == checkpoint.offset
 
@@ -53,7 +53,7 @@ def test_checkpoint_greater_than_7_days(symphony_storage, checkpoint, intake_key
         mock_datetime.now.return_value = now
         mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
 
-        # Timedelta is sligthly less than 7 days since a few microseconds elapsed between `now`
+        # Timedelta is slightly less than 7 days since a few microseconds elapsed between `now`
         # and the moment `last_pull_date` is generated
         assert (now - checkpoint.offset).days == 7
 
@@ -68,7 +68,7 @@ def test_checkpoint_greater_than_7_days_bis(symphony_storage, checkpoint, intake
         mock_datetime.now.return_value = now
         mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
 
-        # Timedelta is sligthly less than 7 days since a few microseconds elapsed between `now`
+        # Timedelta is slightly less than 7 days since a few microseconds elapsed between `now`
         # and the moment `last_pull_date` is generated
         assert (now - checkpoint.offset).days == 7
 


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1703

## Summary by Sourcery

Add retryable, centralized file I/O for Office365 checkpoint context handling and adjust connector and documentation accordingly.

Bug Fixes:
- Ensure connector initializes the checkpoint using the correct data path.
- Improve logging by including the caught exception when the Office365 client session closes unexpectedly.

Enhancements:
- Introduce retry-wrapped read/write helpers on the checkpoint context file with exponential backoff and standardized error handling.
- Refine checkpoint offset logic to use the new context read helper and better handle missing or unreadable checkpoint files.

Documentation:
- Update changelog for version 2.20.6 to document checkpoint context retry behavior.

Tests:
- Add tests covering successful and failing retry scenarios for checkpoint context file reads and writes.