### PR TITLE
Sekoia.io: add manual trigger for cases

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2026-06-23 - 2.73.5
+## 2026-06-23 - 2.74.0
 
 ### Added
 

--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-06-23 - 2.73.5
+
+### Added
+
+- Add Manual trigger for cases
+
 ## 2026-06-23 - 2.73.4
 
 ### Changed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.73.5",
+  "version": "2.74.0",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.73.4",
+  "version": "2.73.5",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/trigger_sekoiaio_case_webhook.json
+++ b/Sekoia.io/trigger_sekoiaio_case_webhook.json
@@ -1,0 +1,27 @@
+{
+  "arguments": {
+    "type": "object",
+    "title": "Trigger Arguments",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {}
+  },
+  "description": "Webhook Trigger to receive specific Sekoia.io Cases",
+  "name": "Manual Trigger for Case",
+  "docker_parameters": "case_webhook_trigger",
+  "results": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Results",
+    "type": "object",
+    "properties": {
+      "case_uuid": {
+        "description": "Unique identifier of the Case (UUID string).",
+        "type": "string"
+      }
+    },
+    "required": [
+      "case_uuid"
+    ]
+  },
+  "uuid": "511d6f60-2166-4a16-9815-f86b42e8f689",
+  "webhook": true
+}


### PR DESCRIPTION
Add manual triggers for cases

## Summary by Sourcery

Add a new manual trigger for Sekoia.io cases and release version 2.73.5.

New Features:
- Introduce a manual trigger for Sekoia.io case webhooks.

Enhancements:
- Update Sekoia.io integration version to 2.73.5 in the manifest.

Documentation:
- Document the new manual case trigger and version 2.73.5 in the changelog.