### PR TITLE
prevent CloudTrail connector from staying in starting

### DIFF
--- a/AWS/connectors/__init__.py
+++ b/AWS/connectors/__init__.py
@@ -47,6 +47,10 @@ class AbstractAwsConnector(AwsAccountProvider, AsyncConnector, metaclass=ABCMeta
                     processing_start = time.time()
                     current_lag: int = 0
 
+                    # Update heartbeat at each processing cycle so liveness reflects
+                    # that the connector loop is still actively running.
+                    self.heartbeat()
+
                     batch_result: tuple[int, list[int]] = loop.run_until_complete(self.next_batch())
                     message_count, messages_timestamp = batch_result
 
@@ -64,13 +68,19 @@ class AbstractAwsConnector(AwsAccountProvider, AsyncConnector, metaclass=ABCMeta
 
                         # Identify delay between message timestamp ( when it was pushed to sqs )
                         # and current timestamp ( when it was processed )
-                        messages_age = [
-                            int(processing_end - message_timestamp / 1000) for message_timestamp in messages_timestamp
-                        ]
-                        current_lag = min(messages_age)
+                        if messages_timestamp:
+                            messages_age = [
+                                int(processing_end - message_timestamp / 1000)
+                                for message_timestamp in messages_timestamp
+                            ]
+                            current_lag = min(messages_age)
 
-                        for age in messages_age:
-                            MESSAGES_AGE.labels(intake_key=self.configuration.intake_key).observe(age)
+                            for age in messages_age:
+                                MESSAGES_AGE.labels(intake_key=self.configuration.intake_key).observe(age)
+                        else:
+                            # Some connectors might not expose source timestamps while
+                            # still forwarding events successfully.
+                            MESSAGES_AGE.labels(intake_key=self.configuration.intake_key).observe(0)
                     else:
                         self.log(message="No records to forward", level="info")
                         MESSAGES_AGE.labels(intake_key=self.configuration.intake_key).observe(0)

--- a/AWS/tests/connectors/test_abstract_aws_connector.py
+++ b/AWS/tests/connectors/test_abstract_aws_connector.py
@@ -1,6 +1,7 @@
 """Test abstract AWS connector."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from connectors import AbstractAwsConnector, AbstractAwsConnectorConfiguration, AwsModule
 from connectors.s3.provider import AwsAccountProvider
@@ -17,3 +18,25 @@ def test_abstract_aws_connector(aws_module: AwsModule, symphony_storage: Path, i
     connector.configuration = AbstractAwsConnectorConfiguration(intake_key=intake_key)
 
     assert isinstance(connector, AwsAccountProvider)
+
+
+def test_abstract_aws_connector_run_with_empty_timestamps(
+    aws_module: AwsModule, symphony_storage: Path, intake_key: str
+):
+    """Ensure run loop handles successful batches without source timestamps."""
+
+    class DummyConnector(AbstractAwsConnector):
+        async def next_batch(self) -> tuple[int, list[int]]:
+            self.stop()
+            return 1, []
+
+    connector = DummyConnector(module=aws_module, data_path=symphony_storage)
+    connector.configuration = AbstractAwsConnectorConfiguration(intake_key=intake_key, frequency=0)
+    connector.log = MagicMock()
+    connector.log_exception = MagicMock()
+
+    initial_heartbeat = connector._last_heartbeat
+    connector.run()
+
+    assert connector.log_exception.call_count == 0
+    assert connector._last_heartbeat >= initial_heartbeat


### PR DESCRIPTION
https://github.com/SekoiaLab/platform/issues/89004

## Summary by Sourcery

Update AWS abstract connector run loop to maintain liveness and handle batches without source timestamps.

Enhancements:
- Refresh connector heartbeat on each processing cycle so supervisor liveness reflects an active loop.
- Handle successful batches with missing message timestamps by recording a default metric instead of computing lag.

Tests:
- Add a regression test ensuring the run loop handles empty timestamp lists without errors and updates the heartbeat.