### PR TITLE
support custom alert statuses in update status action

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-20 - 2.74.3
+
+### Fixed
+
+- `Update Alert Status` now supports alert custom statuses by UUID and by name.
+
 ## 2026-07-10 - 2.74.2
 
 ### Changed

--- a/Sekoia.io/action_trigger_status_update_on_alert.json
+++ b/Sekoia.io/action_trigger_status_update_on_alert.json
@@ -15,15 +15,8 @@
       },
       "status": {
         "type": "string",
-        "description": "Name of the status to update the alert to",
-        "in": "body",
-        "enum": [
-          "Pending",
-          "Acknowledged",
-          "Ongoing",
-          "Rejected",
-          "Closed"
-        ]
+        "description": "Name or UUID of the status to update the alert to (native or custom)",
+        "in": "body"
       },
       "comment": {
         "type": "string",

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.74.2",
+  "version": "2.74.3",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/update_alert_status.py
+++ b/Sekoia.io/sekoiaio/operation_center/update_alert_status.py
@@ -58,17 +58,9 @@ class UpdateAlertStatus(Action):
 
     @staticmethod
     def _extract_custom_statuses(payload: dict) -> list[dict]:
-        """Extract custom statuses from supported API payload containers.
-
-        The current endpoint returns statuses in `items`. We keep `data` and
-        `custom_statuses` support for backward compatibility with older payloads.
-        """
+        """Extract custom statuses from the API payload."""
         if isinstance(payload.get("items"), list):
             return [item for item in payload["items"] if isinstance(item, dict)]
-        if isinstance(payload.get("data"), list):
-            return [item for item in payload["data"] if isinstance(item, dict)]
-        if isinstance(payload.get("custom_statuses"), list):
-            return [item for item in payload["custom_statuses"] if isinstance(item, dict)]
         if payload:
             raise ValueError("Unexpected custom statuses payload format")
         return []
@@ -102,13 +94,11 @@ class UpdateAlertStatus(Action):
 
         status_name_lower = status_name.casefold()
         for custom_status in custom_statuses:
-            label = custom_status.get("label")
-            name = custom_status.get("name")
             custom_status_uuid = custom_status.get("uuid")
-            if not isinstance(custom_status_uuid, str):
-                continue
+            label = custom_status.get("label")
             if isinstance(label, str) and label.casefold() == status_name_lower:
                 return custom_status_uuid
+            name = custom_status.get("name")
             if isinstance(name, str) and name.casefold() == status_name_lower:
                 return custom_status_uuid
         return None

--- a/Sekoia.io/sekoiaio/operation_center/update_alert_status.py
+++ b/Sekoia.io/sekoiaio/operation_center/update_alert_status.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from sekoia_automation.action import Action
 import requests
-from tenacity import retry, wait_exponential, stop_after_attempt
+from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception
 
 STATUS_UUIDS = {
     "PENDING": "2efc4930-1442-4abb-acf2-58ba219a4fd0",
@@ -18,6 +18,18 @@ ACTION_UUIDS = [
     "ade85d7b-7507-4026-bfc6-cc006d10ddac",
     "1390be4e-ced8-4dd6-9bed-573471b235ab",
 ]
+
+
+class NonRetryableAlertStatusError(Exception):
+    """Raised when status resolution fails due to a persistent client-side issue."""
+
+
+def _is_retryable_request_exception(exc: BaseException) -> bool:
+    if isinstance(exc, NonRetryableAlertStatusError):
+        return False
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        return exc.response.status_code >= 500
+    return True
 
 
 class UpdateAlertStatus(Action):
@@ -46,29 +58,59 @@ class UpdateAlertStatus(Action):
 
     @staticmethod
     def _extract_custom_statuses(payload: dict) -> list[dict]:
+        """Extract custom statuses from supported API payload containers.
+
+        The current endpoint returns statuses in `items`. We keep `data` and
+        `custom_statuses` support for backward compatibility with older payloads.
+        """
         if isinstance(payload.get("items"), list):
-            return payload["items"]
+            return [item for item in payload["items"] if isinstance(item, dict)]
         if isinstance(payload.get("data"), list):
-            return payload["data"]
+            return [item for item in payload["data"] if isinstance(item, dict)]
         if isinstance(payload.get("custom_statuses"), list):
-            return payload["custom_statuses"]
+            return [item for item in payload["custom_statuses"] if isinstance(item, dict)]
+        if payload:
+            raise ValueError("Unexpected custom statuses payload format")
         return []
 
     def _resolve_custom_status_uuid(self, status_name: str) -> str | None:
         response = requests.get(self.custom_statuses_url(), headers=self.headers)
+        if 400 <= response.status_code < 500:
+            message = (
+                "Could not list custom statuses due to a client error "
+                f"(check configuration and permissions), status code: {response.status_code}"
+            )
+            self.error(message)
+            raise NonRetryableAlertStatusError(message)
         if response.status_code >= 500:
             self.error(f"Could not list custom statuses, status code: {response.status_code}")
             response.raise_for_status()
 
-        payload = response.json()
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            message = "Could not list custom statuses, response body is not valid JSON"
+            self.error(message)
+            raise NonRetryableAlertStatusError(message) from exc
+
+        try:
+            custom_statuses = self._extract_custom_statuses(payload)
+        except ValueError as exc:
+            message = "Could not list custom statuses, unexpected payload format"
+            self.error(message)
+            raise NonRetryableAlertStatusError(message) from exc
+
         status_name_lower = status_name.casefold()
-        for custom_status in self._extract_custom_statuses(payload):
+        for custom_status in custom_statuses:
             label = custom_status.get("label")
             name = custom_status.get("name")
+            custom_status_uuid = custom_status.get("uuid")
+            if not isinstance(custom_status_uuid, str):
+                continue
             if isinstance(label, str) and label.casefold() == status_name_lower:
-                return custom_status.get("uuid")
+                return custom_status_uuid
             if isinstance(name, str) and name.casefold() == status_name_lower:
-                return custom_status.get("uuid")
+                return custom_status_uuid
         return None
 
     def _patch_workflow_status(self, alert_uuid: str, action_uuid: str, comment: str | None = None):
@@ -83,6 +125,7 @@ class UpdateAlertStatus(Action):
 
     @retry(
         reraise=True,
+        retry=retry_if_exception(_is_retryable_request_exception),
         wait=wait_exponential(max=300),
         stop=stop_after_attempt(10),
     )

--- a/Sekoia.io/sekoiaio/operation_center/update_alert_status.py
+++ b/Sekoia.io/sekoiaio/operation_center/update_alert_status.py
@@ -1,4 +1,5 @@
 from posixpath import join as urljoin
+from uuid import UUID
 
 from sekoia_automation.action import Action
 import requests
@@ -21,13 +22,64 @@ ACTION_UUIDS = [
 
 class UpdateAlertStatus(Action):
 
-    def url(self, alert_uuid: str) -> str:
+    def workflow_url(self, alert_uuid: str) -> str:
         return urljoin(self.module.configuration["base_url"], f"api/v1/sic/alerts/{alert_uuid}/workflow")
+
+    def alert_url(self, alert_uuid: str) -> str:
+        return urljoin(self.module.configuration["base_url"], f"api/v1/sic/alerts/{alert_uuid}")
+
+    def custom_statuses_url(self) -> str:
+        return urljoin(self.module.configuration["base_url"], "api/v1/sic/custom_statuses")
 
     @property
     def headers(self) -> dict:
         api_key = self.module.configuration["api_key"]
         return {"Authorization": f"Bearer {api_key}"}
+
+    @staticmethod
+    def _is_uuid(value: str) -> bool:
+        try:
+            UUID(value)
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _extract_custom_statuses(payload: dict) -> list[dict]:
+        if isinstance(payload.get("items"), list):
+            return payload["items"]
+        if isinstance(payload.get("data"), list):
+            return payload["data"]
+        if isinstance(payload.get("custom_statuses"), list):
+            return payload["custom_statuses"]
+        return []
+
+    def _resolve_custom_status_uuid(self, status_name: str) -> str | None:
+        response = requests.get(self.custom_statuses_url(), headers=self.headers)
+        if response.status_code >= 500:
+            self.error(f"Could not list custom statuses, status code: {response.status_code}")
+            response.raise_for_status()
+
+        payload = response.json()
+        status_name_lower = status_name.casefold()
+        for custom_status in self._extract_custom_statuses(payload):
+            label = custom_status.get("label")
+            name = custom_status.get("name")
+            if isinstance(label, str) and label.casefold() == status_name_lower:
+                return custom_status.get("uuid")
+            if isinstance(name, str) and name.casefold() == status_name_lower:
+                return custom_status.get("uuid")
+        return None
+
+    def _patch_workflow_status(self, alert_uuid: str, action_uuid: str, comment: str | None = None):
+        return requests.patch(
+            self.workflow_url(alert_uuid), headers=self.headers, json={"action_uuid": action_uuid, "comment": comment}
+        )
+
+    def _patch_custom_status(self, alert_uuid: str, custom_status_uuid: str):
+        return requests.patch(
+            self.alert_url(alert_uuid), headers=self.headers, json={"custom_status_uuid": custom_status_uuid}
+        )
 
     @retry(
         reraise=True,
@@ -36,18 +88,17 @@ class UpdateAlertStatus(Action):
     )
     def perform_request(self, alert_uuid: str, status: str, comment: str | None = None):
         if status in STATUS_UUIDS.values() or status in ACTION_UUIDS:
-            result = requests.patch(
-                self.url(alert_uuid), headers=self.headers, json={"action_uuid": status, "comment": comment}
-            )
+            result = self._patch_workflow_status(alert_uuid, status, comment)
         elif status.upper() in STATUS_UUIDS:
-            result = requests.patch(
-                self.url(alert_uuid),
-                headers=self.headers,
-                json={"action_uuid": STATUS_UUIDS[status.upper()], "comment": comment},
-            )
+            result = self._patch_workflow_status(alert_uuid, STATUS_UUIDS[status.upper()], comment)
+        elif self._is_uuid(status):
+            result = self._patch_custom_status(alert_uuid, status)
         else:
-            self.error(f"Invalid status: {status}")
-            return
+            custom_status_uuid = self._resolve_custom_status_uuid(status)
+            if custom_status_uuid is None:
+                self.error(f"Invalid status: {status}")
+                return
+            result = self._patch_custom_status(alert_uuid, custom_status_uuid)
         if result.status_code >= 500:
             self.error(f"Could not change alert {alert_uuid} status, status code: {result.status_code}")
             result.raise_for_status()

--- a/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
@@ -3,7 +3,10 @@ import uuid
 from unittest.mock import patch
 
 import pytest
-from sekoiaio.operation_center.update_alert_status import UpdateAlertStatus
+from sekoiaio.operation_center.update_alert_status import (
+    NonRetryableAlertStatusError,
+    UpdateAlertStatus,
+)
 
 module_base_url = "https://app.sekoia.fake/"
 base_url = module_base_url + "api/v1/sic/alerts"
@@ -34,7 +37,7 @@ def test_patch_alert_status_support_action_uuid(requests_mock):
     assert results == {}
 
 
-def test_patch_alert_status_only_accept_valid_status_or_action_uuid(requests_mock):
+def test_patch_alert_status_rejects_unknown_status_values(requests_mock):
     action = UpdateAlertStatus()
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
     alert_uuid = str(uuid.uuid4())
@@ -43,11 +46,11 @@ def test_patch_alert_status_only_accept_valid_status_or_action_uuid(requests_moc
     requests_mock.patch(f"{base_url}/{alert_uuid}/workflow", json={})
     requests_mock.get(module_base_url + "api/v1/sic/custom_statuses", json={"items": []})
 
-    results: dict = action.run(arguments)
+    results: dict | None = action.run(arguments)
     assert results is None
 
     arguments = {"status": "not-a-valid-uuid", "uuid": alert_uuid}
-    results: dict = action.run(arguments)
+    results = action.run(arguments)
     assert results is None
 
 
@@ -152,8 +155,39 @@ def test_patch_alert_status_custom_status_lookup_fails_on_server_error(requests_
             action.run(arguments)
 
 
-def test_extract_custom_statuses_fallback_returns_empty_list():
-    assert UpdateAlertStatus._extract_custom_statuses({"unexpected": "format"}) == []
+def test_patch_alert_status_custom_status_lookup_fails_on_client_error_without_retry(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    arguments = {"status": "random_status", "uuid": alert_uuid}
+
+    requests_mock.get(module_base_url + "api/v1/sic/custom_statuses", text="forbidden", status_code=403)
+
+    with patch("tenacity.nap.time") as nap_mock:
+        with pytest.raises(NonRetryableAlertStatusError):
+            action.run(arguments)
+
+    nap_mock.assert_not_called()
+
+
+def test_patch_alert_status_custom_status_lookup_fails_on_invalid_json_without_retry(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    arguments = {"status": "random_status", "uuid": alert_uuid}
+
+    requests_mock.get(module_base_url + "api/v1/sic/custom_statuses", text="not-json")
+
+    with patch("tenacity.nap.time") as nap_mock:
+        with pytest.raises(NonRetryableAlertStatusError):
+            action.run(arguments)
+
+    nap_mock.assert_not_called()
+
+
+def test_extract_custom_statuses_unexpected_payload_raises_value_error():
+    with pytest.raises(ValueError):
+        UpdateAlertStatus._extract_custom_statuses({"unexpected": "format"})
 
 
 def test_patch_alert_status_fails(requests_mock):

--- a/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
@@ -103,36 +103,11 @@ def test_patch_alert_status_support_custom_status_name_from_name_field(requests_
     requests_mock.get(
         module_base_url + "api/v1/sic/custom_statuses",
         json={
-            "data": [
+            "items": [
                 {
                     "uuid": custom_status_uuid,
                     "name": "My-Custom-Status",
                     "description": "custom status resolved from name field",
-                }
-            ]
-        },
-    )
-    requests_mock.patch(f"{base_url}/{alert_uuid}", json={})
-
-    results: dict = action.run(arguments)
-    assert results == {}
-
-
-def test_patch_alert_status_support_custom_statuses_container(requests_mock):
-    action = UpdateAlertStatus()
-    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
-    alert_uuid = str(uuid.uuid4())
-    custom_status_uuid = str(uuid.uuid4())
-    arguments = {"status": "mystatus", "uuid": alert_uuid}
-
-    requests_mock.get(
-        module_base_url + "api/v1/sic/custom_statuses",
-        json={
-            "custom_statuses": [
-                {
-                    "uuid": custom_status_uuid,
-                    "label": "MyStatus",
-                    "description": "custom status from custom_statuses key",
                 }
             ]
         },
@@ -212,21 +187,6 @@ def test_patch_alert_status_custom_status_lookup_fails_on_unexpected_payload_wit
             action.run(arguments)
 
     nap_mock.assert_not_called()
-
-
-def test_patch_alert_status_custom_status_name_ignores_non_string_uuid(requests_mock):
-    action = UpdateAlertStatus()
-    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
-    alert_uuid = str(uuid.uuid4())
-    arguments = {"status": "mystatus", "uuid": alert_uuid}
-
-    requests_mock.get(
-        module_base_url + "api/v1/sic/custom_statuses",
-        json={"items": [{"uuid": 42, "label": "mystatus"}]},
-    )
-
-    results = action.run(arguments)
-    assert results is None
 
 
 def test_patch_alert_status_fails(requests_mock):

--- a/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
@@ -89,6 +89,73 @@ def test_patch_alert_status_support_custom_status_name(requests_mock):
     assert results == {}
 
 
+def test_patch_alert_status_support_custom_status_name_from_name_field(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    custom_status_uuid = str(uuid.uuid4())
+    arguments = {"status": "my-custom-status", "uuid": alert_uuid}
+
+    requests_mock.get(
+        module_base_url + "api/v1/sic/custom_statuses",
+        json={
+            "data": [
+                {
+                    "uuid": custom_status_uuid,
+                    "name": "My-Custom-Status",
+                    "description": "custom status resolved from name field",
+                }
+            ]
+        },
+    )
+    requests_mock.patch(f"{base_url}/{alert_uuid}", json={})
+
+    results: dict = action.run(arguments)
+    assert results == {}
+
+
+def test_patch_alert_status_support_custom_statuses_container(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    custom_status_uuid = str(uuid.uuid4())
+    arguments = {"status": "mystatus", "uuid": alert_uuid}
+
+    requests_mock.get(
+        module_base_url + "api/v1/sic/custom_statuses",
+        json={
+            "custom_statuses": [
+                {
+                    "uuid": custom_status_uuid,
+                    "label": "MyStatus",
+                    "description": "custom status from custom_statuses key",
+                }
+            ]
+        },
+    )
+    requests_mock.patch(f"{base_url}/{alert_uuid}", json={})
+
+    results: dict = action.run(arguments)
+    assert results == {}
+
+
+def test_patch_alert_status_custom_status_lookup_fails_on_server_error(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    arguments = {"status": "random_status", "uuid": alert_uuid}
+
+    requests_mock.get(module_base_url + "api/v1/sic/custom_statuses", json={}, status_code=500)
+
+    with patch("tenacity.nap.time"):
+        with pytest.raises(Exception):
+            action.run(arguments)
+
+
+def test_extract_custom_statuses_fallback_returns_empty_list():
+    assert UpdateAlertStatus._extract_custom_statuses({"unexpected": "format"}) == []
+
+
 def test_patch_alert_status_fails(requests_mock):
     action = UpdateAlertStatus()
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}

--- a/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
@@ -41,13 +41,52 @@ def test_patch_alert_status_only_accept_valid_status_or_action_uuid(requests_moc
     arguments = {"status": "random_status", "uuid": alert_uuid}
 
     requests_mock.patch(f"{base_url}/{alert_uuid}/workflow", json={})
+    requests_mock.get(module_base_url + "api/v1/sic/custom_statuses", json={"items": []})
 
     results: dict = action.run(arguments)
-    assert results == None
+    assert results is None
 
-    arguments = {"status": str(uuid.uuid4()), "uuid": alert_uuid}
+    arguments = {"status": "not-a-valid-uuid", "uuid": alert_uuid}
     results: dict = action.run(arguments)
-    assert results == None
+    assert results is None
+
+
+def test_patch_alert_status_support_custom_status_uuid(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    custom_status_uuid = str(uuid.uuid4())
+    arguments = {"status": custom_status_uuid, "uuid": alert_uuid}
+
+    requests_mock.patch(f"{base_url}/{alert_uuid}", json={})
+
+    results: dict = action.run(arguments)
+    assert results == {}
+
+
+def test_patch_alert_status_support_custom_status_name(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    custom_status_uuid = str(uuid.uuid4())
+    arguments = {"status": "ImONit", "uuid": alert_uuid}
+
+    requests_mock.get(
+        module_base_url + "api/v1/sic/custom_statuses",
+        json={
+            "items": [
+                {
+                    "uuid": custom_status_uuid,
+                    "label": "ImONit",
+                    "description": "My in progress custom status",
+                }
+            ]
+        },
+    )
+    requests_mock.patch(f"{base_url}/{alert_uuid}", json={})
+
+    results: dict = action.run(arguments)
+    assert results == {}
 
 
 def test_patch_alert_status_fails(requests_mock):

--- a/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_alert_status.py
@@ -6,6 +6,7 @@ import pytest
 from sekoiaio.operation_center.update_alert_status import (
     NonRetryableAlertStatusError,
     UpdateAlertStatus,
+    _is_retryable_request_exception,
 )
 
 module_base_url = "https://app.sekoia.fake/"
@@ -188,6 +189,44 @@ def test_patch_alert_status_custom_status_lookup_fails_on_invalid_json_without_r
 def test_extract_custom_statuses_unexpected_payload_raises_value_error():
     with pytest.raises(ValueError):
         UpdateAlertStatus._extract_custom_statuses({"unexpected": "format"})
+
+
+def test_extract_custom_statuses_empty_payload_returns_empty_list():
+    assert UpdateAlertStatus._extract_custom_statuses({}) == []
+
+
+def test_is_retryable_request_exception_defaults_to_true():
+    assert _is_retryable_request_exception(RuntimeError("boom")) is True
+
+
+def test_patch_alert_status_custom_status_lookup_fails_on_unexpected_payload_without_retry(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    arguments = {"status": "random_status", "uuid": alert_uuid}
+
+    requests_mock.get(module_base_url + "api/v1/sic/custom_statuses", json={"unexpected": "format"})
+
+    with patch("tenacity.nap.time") as nap_mock:
+        with pytest.raises(NonRetryableAlertStatusError):
+            action.run(arguments)
+
+    nap_mock.assert_not_called()
+
+
+def test_patch_alert_status_custom_status_name_ignores_non_string_uuid(requests_mock):
+    action = UpdateAlertStatus()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    alert_uuid = str(uuid.uuid4())
+    arguments = {"status": "mystatus", "uuid": alert_uuid}
+
+    requests_mock.get(
+        module_base_url + "api/v1/sic/custom_statuses",
+        json={"items": [{"uuid": 42, "label": "mystatus"}]},
+    )
+
+    results = action.run(arguments)
+    assert results is None
 
 
 def test_patch_alert_status_fails(requests_mock):


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1737

## Summary by Sourcery

Extend alert status update action to handle both workflow statuses and custom alert statuses, including resolution by UUID or name, and add tests for the new behavior.

New Features:
- Allow updating an alert's custom status by providing a custom status UUID.
- Allow updating an alert's custom status by providing a custom status name, resolving it via the custom statuses API.

Bug Fixes:
- Ensure invalid non-UUID, non-workflow status values are rejected without attempting to patch the alert.

Enhancements:
- Refactor alert status update logic into helpers for building URLs, resolving custom statuses, and patching workflow versus custom statuses.

Tests:
- Add tests covering custom status UUID and name handling and refine existing tests to assert correct behavior for invalid statuses.