### PR TITLE
Feature: Eset User Asset Connector

### DIFF
--- a/Eset/CHANGELOG.md
+++ b/Eset/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-03 - 1.1.0
+
+### Added
+
+- Add ESET user asset connector.
+
 ## 2025-06-28 - 1.0.2
 
 ### Added

--- a/Eset/CONFIGURE.md
+++ b/Eset/CONFIGURE.md
@@ -21,3 +21,17 @@
     ![Step 4](docs/assets/Step04.png){: style="max-width:100%"}
 
 9. Click `CREATE`
+
+## Asset connectors
+
+The module provides two asset connectors that collect inventory from ESET Connect into Sekoia.io asset management. All of them authenticate with the module configuration (`region`, `username`, `password`) — no extra credentials are required. Each connector needs a Sekoia.io API key (`sekoia_api_key`) with asset-management write permission.
+
+### ESET Device
+
+Collects managed devices from the Device Management API (`{region}.device-management.eset.systems/v1/devices`) and maps them to OCSF Device Inventory Info assets.
+
+### ESET User
+
+Collects users from the User Management API (`{region}.user-management.eset.systems/v1/users`) and maps them to OCSF User Inventory Info assets, inferring the account type (Microsoft 365, Google Workspace, …) from each user's identity provider.
+
+> **Note:** The User Management API is only available on accounts with an **ESET Cloud Office Security (ECOS)** subscription — ESET users are the Microsoft 365 / Google Workspace identities synced through ECOS. Without an ECOS subscription the endpoint returns `501 Not Implemented`; the connector handles this gracefully (it logs a warning and collects no users), so it is safe to enable but will only produce assets once ECOS is in place.

--- a/Eset/connector_eset_user_assets.json
+++ b/Eset/connector_eset_user_assets.json
@@ -1,0 +1,37 @@
+{
+  "name": "ESET User",
+  "description": "Fetch ESET user assets (requires an ESET Cloud Office Security subscription)",
+  "uuid": "661ac982-171b-4308-9a77-6c28fa275a7f",
+  "docker_parameters": "eset_user_asset_connector",
+  "type": "asset",
+  "capability": "account_detection",
+  "arguments": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "sekoia_base_url": {
+        "description": "Sekoia base URL",
+        "type": "string"
+      },
+      "frequency": {
+        "type": "integer",
+        "description": "Batch frequency in seconds",
+        "minimum": 10800,
+        "default": 21600
+      },
+      "sekoia_api_key": {
+        "description": "API key to use from sekoia.io",
+        "type": "string"
+      },
+      "batch_size": {
+        "type": "integer",
+        "description": "Number of assets to process in one batch",
+        "minimum": 1,
+        "default": 100
+      }
+    },
+    "required": ["sekoia_api_key"],
+    "internal": ["sekoia_base_url", "sekoia_api_key", "frequency", "batch_size"],
+    "secrets": ["sekoia_api_key"]
+  }
+}

--- a/Eset/eset_modules/asset_connector/models.py
+++ b/Eset/eset_modules/asset_connector/models.py
@@ -179,3 +179,51 @@ class EsetDeviceGroupPage(BaseModel):
 
     class Config:
         extra = "allow"
+
+
+# --- User management models (/v1/users, ECOS-gated) ---
+
+
+class EsetUserIdentity(BaseModel):
+    type: Optional[str] = None
+    format: Optional[str] = None
+    reference: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class EsetUserCloudOffice(BaseModel):
+    tenantReference: Optional[str] = None
+    hasMsLicense: Optional[bool] = None
+
+    class Config:
+        extra = "allow"
+
+
+class EsetUser(BaseModel):
+    uuid: str
+    displayName: Optional[str] = None
+    primaryEmailAddress: Optional[str] = None
+    proxyEmailAddresses: Optional[list[str]] = None
+    identities: Optional[list[EsetUserIdentity]] = None
+    activeProductIds: Optional[list[str]] = None
+    userGroupUuids: Optional[list[str]] = None
+    cloudOffice: Optional[EsetUserCloudOffice] = None
+    department: Optional[str] = None
+    jobTitle: Optional[str] = None
+    officeLocation: Optional[str] = None
+    phoneNumbers: Optional[list[str]] = None
+    protectionStatus: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class EsetUserPage(BaseModel):
+    users: list[EsetUser] = []
+    nextPageToken: Optional[str] = None
+    totalSize: Optional[int] = None
+
+    class Config:
+        extra = "allow"

