### PR TITLE
fix(MicrosoftAD) : Fix device accounts

### DIFF
--- a/MicrosoftActiveDirectory/CHANGELOG.md
+++ b/MicrosoftActiveDirectory/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-06 - 1.5.5
+
+### Fixed
+
+- Classify machine/computer accounts (sAMAccountName or UPN local part ending with `$`) as `SYSTEM` instead of `USER`
+- Discard AD UPN-style values (e.g. `compte$@domain.ad.recouv`) from `email_addr` — they are not real email addresses
+
 ## 2026-04-24 - 1.5.4
 
 ### Fixed

--- a/MicrosoftActiveDirectory/manifest.json
+++ b/MicrosoftActiveDirectory/manifest.json
@@ -32,7 +32,7 @@
   "name": "Microsoft Active Directory",
   "uuid": "b2d96259-af89-4f7a-ae6e-a0af2d2400f3",
   "slug": "microsoft-ad",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -132,6 +132,23 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
         user_object = UserEnrichmentObject(name="login", value="infos", data=data)
         return [user_object]
 
+    @staticmethod
+    def _upn_local_part_ends_with_dollar(value: str) -> bool:
+        """Return True if the local part (before '@') of an AD UPN-like string ends with '$'."""
+        if "@" in value:
+            return value.split("@", 1)[0].endswith("$")
+        return False
+
+    @staticmethod
+    def is_machine_account(user_attributes: LDAPUserAttributes) -> bool:
+        """Detect machine/computer accounts in AD."""
+        if user_attributes.sAMAccountName and user_attributes.sAMAccountName.endswith("$"):
+            return True
+        upn = user_attributes.userPrincipalName
+        if upn and MicrosoftADUserAssetConnector._upn_local_part_ends_with_dollar(upn):
+            return True
+        return False
+
     def compute_user_type(self, user_attributes: LDAPUserAttributes) -> tuple[UserTypeStr, UserTypeId]:
         """
         Compute user type based on LDAP user attributes.
@@ -140,6 +157,9 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
         :return:
             tuple[UserTypeStr, UserTypeId]: User type string and ID.
         """
+        if self.is_machine_account(user_attributes):
+            return UserTypeStr.SYSTEM, UserTypeId.SYSTEM
+
         group_memberships = user_attributes.member_of or []
         for group_dn in group_memberships:
             if "admin" in group_dn.lower():
@@ -162,6 +182,16 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
             )
             user_groups.append(group_object)
         return user_groups
+
+    @staticmethod
+    def resolve_email_addr(mail: str | None) -> str | None:
+        """
+        Return the mail value only if it is a real email address.
+        AD UPN-style values whose local part ends with '$'
+        """
+        if mail and not MicrosoftADUserAssetConnector._upn_local_part_ends_with_dollar(mail):
+            return mail
+        return None
 
     def user_ocsf_object(self, user_attributes: LDAPUserAttributes) -> UserOCSF:
         """
@@ -202,13 +232,15 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
             uid=user_attributes.objectSid or "Unknown",
         )
 
+        email_addr = self.resolve_email_addr(user_attributes.mail)
+
         return UserOCSF(
             name=user_name,
             uid=user_attributes.objectSid or "Unknown",
             account=account,
             groups=self.get_user_groups(user_attributes),
             full_name=user_attributes.displayName or "Unknown",
-            email_addr=user_attributes.mail or "Unknown",
+            email_addr=email_addr,
             display_name=user_attributes.displayName or "Unknown",
             domain=user_attributes.distinguishedName or "Unknown",
             type_id=user_type_id,

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -189,7 +189,7 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
         Return the mail value only if it is a real email address.
         AD UPN-style values whose local part ends with '$'
         """
-        if mail and not MicrosoftADUserAssetConnector._upn_local_part_ends_with_dollar(mail):
+        if mail and "@" in mail and not MicrosoftADUserAssetConnector._upn_local_part_ends_with_dollar(mail):
             return mail
         return None
 

--- a/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
+++ b/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
@@ -127,6 +127,40 @@ def test_compute_user_type_regular_user(connector):
     assert user_type_id == UserTypeId.USER
 
 
+def test_compute_user_type_machine_account_via_sam(connector):
+    user_attr = LDAPUserAttributes(sAMAccountName="COMPUTERNAME$", member_of=[])
+
+    user_type, user_type_id = connector.compute_user_type(user_attr)
+
+    assert user_type == UserTypeStr.SYSTEM
+    assert user_type_id == UserTypeId.SYSTEM
+
+
+def test_compute_user_type_machine_account_via_upn(connector):
+    user_attr = LDAPUserAttributes(sAMAccountName=None, userPrincipalName="compte$@test.ad.recouv", member_of=[])
+
+    user_type, user_type_id = connector.compute_user_type(user_attr)
+
+    assert user_type == UserTypeStr.SYSTEM
+    assert user_type_id == UserTypeId.SYSTEM
+
+
+def test_resolve_email_addr_valid(connector):
+    assert connector.resolve_email_addr("user@example.com") == "user@example.com"
+
+
+def test_resolve_email_addr_machine_upn(connector):
+    assert connector.resolve_email_addr("compte$@urdom.ad.recouv") is None
+
+
+def test_resolve_email_addr_none(connector):
+    assert connector.resolve_email_addr(None) is None
+
+
+def test_resolve_email_addr_no_at_sign(connector):
+    assert connector.resolve_email_addr("notanemail") is None
+
+
 def test_get_user_groups(connector):
     user_attr = LDAPUserAttributes(member_of=["CN=Group1,DC=example,DC=com", "CN=Group2,DC=example,DC=com"])
 
@@ -157,6 +191,22 @@ def test_user_ocsf_object(connector):
     assert user_ocsf.account.name == "john.doe@example.com"
     assert user_ocsf.account.type_id == AccountTypeId.LDAP_ACCOUNT
     assert user_ocsf.email_addr == "john.doe@example.com"
+
+
+def test_user_ocsf_object_machine_account_email_not_set(connector):
+    # AD UPN-style mail values (local part ends with '$') must not be stored as email_addr
+    user_attr = LDAPUserAttributes(
+        sAMAccountName="compte$",
+        userPrincipalName="compte$@urdom.ad.recouv",
+        mail="compte$@urdom.ad.recouv",
+        objectSid="S-1-5-21-999",
+        distinguishedName="CN=compte,DC=urdom,DC=ad,DC=recouv",
+    )
+
+    user_ocsf = connector.user_ocsf_object(user_attr)
+
+    assert user_ocsf.type_id == UserTypeId.SYSTEM
+    assert user_ocsf.email_addr is None
 
 
 def test_map_user_fields(connector):


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/platform/issues/88990)

## Summary by Sourcery

Classify Microsoft AD machine/computer accounts correctly and prevent non-user UPN-style addresses from being stored as email addresses.

Bug Fixes:
- Detect machine/computer accounts via sAMAccountName or UPN local-part ending with '$' and mark them as SYSTEM rather than USER.
- Avoid populating email_addr with AD UPN-style values whose local part ends with '$', returning no email for such accounts.

Build:
- Bump Microsoft Active Directory connector manifest version from 1.5.4 to 1.5.5.

Documentation:
- Update the changelog with version 1.5.5 details describing machine account classification and email handling changes.

Tests:
- Add unit tests covering machine account type detection via sAMAccountName and UPN, email resolution behavior, and OCSF user object construction for machine accounts.