### PR TITLE
improve(sophos): Add some fields

### DIFF
--- a/Sophos/CHANGELOG.md
+++ b/Sophos/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-06 - 1.20.0
+
+### Changed
+
+- Map `exchangeLogin` to `user.uid_alt`
+- Extract domain prefix from domain-qualified names into `user.domain`
+- Detect AD domain accounts (`DOMAIN/username` format) as `LDAP_ACCOUNT` instead of `UNKNOWN`
+- Classify local Windows machine accounts (`COMPUTERNAME\username`) as `UserTypeId.SYSTEM` instead of `USER`
+
 ## 2026-06-29 - 1.19.2
 
 ### Fixed

--- a/Sophos/manifest.json
+++ b/Sophos/manifest.json
@@ -38,7 +38,7 @@
   "name": "Sophos",
   "uuid": "0de5216e-19b0-4ad3-9b91-a547cfaf52ca",
   "slug": "sophos",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "categories": [
     "Endpoint",
     "Network"

--- a/Sophos/sophos_module/asset_connector/user_assets.py
+++ b/Sophos/sophos_module/asset_connector/user_assets.py
@@ -57,7 +57,6 @@ class SophosUserAssetConnector(AssetConnector):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("user_context.json", self._data_path)
-        # Snapshot of the full current run: id → updatedAt (or createdAt fallback)
         self._current_run: dict[str, str] = {}
 
     @property
@@ -99,15 +98,36 @@ class SophosUserAssetConnector(AssetConnector):
         return user.updatedAt or user.createdAt
 
     @staticmethod
-    def _get_account_type(user: SophosUser) -> tuple[AccountTypeId, AccountTypeStr]:
-        """Infer account type from available fields.
+    def _extract_domain(name: str | None) -> str | None:
+        """Extract the domain prefix from 'DOMAIN\\user' or 'DOMAIN/user' formats."""
+        if not name:
+            return None
+        for sep in ("\\", "/"):
+            if sep in name:
+                domain = name.split(sep, 1)[0]
+                return domain if domain else None
+        return None
 
-        - name like 'DOMAIN\\username' (backslash) and no email → Windows account
-        - otherwise → Unknown
+    @staticmethod
+    def _is_local_machine_account(user: SophosUser) -> bool:
+        """Return True for local Windows session accounts"""
+        name = user.name or ""
+        return "\\" in name and not user.email and not user.firstName and not user.lastName
+
+    @staticmethod
+    def _get_account_type(user: SophosUser) -> tuple[AccountTypeId, AccountTypeStr]:
+        """
+        Infer account type from username.
+
+        - Local machine account (COMPUTERNAME\\username, no email/names) → Windows account
+        - AD domain account (DOMAIN/username, no email) → LDAP account
+        - Otherwise → Unknown
         """
         name = user.name or ""
-        if "\\" in name and not user.email:
+        if SophosUserAssetConnector._is_local_machine_account(user):
             return AccountTypeId.WINDOWS_ACCOUNT, AccountTypeStr.WINDOWS_ACCOUNT
+        if "/" in name and not user.email:
+            return AccountTypeId.LDAP_ACCOUNT, AccountTypeStr.LDAP_ACCOUNT
         return AccountTypeId.UNKNOWN, AccountTypeStr.UNKNOWN
 
     @staticmethod
@@ -122,6 +142,18 @@ class SophosUserAssetConnector(AssetConnector):
         if user.tenant and user.tenant.id:
             return Organization(uid=user.tenant.id, name=user.tenant.id)
         return None
+
+    @staticmethod
+    def _get_user_type(user: SophosUser) -> tuple[UserTypeId, UserTypeStr]:
+        """Return the OCSF user type based on whether this is a real directory user.
+
+        Local machine accounts (COMPUTERNAME\\username) are OS-managed accounts
+        bound to a specific machine → SYSTEM.
+        All other directory entries (named users, AD accounts) are real users → USER.
+        """
+        if SophosUserAssetConnector._is_local_machine_account(user):
+            return UserTypeId.SYSTEM, UserTypeStr.SYSTEM
+        return UserTypeId.USER, UserTypeStr.USER
 
     def _is_new_or_changed(self, user: SophosUser, known: dict[str, str]) -> bool:
         """Return True when the user is not yet cached or its timestamp has changed."""
@@ -149,8 +181,10 @@ class SophosUserAssetConnector(AssetConnector):
             return None
 
         account_type_id, account_type_str = self._get_account_type(user)
+        user_type_id, user_type_str = self._get_user_type(user)
         groups = self._get_groups(user)
         org = self._get_organization(user)
+        domain = self._extract_domain(name)
 
         # Build full name from firstName + lastName when available
         full_name: str | None = None
@@ -172,8 +206,10 @@ class SophosUserAssetConnector(AssetConnector):
             account=account,
             groups=groups,
             org=org,
-            type_id=UserTypeId.USER,
-            type=UserTypeStr.USER,
+            domain=domain,
+            uid_alt=user.exchangeLogin if user.exchangeLogin else None,
+            type_id=user_type_id,
+            type=user_type_str,
         )
 
         # Event time: prefer updatedAt, fallback to createdAt, then now
@@ -205,6 +241,7 @@ class SophosUserAssetConnector(AssetConnector):
             params: dict[str, Any] = {
                 "pageSize": self.PAGE_SIZE,
                 "page": page,
+                "includeGroupIds": True,
             }
             response = self.client.list_directory_users(params)
             response.raise_for_status()

--- a/Sophos/sophos_module/asset_connector/user_mapping.yml
+++ b/Sophos/sophos_module/asset_connector/user_mapping.yml
@@ -5,27 +5,50 @@ mapping:
 
   samples:
     - name: "Named user with email"
-      description: "A Sophos directory user with full name and email address"
+      description: "A real directory user with full name and email address"
       data: |
         {
           "id": "00000000-0000-0000-0000-000000000001",
-          "name": "Jane Doe",
-          "firstName": "Jane",
-          "lastName": "Doe",
-          "email": "jane.doe@example.com",
-          "exchangeLogin": "",
+          "name": "Alice Martin",
+          "firstName": "Alice",
+          "lastName": "Martin",
+          "email": "alice.martin@example.com",
+          "exchangeLogin": "amartin",
           "groups": { "total": 0, "itemsCount": 0, "items": [] },
           "tenant": { "id": "00000000-0000-0000-0000-000000000010" },
           "source": { "type": "custom" },
           "createdAt": "2023-06-16T15:00:56.473Z",
           "updatedAt": "2023-06-16T15:00:56.870Z"
         }
-    - name: "Windows local account"
-      description: "A Sophos directory user representing a Windows local account (DOMAIN\\username)"
+    - name: "AD domain account"
+      description: "An Active Directory account with short-domain-qualified login (DOMAIN/username format)"
+      data: |
+        {
+          "id": "00000000-0000-0000-0000-000000000004",
+          "name": "CORPDOMAIN/BC12345678",
+          "exchangeLogin": "BC12345678",
+          "groups": {
+            "total": 1,
+            "itemsCount": 1,
+            "items": [
+              {
+                "id": "00000000-0000-0000-0000-000000000021",
+                "name": "CORPDOMAIN",
+                "displayName": "CORPDOMAIN"
+              }
+            ]
+          },
+          "tenant": { "id": "00000000-0000-0000-0000-000000000010" },
+          "source": { "type": "active_directory" },
+          "createdAt": "2024-01-10T08:00:00.000Z",
+          "updatedAt": "2024-01-10T08:00:00.000Z"
+        }
+    - name: "Windows local machine account"
+      description: "A local Windows session account bound to a specific machine (COMPUTERNAME\\username format, no email or first/last name)"
       data: |
         {
           "id": "00000000-0000-0000-0000-000000000002",
-          "name": "DESKTOP-ABC1234\\jdoe",
+          "name": "DESKTOP-ABC1234\\localuser",
           "groups": { "total": 0, "itemsCount": 0, "items": [] },
           "tenant": { "id": "00000000-0000-0000-0000-000000000010" },
           "source": { "type": "custom" },
@@ -33,12 +56,12 @@ mapping:
           "updatedAt": "2025-12-11T12:22:37.223Z"
         }
     - name: "User with groups"
-      description: "A Sophos directory user that belongs to one or more groups"
+      description: "A Sophos directory user that belongs to one or more AD groups"
       data: |
         {
           "id": "00000000-0000-0000-0000-000000000003",
-          "name": "John Smith",
-          "email": "john.smith@example.onmicrosoft.com",
+          "name": "Bob Dupont",
+          "email": "bob.dupont@example.onmicrosoft.com",
           "groups": {
             "total": 1,
             "itemsCount": 1,
@@ -141,12 +164,12 @@ mapping:
       target: "user.name"
       type: "string"
       logic: "Direct mapping"
-      description: "Display name of the user"
+      description: "Display name or domain-qualified login of the user"
 
     - source: "firstName + lastName"
       target: "user.full_name"
       type: "string"
-      logic: "Concatenate firstName and lastName with a space when either is present"
+      logic: "Concatenate firstName and lastName with a space when either is present; omitted otherwise"
       description: "Full name constructed from first and last name fields"
 
     - source: "email"
@@ -155,25 +178,46 @@ mapping:
       logic: "Direct mapping; omitted when null or empty"
       description: "Primary email address of the user"
 
-    - source: "static: User"
+    - source: "name (classification logic)"
       target: "user.type_id / user.type"
       type: "integer / string"
-      logic: "All Sophos directory users are classified as UserTypeId.USER (1)"
-      description: "OCSF user type classification"
+      logic: |
+        Local machine account: name contains '\' AND no email AND no firstName AND no lastName
+          → UserTypeId.SYSTEM (3) / "System"
+          (machine-bound Windows session, not a real directory user)
+        All other users (named, AD domain):
+          → UserTypeId.USER (1) / "User"
+      description: "OCSF user type — System for local machine accounts, User for real directory entries"
 
-    - source: "name (presence of backslash and absence of email)"
+    - source: "name (classification logic)"
       target: "user.account.type_id / user.account.type"
       type: "integer / string"
       logic: |
-        If name contains '\' and email is absent → AccountTypeId.WINDOWS_ACCOUNT (2)
-        Otherwise → AccountTypeId.UNKNOWN (0)
+        Local machine account (name contains '\', no email/firstName/lastName):
+          → AccountTypeId.WINDOWS_ACCOUNT (2) / "Windows Account"
+        AD domain account (name contains '/', no email):
+          → AccountTypeId.LDAP_ACCOUNT (1) / "LDAP Account"
+        Otherwise:
+          → AccountTypeId.UNKNOWN (0) / "Unknown"
       description: "Account type inferred from the name format"
+
+    - source: "name (part before '\\' or '/')"
+      target: "user.domain"
+      type: "string"
+      logic: "Split name on '\\' or '/' (first occurrence); use left-hand side as domain. Omitted when name has no separator."
+      description: "Domain prefix extracted from domain-qualified usernames (e.g. CORPDOMAIN from CORPDOMAIN/BC12345678, or DESKTOP-ABC1234 from DESKTOP-ABC1234\\localuser)"
+
+    - source: "exchangeLogin"
+      target: "user.uid_alt"
+      type: "string"
+      logic: "Direct mapping; omitted when null or empty"
+      description: "Exchange / AD sAMAccountName used as an alternate user identifier (e.g. BC12345678)"
 
     - source: "groups.items[].id + groups.items[].name"
       target: "user.groups[]"
       type: "array"
-      logic: "Map each group item to an OCSF Group object (uid=id, name=name)"
-      description: "Groups the user belongs to"
+      logic: "Map each group item to an OCSF Group object (uid=id, name=name or displayName). Groups are fetched via includeGroupIds=true query parameter."
+      description: "AD group memberships of the user"
 
     - source: "tenant.id"
       target: "user.org.uid / user.org.name"
@@ -189,14 +233,12 @@ mapping:
       description: "Incremental collection checkpoint for change detection"
 
   not_mapped:
-    - field: "exchangeLogin"
-      reason: "No corresponding OCSF field for Exchange login"
     - field: "source.type"
       reason: "Internal Sophos user source type; not relevant to OCSF user model"
 
   ocsf_samples:
     - name: "Named user with email – OCSF output"
-      description: "Transformed OCSF UserOCSFModel for a user with firstName/lastName/email"
+      description: "Transformed OCSF UserOCSFModel for a real directory user with exchangeLogin"
       data: |
         {
           "activity_id": 2,
@@ -216,16 +258,102 @@ mapping:
           },
           "user": {
             "uid": "00000000-0000-0000-0000-000000000001",
-            "name": "Jane Doe",
-            "full_name": "Jane Doe",
-            "email_addr": "jane.doe@example.com",
+            "name": "Alice Martin",
+            "full_name": "Alice Martin",
+            "email_addr": "alice.martin@example.com",
+            "uid_alt": "amartin",
             "type_id": 1,
             "type": "User",
+            "domain": null,
             "account": {
-              "name": "Jane Doe",
+              "name": "Alice Martin",
               "type_id": 0,
               "type": "Unknown",
               "uid": "00000000-0000-0000-0000-000000000001"
+            },
+            "groups": null,
+            "org": {
+              "uid": "00000000-0000-0000-0000-000000000010",
+              "name": "00000000-0000-0000-0000-000000000010"
+            }
+          }
+        }
+    - name: "AD domain account – OCSF output"
+      description: "Transformed OCSF UserOCSFModel for an Active Directory domain account"
+      data: |
+        {
+          "activity_id": 2,
+          "activity_name": "Collect",
+          "category_name": "Discovery",
+          "category_uid": 5,
+          "class_name": "User Inventory Info",
+          "class_uid": 5003,
+          "type_name": "User Inventory Info: Collect",
+          "type_uid": 500302,
+          "severity": "Informational",
+          "severity_id": 1,
+          "time": 1704873600.0,
+          "metadata": {
+            "product": { "name": "Sophos EDR", "version": "N/A" },
+            "version": "1.6.0"
+          },
+          "user": {
+            "uid": "00000000-0000-0000-0000-000000000004",
+            "name": "CORPDOMAIN/BC12345678",
+            "full_name": null,
+            "email_addr": null,
+            "uid_alt": "BC12345678",
+            "type_id": 1,
+            "type": "User",
+            "domain": "CORPDOMAIN",
+            "account": {
+              "name": "CORPDOMAIN/BC12345678",
+              "type_id": 1,
+              "type": "LDAP Account",
+              "uid": "00000000-0000-0000-0000-000000000004"
+            },
+            "groups": [
+              { "uid": "00000000-0000-0000-0000-000000000021", "name": "CORPDOMAIN" }
+            ],
+            "org": {
+              "uid": "00000000-0000-0000-0000-000000000010",
+              "name": "00000000-0000-0000-0000-000000000010"
+            }
+          }
+        }
+    - name: "Windows local machine account – OCSF output"
+      description: "Transformed OCSF UserOCSFModel for a local Windows session account"
+      data: |
+        {
+          "activity_id": 2,
+          "activity_name": "Collect",
+          "category_name": "Discovery",
+          "category_uid": 5,
+          "class_name": "User Inventory Info",
+          "class_uid": 5003,
+          "type_name": "User Inventory Info: Collect",
+          "type_uid": 500302,
+          "severity": "Informational",
+          "severity_id": 1,
+          "time": 1733914957.0,
+          "metadata": {
+            "product": { "name": "Sophos EDR", "version": "N/A" },
+            "version": "1.6.0"
+          },
+          "user": {
+            "uid": "00000000-0000-0000-0000-000000000002",
+            "name": "DESKTOP-ABC1234\\localuser",
+            "full_name": null,
+            "email_addr": null,
+            "uid_alt": null,
+            "type_id": 3,
+            "type": "System",
+            "domain": "DESKTOP-ABC1234",
+            "account": {
+              "name": "DESKTOP-ABC1234\\localuser",
+              "type_id": 2,
+              "type": "Windows Account",
+              "uid": "00000000-0000-0000-0000-000000000002"
             },
             "groups": null,
             "org": {

--- a/Sophos/tests/asset_connector/test_user_assets.py
+++ b/Sophos/tests/asset_connector/test_user_assets.py
@@ -20,6 +20,7 @@ from sekoia_automation.asset_connector.models.ocsf.user import (
     AccountTypeId,
     AccountTypeStr,
     UserTypeId,
+    UserTypeStr,
 )
 
 NAMED_USER = SophosUser(
@@ -44,6 +45,17 @@ WINDOWS_USER = SophosUser(
     source=SophosUserSource(type="custom"),
     createdAt="2025-12-10T12:49:12.371Z",
     updatedAt="2025-12-11T12:22:37.223Z",
+)
+
+AD_USER = SophosUser(
+    id="aaaaaaaa-0000-0000-0000-000000000005",
+    name="test/AC00008700",
+    exchangeLogin="AC00008700",
+    groups=SophosUserGroups(total=0, itemsCount=0, items=[]),
+    tenant=SophosTenant(id="bbbbbbbb-0000-0000-0000-000000000001"),
+    source=SophosUserSource(type="active_directory"),
+    createdAt="2024-01-10T08:00:00.000Z",
+    updatedAt="2024-01-10T08:00:00.000Z",
 )
 
 USER_WITH_GROUPS = SophosUser(
@@ -167,7 +179,7 @@ def connector(symphony_storage):
 
 
 def _mock_list_users(connector, pages: list[dict]) -> None:
-    """Wire connector.client to return successive page responses."""
+    """Wire connector.client to return successive page responses for users."""
     connector.client = MagicMock()
     responses = []
     for page in pages:
@@ -185,18 +197,34 @@ def _seed_cache(connector, data: dict[str, str]) -> None:
 
 
 class TestGetAccountType:
-    def test_windows_local_account(self):
+    def test_local_machine_account_backslash_no_names(self):
         type_id, type_str = SophosUserAssetConnector._get_account_type(WINDOWS_USER)
         assert type_id == AccountTypeId.WINDOWS_ACCOUNT
         assert type_str == AccountTypeStr.WINDOWS_ACCOUNT
+
+    def test_backslash_but_has_first_name_is_not_windows(self):
+        """A real named user whose name happens to contain a backslash is not a local account."""
+        user = SophosUser(id="x", name="DOMAIN\\user", firstName="John")
+        type_id, _ = SophosUserAssetConnector._get_account_type(user)
+        assert type_id == AccountTypeId.UNKNOWN
+
+    def test_backslash_but_has_email_is_not_windows(self):
+        user = SophosUser(id="x", name="DOMAIN\\user", email="user@example.com")
+        type_id, _ = SophosUserAssetConnector._get_account_type(user)
+        assert type_id == AccountTypeId.UNKNOWN
+
+    def test_ad_user_with_forward_slash(self):
+        type_id, type_str = SophosUserAssetConnector._get_account_type(AD_USER)
+        assert type_id == AccountTypeId.LDAP_ACCOUNT
+        assert type_str == AccountTypeStr.LDAP_ACCOUNT
 
     def test_named_user_with_email_is_unknown(self):
         type_id, type_str = SophosUserAssetConnector._get_account_type(NAMED_USER)
         assert type_id == AccountTypeId.UNKNOWN
         assert type_str == AccountTypeStr.UNKNOWN
 
-    def test_backslash_but_has_email_is_unknown(self):
-        user = SophosUser(id="x", name="DOMAIN\\user", email="user@example.com")
+    def test_forward_slash_but_has_email_is_unknown(self):
+        user = SophosUser(id="x", name="DOMAIN/user", email="user@example.com")
         type_id, _ = SophosUserAssetConnector._get_account_type(user)
         assert type_id == AccountTypeId.UNKNOWN
 
@@ -204,6 +232,59 @@ class TestGetAccountType:
         user = SophosUser(id="x", name=None)
         type_id, _ = SophosUserAssetConnector._get_account_type(user)
         assert type_id == AccountTypeId.UNKNOWN
+
+
+class TestGetUserType:
+    def test_named_user_is_user_type(self):
+        type_id, type_str = SophosUserAssetConnector._get_user_type(NAMED_USER)
+        assert type_id == UserTypeId.USER
+        assert type_str == UserTypeStr.USER
+
+    def test_ad_user_is_user_type(self):
+        type_id, type_str = SophosUserAssetConnector._get_user_type(AD_USER)
+        assert type_id == UserTypeId.USER
+        assert type_str == UserTypeStr.USER
+
+    def test_local_machine_account_is_system(self):
+        type_id, type_str = SophosUserAssetConnector._get_user_type(WINDOWS_USER)
+        assert type_id == UserTypeId.SYSTEM
+        assert type_str == UserTypeStr.SYSTEM
+
+
+
+    def test_desktop_user_is_local(self):
+        assert SophosUserAssetConnector._is_local_machine_account(WINDOWS_USER) is True
+
+    def test_named_user_is_not_local(self):
+        assert SophosUserAssetConnector._is_local_machine_account(NAMED_USER) is False
+
+    def test_ad_user_forward_slash_is_not_local(self):
+        assert SophosUserAssetConnector._is_local_machine_account(AD_USER) is False
+
+    def test_backslash_with_email_is_not_local(self):
+        user = SophosUser(id="x", name="DOMAIN\\user", email="user@example.com")
+        assert SophosUserAssetConnector._is_local_machine_account(user) is False
+
+    def test_backslash_with_first_name_is_not_local(self):
+        user = SophosUser(id="x", name="DOMAIN\\user", firstName="John")
+        assert SophosUserAssetConnector._is_local_machine_account(user) is False
+
+
+class TestExtractDomain:
+    def test_backslash_format(self):
+        assert SophosUserAssetConnector._extract_domain("DESKTOP-ABC1234\\jdoe") == "DESKTOP-ABC1234"
+
+    def test_forward_slash_format(self):
+        assert SophosUserAssetConnector._extract_domain("URDOM/AC75008715") == "URDOM"
+
+    def test_no_separator_returns_none(self):
+        assert SophosUserAssetConnector._extract_domain("Jane Doe") is None
+
+    def test_none_input_returns_none(self):
+        assert SophosUserAssetConnector._extract_domain(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert SophosUserAssetConnector._extract_domain("") is None
 
 
 class TestGetGroups:
@@ -317,8 +398,28 @@ class TestMapUserFields:
         result = connector.map_user_fields(WINDOWS_USER)
         assert result is not None
         assert result.user.account.type_id == AccountTypeId.WINDOWS_ACCOUNT
+        assert result.user.type_id == UserTypeId.SYSTEM
         assert result.user.email_addr is None
         assert result.user.full_name is None
+        assert result.user.domain == "DESKTOP-ABC1234"
+
+    def test_ad_user_mapping(self, connector):
+        result = connector.map_user_fields(AD_USER)
+        assert result is not None
+        assert result.user.account.type_id == AccountTypeId.LDAP_ACCOUNT
+        assert result.user.domain == "test"
+        assert result.user.uid_alt == "AC00008700"
+
+    def test_exchange_login_mapped_to_uid_alt(self, connector):
+        user = NAMED_USER.model_copy(update={"exchangeLogin": "AC00008700"})
+        result = connector.map_user_fields(user)
+        assert result is not None
+        assert result.user.uid_alt == "AC00008700"
+
+    def test_empty_exchange_login_produces_no_uid_alt(self, connector):
+        result = connector.map_user_fields(NAMED_USER)
+        assert result is not None
+        assert result.user.uid_alt is None
 
     def test_user_with_groups(self, connector):
         result = connector.map_user_fields(USER_WITH_GROUPS)
@@ -369,6 +470,15 @@ class TestFetchAllPages:
         items = list(connector._fetch_all_pages())
         assert len(items) == 2
         connector.client.list_directory_users.assert_called_once()
+
+    def test_include_group_ids_param_is_sent(self, connector):
+        _mock_list_users(
+            connector,
+            [{"items": [NAMED_USER_DICT], "pages": {"current": 1, "size": 50, "maxSize": 100}}],
+        )
+        list(connector._fetch_all_pages())
+        call_params = connector.client.list_directory_users.call_args[0][0]
+        assert call_params.get("includeGroupIds") is True
 
     def test_multi_page(self, connector):
         _mock_list_users(connector, [API_RESPONSE_PAGE1, API_RESPONSE_PAGE2])
@@ -524,6 +634,17 @@ class TestGetAssets:
         )
         assets = list(connector.get_assets())
         assert len(assets) == 2
+
+    def test_desktop_user_domain_in_user(self, connector):
+        """Local machine account has its computer name as user.domain."""
+        _mock_list_users(
+            connector,
+            [{"items": [WINDOWS_USER_DICT], "pages": {"current": 1, "size": 50, "maxSize": 100}}],
+        )
+        assets = list(connector.get_assets())
+        assert len(assets) == 1
+        assert assets[0].user.domain == "DESKTOP-ABC1234"
+        assert assets[0].user.type_id == UserTypeId.SYSTEM
 
     def test_second_run_yields_nothing_when_unchanged(self, connector):
         _seed_cache(

--- a/Sophos/tests/asset_connector/test_user_assets.py
+++ b/Sophos/tests/asset_connector/test_user_assets.py
@@ -250,8 +250,6 @@ class TestGetUserType:
         assert type_id == UserTypeId.SYSTEM
         assert type_str == UserTypeStr.SYSTEM
 
-
-
     def test_desktop_user_is_local(self):
         assert SophosUserAssetConnector._is_local_machine_account(WINDOWS_USER) is True
 


### PR DESCRIPTION
Linked issue : [issue](https://github.com/SekoiaLab/platform/issues/89124) 

- Map `exchangeLogin` to `user.uid_alt`
- Extract domain prefix from domain-qualified names into `user.domain`
- Detect AD domain accounts (`DOMAIN/username` format) as `LDAP_ACCOUNT` instead of `UNKNOWN`
- Classify local Windows machine accounts (`COMPUTERNAME\username`) as `UserTypeId.SYSTEM` instead of `USER`

## Summary by Sourcery

Improve Sophos user asset mapping with richer identifiers and more accurate classification of local vs directory accounts.

New Features:
- Map Sophos exchangeLogin to OCSF user.uid_alt as an alternate user identifier.
- Populate OCSF user.domain from the domain prefix in Sophos usernames using backslash or forward-slash formats.

Enhancements:
- Refine account type classification to treat AD domain-style usernames as LDAP accounts and keep non-local mixed formats as Unknown.
- Classify Windows local machine accounts as System users instead of regular User entries in the OCSF model.
- Include group IDs when fetching directory users to support accurate group membership mapping.
- Expand sample mappings and OCSF output examples to cover named, AD domain, and local machine accounts.

Build:
- Bump Sophos manifest version from 1.19.2 to 1.20.0 to reflect the new release.

Documentation:
- Update changelog for version 1.20.0 to document the new user mapping behavior and classifications.

Tests:
- Add unit tests covering AD user handling, local machine account detection, domain extraction logic, user type and account type classification, and mapping of exchangeLogin to uid_alt.
- Extend connector tests to validate updated mapping behavior, domain population, and the includeGroupIds query parameter.