--- a/Eset/eset_modules/asset_connector/user_assets.py
+++ b/Eset/eset_modules/asset_connector/user_assets.py
@@ -1,0 +1,269 @@
+"""ESET user asset connector (ECOS-gated).
+
+ESET Connect API references:
+- List users:
+  https://help.eset.com/eset_connect/en-US/user_management_v1_users_get.html
+
+- User Management overview:
+  https://help.eset.com/eset_connect/en-US/user_management.html
+
+- Authenticate API user (OAuth token):
+  https://help.eset.com/eset_connect/en-US/authenticate_api_user.html
+
+- Create API user account (required permissions):
+  https://help.eset.com/eset_connect/en-US/create_api_user_account.html
+
+- Requires an ESET Cloud Office Security (ECOS) subscription; users are the
+  Microsoft 365 / Google Workspace identities synced via ECOS. Without it the
+  endpoint returns 501 Not Implemented:
+  https://help.eset.com/ecos/en-US/eset_connect.html
+
+- Release notes (User Management API available with ECOS subscription, ESET Connect 3.3):
+  https://help.eset.com/eset_connect/en-US/release_notes.html
+"""
+
+from collections.abc import Generator
+from datetime import datetime
+from functools import cached_property
+from typing import Optional
+from urllib.parse import urljoin
+
+from pydantic.v1 import ValidationError
+from requests.exceptions import HTTPError, RequestException
+from sekoia_automation.asset_connector import AssetConnector
+from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product
+from sekoia_automation.asset_connector.models.ocsf.group import Group
+from sekoia_automation.asset_connector.models.ocsf.user import (
+    Account,
+    AccountTypeId,
+    AccountTypeStr,
+    User,
+    UserEnrichmentObject,
+    UserOCSFModel,
+)
+from sekoia_automation.storage import PersistentJSON
+
+from eset_modules.asset_connector.models import EsetUser, EsetUserPage
+from eset_modules.client import ApiClient
+
+# HTTP statuses that mean "user management is not available on this account"
+# (no ESET Cloud Office Security subscription). Handle gracefully, don't crash.
+ECOS_UNAVAILABLE_STATUSES: frozenset[int] = frozenset({403, 501})
+
+
+class EsetUserAssetConnector(AssetConnector):
+
+    # Endpoint constants
+    USERS_ENDPOINT: str = "/v1/users"
+    DEFAULT_PAGE_SIZE: int = 1000
+
+    # Product constants
+    PRODUCT_NAME: str = "ESET"
+    METADATA_VERSION: str = "1.5.0"
+
+    # OCSF constants
+    ACTIVITY_ID: int = 2
+    ACTIVITY_NAME: str = "Collect"
+    CATEGORY_NAME: str = "Discovery"
+    CATEGORY_UID: int = 5
+    CLASS_NAME: str = "User Inventory Info"
+    CLASS_UID: int = 5003
+    TYPE_NAME: str = "User Inventory Info: Collect"
+    TYPE_UID: int = 500302
+
+    # ESET identity provider type -> OCSF account type
+    ACCOUNT_TYPE_MAP: dict[str, tuple[AccountTypeStr, AccountTypeId]] = {
+        "MICROSOFT": (AccountTypeStr.M365_TENANT, AccountTypeId.M365_TENANT),
+        "M365": (AccountTypeStr.M365_TENANT, AccountTypeId.M365_TENANT),
+        "OFFICE365": (AccountTypeStr.M365_TENANT, AccountTypeId.M365_TENANT),
+        "AZURE": (AccountTypeStr.AZURE_AD_ACCOUNT, AccountTypeId.AZURE_AD_ACCOUNT),
+        "GOOGLE": (AccountTypeStr.GOOGLE_WORKSPACE, AccountTypeId.GOOGLE_WORKSPACE),
+        "GSUITE": (AccountTypeStr.GOOGLE_WORKSPACE, AccountTypeId.GOOGLE_WORKSPACE),
+        "WORKSPACE": (AccountTypeStr.GOOGLE_WORKSPACE, AccountTypeId.GOOGLE_WORKSPACE),
+    }
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.context = PersistentJSON("eset_user_context.json", self._data_path)
+        self._latest_time: Optional[str] = None
+
+    @cached_property
+    def base_url(self) -> str:
+        region = self.module.configuration.region
+        return f"https://{region}.user-management.eset.systems"
+
+    @cached_property
+    def client(self) -> ApiClient:
+        region = self.module.configuration.region
+        return ApiClient(
+            auth_base_url=f"https://{region}.business-account.iam.eset.systems",
+            username=self.module.configuration.username,
+            password=self.module.configuration.password,
+        )
+
+    @cached_property
+    def metadata(self) -> Metadata:
+        return Metadata(
+            product=Product(name=self.PRODUCT_NAME),
+            version=self.METADATA_VERSION,
+        )
+
+    def _resolve_account_type(self, user: EsetUser) -> tuple[AccountTypeStr, AccountTypeId]:
+        """Infer the OCSF account type from the user's identity providers."""
+        if user.identities:
+            for identity in user.identities:
+                if not identity.type:
+                    continue
+                key = identity.type.upper()
+                for token, mapped in self.ACCOUNT_TYPE_MAP.items():
+                    if token in key:
+                        return mapped
+        return AccountTypeStr.OTHER, AccountTypeId.OTHER
+
+    @staticmethod
+    def _build_enrichments(user: EsetUser) -> Optional[list[UserEnrichmentObject]]:
+        enrichments: list[UserEnrichmentObject] = []
+        for name, value in (
+            ("department", user.department),
+            ("job_title", user.jobTitle),
+            ("office_location", user.officeLocation),
+            ("protection_status", user.protectionStatus),
+        ):
+            if value:
+                enrichments.append(UserEnrichmentObject(name=name, value=value))
+        return enrichments or None
+
+    def map_fields(self, user: EsetUser) -> UserOCSFModel:
+        """Map an ESET user to a full OCSF UserOCSFModel."""
+        name = user.displayName or user.primaryEmailAddress or user.uuid
+        account_type_str, account_type_id = self._resolve_account_type(user)
+
+        groups = None
+        if user.userGroupUuids:
+            groups = [Group(name=uuid, uid=uuid) for uuid in user.userGroupUuids]
+
+        ocsf_user = User(
+            name=name,
+            uid=user.uuid,
+            email_addr=user.primaryEmailAddress,
+            display_name=user.displayName,
+            groups=groups,
+            account=Account(
+                name=name,
+                uid=user.uuid,
+                type=account_type_str,
+                type_id=account_type_id,
+            ),
+        )
+
+        return UserOCSFModel(
+            activity_id=self.ACTIVITY_ID,
+            activity_name=self.ACTIVITY_NAME,
+            category_name=self.CATEGORY_NAME,
+            category_uid=self.CATEGORY_UID,
+            class_name=self.CLASS_NAME,
+            class_uid=self.CLASS_UID,
+            type_name=self.TYPE_NAME,
+            type_uid=self.TYPE_UID,
+            time=datetime.now().astimezone().timestamp(),
+            metadata=self.metadata,
+            user=ocsf_user,
+            enrichments=self._build_enrichments(user),
+        )
+
+    def _fetch_users(self) -> Generator[list[EsetUser], None, None]:
+        """Fetch all users with pagination. ECOS-gated: 403/501 yield nothing (no crash)."""
+        url = urljoin(self.base_url, self.USERS_ENDPOINT)
+        params: dict[str, str | int] = {"pageSize": self.DEFAULT_PAGE_SIZE}
+
+        self.log("Fetching ESET users", level="info")
+
+        try:
+            page_number = 1
+            while self.running:
+                response = self.client.get(url, params=params, timeout=60)
+
+                if response.status_code in ECOS_UNAVAILABLE_STATUSES:
+                    self.log(
+                        "ESET user management is unavailable on this account "
+                        f"(HTTP {response.status_code}). This API requires an ESET Cloud Office Security "
+                        "(ECOS) subscription — no users returned.",
+                        level="warning",
+                    )
+                    return
+
+                response.raise_for_status()
+                raw = response.json()
+
+                try:
+                    page = EsetUserPage.parse_obj(raw)
+                except ValidationError as e:
+                    self.log(f"Failed to parse users page {page_number}: {e}", level="warning")
+                    break
+
+                self.log(f"Retrieved page {page_number} - {len(page.users)} users", level="info")
+
+                if not page.users:
+                    break
+
+                yield page.users
+
+                if not page.nextPageToken:
+                    self.log(f"Pagination complete after {page_number} pages", level="info")
+                    break
+
+                params = {"pageSize": self.DEFAULT_PAGE_SIZE, "pageToken": page.nextPageToken}
+                page_number += 1
+
+        except HTTPError as e:
+            status = e.response.status_code if e.response is not None else None
+            if status in ECOS_UNAVAILABLE_STATUSES:
+                self.log(
+                    f"ESET user management is unavailable on this account (HTTP {status}). "
+                    "This API requires an ESET Cloud Office Security (ECOS) subscription — no users returned.",
+                    level="warning",
+                )
+                return
+            self.log(f"API request failed while fetching users: {e}", level="error")
+            raise
+        except RequestException as e:
+            self.log(f"API request failed while fetching users: {e}", level="error")
+            raise
+
+    def update_checkpoint(self) -> None:
+        """Users carry no modified-time field; store a last-run marker only."""
+        if self._latest_time:
+            with self.context as cache:
+                cache["last_run"] = self._latest_time
+            self.log(f"Checkpoint updated to: {self._latest_time}", level="debug")
+
+    def get_assets(self) -> Generator[UserOCSFModel, None, None]:
+        """Main entry point. Fetch ESET users and yield OCSF UserOCSFModel instances."""
+        self.log("Starting ESET user asset collection", level="info")
+
+        assets_generated = 0
+        assets_skipped = 0
+
+        try:
+            for users in self._fetch_users():
+                for user in users:
+                    try:
+                        yield self.map_fields(user)
+                        assets_generated += 1
+                    except (KeyError, ValueError) as e:
+                        assets_skipped += 1
+                        self.log(f"Asset skipped - UUID: {user.uuid}, Reason: {e}", level="warning")
+                        continue
+
+            self._latest_time = datetime.now().astimezone().isoformat()
+            self.log(
+                f"Asset collection complete - Generated: {assets_generated}, Skipped: {assets_skipped}",
+                level="info",
+            )
+
+        except Exception as e:
+            self.log(
+                f"Asset collection failed - Generated: {assets_generated}, Skipped: {assets_skipped}, Error: {e}",
+                level="error",
+            )
+            raise

