### PR TITLE
Check for uv.lock in addition to poetry.lock

### DIFF
--- a/_utils/compliance/validators/deps.py
+++ b/_utils/compliance/validators/deps.py
@@ -16,7 +16,7 @@ class DependenciesValidator(Validator):
 
         pyproject = module_dir / "pyproject.toml"
         poetry_lock = module_dir / "poetry.lock"
-        uv_lock = module_path / "uv.lock"
+        uv_lock = module_dir / "uv.lock"
 
         if not pyproject.is_file():
             result.errors.append(

--- a/_utils/compliance/validators/deps.py
+++ b/_utils/compliance/validators/deps.py
@@ -16,13 +16,14 @@ class DependenciesValidator(Validator):
 
         pyproject = module_dir / "pyproject.toml"
         poetry_lock = module_dir / "poetry.lock"
+        uv_lock = module_path / "uv.lock"
 
         if not pyproject.is_file():
             result.errors.append(
                 CheckError(filepath=pyproject, error="pyproject.toml is missing")
             )
 
-        if not poetry_lock.is_file():
+        if not poetry_lock.is_file() and not uv_lock.is_file():
             result.errors.append(
                 CheckError(filepath=pyproject, error="poetry.lock is missing")
             )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Relax lockfile presence check to avoid errors when uv.lock is used instead of poetry.lock.