### PR TITLE
Retarus - add intake_server to configuration

### DIFF
--- a/Retarus/CHANGELOG.md
+++ b/Retarus/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-02 - 1.1.3
+
+### Fixed
+
+- Add intake_server to connector's manifests
+
 ## 2024-07-30 - 1.1.2
 
 ### Fixed

--- a/Retarus/connector_retarus_events.json
+++ b/Retarus/connector_retarus_events.json
@@ -15,6 +15,11 @@
         "description": "Retarus websocket auth key",
         "type": "string"
       },
+      "intake_server": {
+        "description": "Server of the intake server (e.g. 'https://intake.sekoia.io')",
+        "default": "https://intake.sekoia.io",
+        "type": "string"
+      },
       "intake_key": {
         "description": "Intake key to use when sending events",
         "type": "string"

--- a/Retarus/manifest.json
+++ b/Retarus/manifest.json
@@ -8,7 +8,7 @@
   "name": "Retarus",
   "uuid": "a3b18f0e-ffd2-4e3f-b737-f65c0aac8d0d",
   "slug": "retarus",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "categories": [
     "Email"
   ]


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1738

## Summary by Sourcery

Update the Retarus connector configuration to include the intake_server setting and release version 1.1.3.

Bug Fixes:
- Ensure the Retarus connector manifests declare the intake_server configuration field so deployments use the correct intake endpoint.

Build:
- Bump the Retarus connector version from 1.1.2 to 1.1.3.

Documentation:
- Document the 1.1.3 Retarus release and the intake_server manifest fix in the changelog.