--- a/Eset/eset_modules/asset_connector/user_mapping.yml
+++ b/Eset/eset_modules/asset_connector/user_mapping.yml
@@ -1,0 +1,140 @@
+mapping:
+  ocsf_class: "User Inventory Info"
+  class_uid: 5003
+  type_uid: 500302
+  ocsf_version: "1.5.0"
+
+  samples:
+    - name: "ESET User Sample"
+      description: "A sample user from the ESET GET /v1/users endpoint (requires an ESET Cloud Office Security subscription)"
+      data: |
+        {
+          "uuid": "user-uuid-1",
+          "displayName": "Jane Doe",
+          "primaryEmailAddress": "jane.doe@example.com",
+          "proxyEmailAddresses": ["j.doe@example.com"],
+          "identities": [
+            {
+              "type": "MICROSOFT",
+              "format": "IDENTITY_FORMAT_EMAIL",
+              "reference": "jane.doe@example.com"
+            }
+          ],
+          "activeProductIds": ["prod-1"],
+          "userGroupUuids": ["group-a", "group-b"],
+          "cloudOffice": {
+            "tenantReference": "tenant-1",
+            "hasMsLicense": true
+          },
+          "department": "Finance",
+          "jobTitle": "Analyst",
+          "officeLocation": "HQ",
+          "phoneNumbers": ["+1-555-0100"],
+          "protectionStatus": "PROTECTION_STATUS_PROTECTED"
+        }
+
+  fields:
+    - source: "displayName / primaryEmailAddress / uuid"
+      target: "user.name"
+      type: "string"
+      logic: "Uses displayName; falls back to primaryEmailAddress, then uuid"
+      description: "Display name used as the OCSF user name"
+
+    - source: "uuid"
+      target: "user.uid / user.account.uid"
+      type: "string"
+      logic: "Direct mapping — ESET user UUID becomes the OCSF user UID"
+      description: "Unique identifier of the user"
+
+    - source: "primaryEmailAddress"
+      target: "user.email_addr"
+      type: "string"
+      logic: "Direct mapping"
+      description: "Primary email address of the user"
+
+    - source: "displayName"
+      target: "user.display_name"
+      type: "string"
+      logic: "Direct mapping"
+      description: "Human-readable display name"
+
+    - source: "identities[].type"
+      target: "user.account.type / user.account.type_id"
+      type: "string / integer"
+      logic: >-
+        Inferred from the identity provider: MICROSOFT/M365/OFFICE365 → M365 Tenant (17);
+        AZURE → Azure AD Account (6); GOOGLE/GSUITE/WORKSPACE → Google Workspace (15);
+        otherwise → Other (99).
+      description: "OCSF account type derived from the user's identity provider"
+
+    - source: "userGroupUuids"
+      target: "user.groups"
+      type: "list[Group]"
+      logic: "Each group UUID becomes an OCSF Group with name=uid=UUID"
+      description: "Groups the user belongs to"
+
+    - source: "department / jobTitle / officeLocation / protectionStatus"
+      target: "enrichments[]"
+      type: "list[UserEnrichmentObject]"
+      logic: "Each non-empty attribute is added as an enrichment (name/value pair)"
+      description: "Additional user attributes captured as enrichments"
+
+    - source: "static: ESET"
+      target: "metadata.product.name"
+      type: "string"
+      logic: "Static value"
+      description: "Product name in OCSF metadata"
+
+    - source: "static: 2 / Collect"
+      target: "activity_id / activity_name"
+      type: "integer / string"
+      logic: "User inventory collection maps to OCSF activity Collect (2)"
+      description: "OCSF activity classification"
+
+    - source: "static: 5003 / User Inventory Info"
+      target: "class_uid / class_name"
+      type: "integer / string"
+      logic: "Static OCSF class for user inventory"
+      description: "OCSF class classification"
+
+  ocsf_samples:
+    - name: "Transformed OCSF User Output"
+      description: "The OCSF UserOCSFModel produced after transformation"
+      data: |
+        {
+          "activity_id": 2,
+          "activity_name": "Collect",
+          "category_name": "Discovery",
+          "category_uid": 5,
+          "class_name": "User Inventory Info",
+          "class_uid": 5003,
+          "type_name": "User Inventory Info: Collect",
+          "type_uid": 500302,
+          "time": 1747821600.0,
+          "metadata": {
+            "product": { "name": "ESET" },
+            "version": "1.5.0"
+          },
+          "user": {
+            "name": "Jane Doe",
+            "uid": "user-uuid-1",
+            "email_addr": "jane.doe@example.com",
+            "display_name": "Jane Doe",
+            "groups": [
+              { "name": "group-a", "uid": "group-a" },
+              { "name": "group-b", "uid": "group-b" }
+            ],
+            "account": {
+              "name": "Jane Doe",
+              "uid": "user-uuid-1",
+              "type": "M365 Tenant",
+              "type_id": 17
+            }
+          },
+          "enrichments": [
+            { "name": "department", "value": "Finance" },
+            { "name": "job_title", "value": "Analyst" },
+            { "name": "office_location", "value": "HQ" },
+            { "name": "protection_status", "value": "PROTECTION_STATUS_PROTECTED" }
+          ]
+        }

