### PR TITLE
CrowdStrike Falcon - add intake_server to configuration

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-02 - 1.25.18
+
+### Fixed
+
+- Add intake_server to connector's manifests
+
 ## 2026-06-23 - 1.25.17
 
 ### Fixed

--- a/CrowdStrikeFalcon/connector_event_stream.json
+++ b/CrowdStrikeFalcon/connector_event_stream.json
@@ -5,6 +5,11 @@
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
+      "intake_server": {
+        "description": "Server of the intake server (e.g. 'https://intake.sekoia.io')",
+        "default": "https://intake.sekoia.io",
+        "type": "string"
+      },
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "CrowdStrike Falcon is a cloud-native cybersecurity platform known for its advanced threat detection, endpoint protection, and real-time response capabilities. It leverages AI and machine learning to protect against malware and sophisticated cyberattacks.",
-  "version": "1.25.17",
+  "version": "1.25.18",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/CrowdStrikeFalcon/trigger_event_stream.json
+++ b/CrowdStrikeFalcon/trigger_event_stream.json
@@ -5,6 +5,11 @@
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
+      "intake_server": {
+        "description": "Server of the intake server (e.g. 'https://intake.sekoia.io')",
+        "default": "https://intake.sekoia.io",
+        "type": "string"
+      },
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1738

## Summary by Sourcery

Add configuration support for the Intake Server in the CrowdStrike Falcon connector and release a new patch version.

Bug Fixes:
- Include intake_server in the connector manifests to ensure proper configuration handling.

Documentation:
- Document the intake_server fix and version 1.25.18 in the CrowdStrike Falcon changelog.

## Summary by Sourcery

Add intake_server configuration support to the CrowdStrike Falcon connector and release a new patch version.

Bug Fixes:
- Include intake_server in the CrowdStrike Falcon connector manifests so the option is properly handled in configuration.

Build:
- Bump the CrowdStrike Falcon connector version from 1.25.17 to 1.25.18.

Documentation:
- Document the intake_server fix and release version 1.25.18 in the CrowdStrike Falcon changelog.