### PR TITLE
Imperva - add intake_server to configuration

### DIFF
--- a/Imperva/CHANGELOG.md
+++ b/Imperva/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-02 - 1.21.6
+
+### Fixed
+
+- Add intake_server to connector's manifests
+
 ## 2026-06-08 - 1.21.5
 
 ### Fixed

--- a/Imperva/connector_fetch_logs.json
+++ b/Imperva/connector_fetch_logs.json
@@ -12,6 +12,11 @@
         "description": "The size of chunks for the batch processing",
         "default": 500
       },
+      "intake_server": {
+        "description": "Server of the intake server (e.g. 'https://intake.sekoia.io')",
+        "default": "https://intake.sekoia.io",
+        "type": "string"
+      },
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"

--- a/Imperva/manifest.json
+++ b/Imperva/manifest.json
@@ -46,7 +46,7 @@
   "name": "Imperva",
   "uuid": "ee0e5c81-5410-48d4-b155-135679c5ebb8",
   "slug": "imperva",
-  "version": "1.21.5",
+  "version": "1.21.6",
   "categories": [
     "Network"
   ]

--- a/Imperva/trigger_fetch_logs.json
+++ b/Imperva/trigger_fetch_logs.json
@@ -11,6 +11,11 @@
         "description": "The size of chunks for the batch processing",
         "default": 500
       },
+      "intake_server": {
+        "description": "Server of the intake server (e.g. 'https://intake.sekoia.io')",
+        "default": "https://intake.sekoia.io",
+        "type": "string"
+      },
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1738

## Summary by Sourcery

Update Imperva integration configuration to include intake_server in connector manifests and bump the integration version.

Bug Fixes:
- Add intake_server configuration to Imperva connector manifests to fix missing intake server setup.

Documentation:
- Record Imperva 1.21.6 release and its fix in the changelog.