--- a/Eset/main.py
+++ b/Eset/main.py
@@ -4,6 +4,7 @@ from eset_modules.action_deisolate_endpoint import EsetDeIsolateEndpointAction
 from eset_modules.action_isolate_endpoint import EsetIsolateEndpointAction
 from eset_modules.action_scan import EsetScanAction
 from eset_modules.asset_connector.device_assets import EsetDeviceAssetConnector
+from eset_modules.asset_connector.user_assets import EsetUserAssetConnector
 
 if __name__ == "__main__":
     module = EsetModule()
@@ -11,5 +12,6 @@ if __name__ == "__main__":
     module.register(EsetIsolateEndpointAction, "EsetIsolateEndpointAction")
     module.register(EsetDeIsolateEndpointAction, "EsetDeIsolateEndpointAction")
     module.register(EsetDeviceAssetConnector, "eset_device_asset_connector")
+    module.register(EsetUserAssetConnector, "eset_user_asset_connector")
     module.register_account_validator(EsetAccountValidator)
     module.run()

--- a/Eset/manifest.json
+++ b/Eset/manifest.json
@@ -38,7 +38,7 @@
   "description": "ESET is a global cybersecurity company known for its antivirus and security software solutions for both businesses and consumers, providing advanced threat detection and malware protection.",
   "name": "Eset",
   "uuid": "91140c5a-770f-44c6-81ce-ea57daf3fe34",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "slug": "eset",
   "categories": [
     "Endpoint"

--- a/Eset/tests/asset_connector/test_user_assets.py
+++ b/Eset/tests/asset_connector/test_user_assets.py
@@ -1,0 +1,220 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+import requests_mock as requests_mock_module
+from sekoia_automation.asset_connector.models.ocsf.user import AccountTypeId, UserOCSFModel
+
+from eset_modules import EsetModule
+from eset_modules.asset_connector.models import EsetUser, EsetUserIdentity
+from eset_modules.asset_connector.user_assets import EsetUserAssetConnector
+
+
+@pytest.fixture
+def data_storage(tmp_path):
+    return tmp_path
+
+
+@pytest.fixture
+def test_connector(data_storage):
+    module = EsetModule()
+    module.configuration = {
+        "region": "eu",
+        "username": "testuser",
+        "password": "testpassword",
+    }
+
+    connector = EsetUserAssetConnector(module=module, data_path=data_storage)
+    connector.configuration = {
+        "sekoia_base_url": "https://sekoia.io",
+        "sekoia_api_key": "fake_api_key",
+        "frequency": 60,
+    }
+
+    connector.log = Mock()
+    connector.log_exception = Mock()
+
+    connector.__dict__["client"] = requests.Session()
+
+    yield connector
+
+
+@pytest.fixture
+def sample_user() -> EsetUser:
+    return EsetUser(
+        uuid="user-1",
+        displayName="Jane Doe",
+        primaryEmailAddress="jane@example.com",
+        userGroupUuids=["group-a", "group-b"],
+        department="Finance",
+        jobTitle="Analyst",
+        officeLocation="HQ",
+        identities=[EsetUserIdentity(type="MICROSOFT", reference="jane@example.com")],
+    )
+
+
+@pytest.fixture
+def sample_users_response():
+    return {
+        "users": [
+            {
+                "uuid": "user-1",
+                "displayName": "Jane Doe",
+                "primaryEmailAddress": "jane@example.com",
+                "userGroupUuids": ["group-a"],
+                "identities": [{"type": "MICROSOFT", "reference": "jane@example.com"}],
+            }
+        ],
+        "nextPageToken": None,
+        "totalSize": 1,
+    }
+
+
+# --- account type inference ---
+
+
+@pytest.mark.parametrize(
+    "provider,expected_id",
+    [
+        ("MICROSOFT", AccountTypeId.M365_TENANT),
+        ("m365", AccountTypeId.M365_TENANT),
+        ("Office365", AccountTypeId.M365_TENANT),
+        ("GOOGLE", AccountTypeId.GOOGLE_WORKSPACE),
+        ("google_workspace", AccountTypeId.GOOGLE_WORKSPACE),
+        ("AZURE_AD", AccountTypeId.AZURE_AD_ACCOUNT),
+        ("something", AccountTypeId.OTHER),
+    ],
+)
+def test_resolve_account_type(test_connector, provider, expected_id):
+    user = EsetUser(uuid="u", identities=[EsetUserIdentity(type=provider)])
+    _, type_id = test_connector._resolve_account_type(user)
+    assert type_id == expected_id
+
+
+def test_resolve_account_type_no_identities(test_connector):
+    _, type_id = test_connector._resolve_account_type(EsetUser(uuid="u"))
+    assert type_id == AccountTypeId.OTHER
+
+
+# --- map_fields ---
+
+
+def test_map_fields_classification(test_connector, sample_user):
+    result = test_connector.map_fields(sample_user)
+    assert isinstance(result, UserOCSFModel)
+    assert result.class_uid == 5003
+    assert result.category_uid == 5
+    assert result.type_uid == 500302
+    assert result.activity_id == 2
+
+
+def test_map_fields_user_and_account(test_connector, sample_user):
+    result = test_connector.map_fields(sample_user)
+    assert result.user.uid == "user-1"
+    assert result.user.name == "Jane Doe"
+    assert result.user.email_addr == "jane@example.com"
+    assert result.user.account.type_id == AccountTypeId.M365_TENANT
+    assert result.user.groups is not None
+    assert {g.uid for g in result.user.groups} == {"group-a", "group-b"}
+
+
+def test_map_fields_enrichments(test_connector, sample_user):
+    result = test_connector.map_fields(sample_user)
+    assert result.enrichments is not None
+    names = {e.name: e.value for e in result.enrichments}
+    assert names["department"] == "Finance"
+    assert names["job_title"] == "Analyst"
+    assert names["office_location"] == "HQ"
+
+
+def test_map_fields_name_fallback_to_email(test_connector):
+    user = EsetUser(uuid="u", primaryEmailAddress="x@y.com")
+    result = test_connector.map_fields(user)
+    assert result.user.name == "x@y.com"
+
+
+def test_map_fields_name_fallback_to_uuid(test_connector):
+    result = test_connector.map_fields(EsetUser(uuid="only-uuid"))
+    assert result.user.name == "only-uuid"
+
+
+def test_map_fields_no_enrichments(test_connector):
+    result = test_connector.map_fields(EsetUser(uuid="u"))
+    assert result.enrichments is None
+
+
+def test_map_fields_json_serializable(test_connector, sample_user):
+    result = test_connector.map_fields(sample_user)
+    assert json.dumps(result.model_dump())
+
+
+# --- fetch / ECOS gating ---
+
+
+def test_fetch_users_single_page(test_connector, sample_users_response):
+    with requests_mock_module.Mocker() as m:
+        m.get(f"{test_connector.base_url}/v1/users", json=sample_users_response)
+        pages = list(test_connector._fetch_users())
+
+    assert len(pages) == 1
+    assert pages[0][0].uuid == "user-1"
+
+
+def test_fetch_users_pagination(test_connector):
+    page1 = {"users": [{"uuid": "u1"}], "nextPageToken": "tok"}
+    page2 = {"users": [{"uuid": "u2"}], "nextPageToken": None}
+    with requests_mock_module.Mocker() as m:
+        m.get(f"{test_connector.base_url}/v1/users", [{"json": page1}, {"json": page2}])
+        pages = list(test_connector._fetch_users())
+
+    assert len(pages) == 2
+
+
+@pytest.mark.parametrize("status", [403, 501])
+def test_fetch_users_ecos_unavailable_yields_nothing(test_connector, status):
+    with requests_mock_module.Mocker() as m:
+        m.get(f"{test_connector.base_url}/v1/users", status_code=status)
+        pages = list(test_connector._fetch_users())
+
+    assert pages == []
+    test_connector.log.assert_called()
+
+
+def test_fetch_users_server_error_raises(test_connector):
+    with requests_mock_module.Mocker() as m:
+        m.get(f"{test_connector.base_url}/v1/users", status_code=500)
+        with pytest.raises(Exception):
+            list(test_connector._fetch_users())
+
+
+# --- get_assets ---
+
+
+def test_get_assets_yields_ocsf(test_connector, sample_users_response):
+    with requests_mock_module.Mocker() as m:
+        m.get(f"{test_connector.base_url}/v1/users", json=sample_users_response)
+        assets = list(test_connector.get_assets())
+
+    assert len(assets) == 1
+    assert isinstance(assets[0], UserOCSFModel)
+    assert assets[0].user.uid == "user-1"
+
+
+@pytest.mark.parametrize("status", [403, 501])
+def test_get_assets_ecos_unavailable_empty(test_connector, status):
+    with requests_mock_module.Mocker() as m:
+        m.get(f"{test_connector.base_url}/v1/users", status_code=status)
+        assets = list(test_connector.get_assets())
+
+    assert assets == []
+
+
+def test_update_checkpoint_persists_last_run(test_connector, sample_users_response):
+    with requests_mock_module.Mocker() as m:
+        m.get(f"{test_connector.base_url}/v1/users", json=sample_users_response)
+        list(test_connector.get_assets())
+        test_connector.update_checkpoint()
+
+    with test_connector.context as cache:
+        assert cache.get("last_run") is not None


### PR DESCRIPTION
Relates to [1640](https://github.com/SekoiaLab/integration/issues/1640)

## Summary by Sourcery

Introduce a new ESET user asset connector that ingests users from the ESET User Management API into Sekoia.io asset management and updates module metadata accordingly.

New Features:
- Add models, mapping, and implementation for collecting ESET users and transforming them into OCSF User Inventory Info assets.
- Register the ESET user asset connector in the module entrypoint and expose its connector definition.
- Document the available asset connectors and the ECOS requirement for the ESET User connector in the configuration guide.

Enhancements:
- Update the module version to 1.1.0 and record the new user asset connector in the changelog.

Documentation:
- Add a user mapping specification and sample OCSF output for the ESET user asset connector.

Tests:
- Add unit tests covering user account-type inference, field mapping, pagination, ECOS-gated behavior, and checkpoint persistence for the user asset connector.