### PR TITLE
Fix/client microsoft ad

### DIFF
--- a/MicrosoftActiveDirectory/CHANGELOG.md
+++ b/MicrosoftActiveDirectory/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-07 - 1.5.6
+
+### Fixed
+
+- Reconnect LDAP connection automatically when the socket is closed between asset fetch cycles
+
 ## 2026-07-06 - 1.5.5
 
 ### Fixed

--- a/MicrosoftActiveDirectory/manifest.json
+++ b/MicrosoftActiveDirectory/manifest.json
@@ -32,7 +32,7 @@
   "name": "Microsoft Active Directory",
   "uuid": "b2d96259-af89-4f7a-ae6e-a0af2d2400f3",
   "slug": "microsoft-ad",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftActiveDirectory/microsoft_ad/account_validator.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/account_validator.py
@@ -4,7 +4,6 @@ from microsoft_ad.client.ldap_client import LDAPClient
 from sekoia_automation.account_validator import AccountValidator
 
 
-
 class MicrosoftADAccountValidator(AccountValidator, LDAPClient):
     """Account validator for Microsoft AD asset connector."""
 

--- a/MicrosoftActiveDirectory/microsoft_ad/account_validator.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/account_validator.py
@@ -1,11 +1,8 @@
-# Import ldap3 exceptions
 from ldap3.core.exceptions import LDAPBindError, LDAPSocketOpenError
+from microsoft_ad.client.ldap_client import LDAPClient
 
-# Import sekoia libraries
 from sekoia_automation.account_validator import AccountValidator
 
-# Import internal classes, functions, and models
-from microsoft_ad.client.ldap_client import LDAPClient
 
 
 class MicrosoftADAccountValidator(AccountValidator, LDAPClient):
@@ -29,19 +26,16 @@ class MicrosoftADAccountValidator(AccountValidator, LDAPClient):
                 level="info",
             )
             return True
-        # Handle lDAP Timeout Error
         except LDAPSocketOpenError as ldap_socket_timeout_err:
             self.log(message=f"LDAP socket timeout error : {ldap_socket_timeout_err}", level="error")
             self.error(
                 message=f"Failed to validate Microsoft AD credentials due to LDAP timeout error: {ldap_socket_timeout_err}"
             )
             return False
-        # Handle LDAP Bind Error
         except LDAPBindError as bind_err:
             self.log(message=f"LDAP bind error : {bind_err}", level="error")
             self.error(message=f"Failed to validate Microsoft AD credentials due to LDAP bind error: {bind_err}")
             return False
-        # Handle any other exceptions
         except Exception as ldap_error:
             self.log(message=f"Failed to validate Microsoft AD credentials : {ldap_error}", level="error")
             self.error(message=f"Failed to validate Microsoft AD credentials due to unknown error: {ldap_error}")

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from typing import Any
 
 from ldap3 import ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES
+from ldap3.core.exceptions import LDAPSocketOpenError
 from sekoia_automation.asset_connector import AssetConnector
 from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product
 from sekoia_automation.asset_connector.models.ocsf.group import Group
@@ -284,13 +285,8 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
 
         return user_ocsf_model
 
-    def get_users_generator(self) -> Generator[dict[str, Any], None, None]:
-
-        self.log("Starting LDAP paged search for users...", level="info")
-
-        # Create paged search generator
-        # pagination is handled internally by ldap3
-        paged_search = self.ldap_client.extend.standard.paged_search(
+    def _run_paged_search(self) -> Generator[dict[str, Any], None, None]:
+        return self.ldap_client.extend.standard.paged_search(
             search_base=self.configuration.basedn,
             search_filter=self.user_ldap_query,
             attributes=self.QUERY_ATTRIBUTES,
@@ -298,7 +294,20 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
             generator=True,
         )
 
-        for entry in paged_search:
+    def get_users_generator(self) -> Generator[dict[str, Any], None, None]:
+
+        self.log("Starting LDAP paged search for users...", level="info")
+
+        try:
+            paged_search = self._run_paged_search()
+            entries = list(paged_search)
+        except LDAPSocketOpenError:
+            self.log("LDAP socket closed, reconnecting...", level="warning")
+            self._reset_ldap_connection()
+            paged_search = self._run_paged_search()
+            entries = list(paged_search)
+
+        for entry in entries:
             user_attributes = entry.get("attributes", {})
             if not user_attributes:
                 self.log("No user attributes found for user", level="error")

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -298,15 +298,26 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
 
         self.log("Starting LDAP paged search for users...", level="info")
 
-        try:
-            paged_search = self._run_paged_search()
-            entries = list(paged_search)
-        except LDAPSocketOpenError:
-            self.log("LDAP socket closed, reconnecting...", level="warning")
-            self._reset_ldap_connection()
-            paged_search = self._run_paged_search()
-            entries = list(paged_search)
+        seen_dns: set[str] = set()
 
+        def _entries() -> Generator[dict[str, Any], None, None]:
+            for attempt in range(2):
+                try:
+                    for entry in self._run_paged_search():
+                        dn = entry.get("dn")
+                        if dn is not None:
+                            if dn in seen_dns:
+                                continue
+                            seen_dns.add(dn)
+                        yield entry
+                    return
+                except LDAPSocketOpenError as exc:
+                    if attempt == 1:
+                        raise
+                    self.log(f"LDAP socket closed, reconnecting... ({exc})", level="warning")
+                    self._reset_ldap_connection()
+
+        entries = _entries()
         for entry in entries:
             user_attributes = entry.get("attributes", {})
             if not user_attributes:

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -119,16 +119,12 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
             list[UserEnrichmentObject]: List of user enrichment objects.
         """
         pwd_last_set = user_attributes.pwdLastSet
-        last_time_password_change = (
-            float(int(pwd_last_set.timestamp())) if pwd_last_set and pwd_last_set.year > 1601 else None
-        )
 
         data = UserDataObject(
             is_enabled=self.compute_enabling_condition(user_attributes),
             last_logon=self.convert_last_logon_to_timestamp(user_attributes.lastLogon),
             bad_password_count=user_attributes.badPwdCount,
             number_of_logons=user_attributes.logonCount,
-            last_time_password_change=last_time_password_change,
         )
         user_object = UserEnrichmentObject(name="login", value="infos", data=data)
         return [user_object]
@@ -294,31 +290,31 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
             generator=True,
         )
 
+    def _entries(self) -> Generator[dict[str, Any], None, None]:
+
+        seen_dn: set[str] = set()
+
+        for attempt in range(2):
+            try:
+                for entry in self._run_paged_search():
+                    dn = entry.get("dn")
+                    if dn is not None:
+                        if dn in seen_dn:
+                            continue
+                        seen_dn.add(dn)
+                    yield entry
+                return
+            except LDAPSocketOpenError as exc:
+                if attempt == 1:
+                    raise
+                self.log(f"LDAP socket closed, reconnecting... ({exc})", level="warning")
+                self._reset_ldap_connection()
+
     def get_users_generator(self) -> Generator[dict[str, Any], None, None]:
 
         self.log("Starting LDAP paged search for users...", level="info")
 
-        seen_dns: set[str] = set()
-
-        def _entries() -> Generator[dict[str, Any], None, None]:
-            for attempt in range(2):
-                try:
-                    for entry in self._run_paged_search():
-                        dn = entry.get("dn")
-                        if dn is not None:
-                            if dn in seen_dns:
-                                continue
-                            seen_dns.add(dn)
-                        yield entry
-                    return
-                except LDAPSocketOpenError as exc:
-                    if attempt == 1:
-                        raise
-                    self.log(f"LDAP socket closed, reconnecting... ({exc})", level="warning")
-                    self._reset_ldap_connection()
-
-        entries = _entries()
-        for entry in entries:
+        for entry in self._entries():
             user_attributes = entry.get("attributes", {})
             if not user_attributes:
                 self.log("No user attributes found for user", level="error")

--- a/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 
 from ldap3 import Connection, Server
+from ldap3.core.exceptions import LDAPSocketOpenError
 
 from microsoft_ad.models.common_models import MicrosoftADModule
 
@@ -28,6 +29,13 @@ class LDAPClient:
 
     @property
     def ldap_client(self) -> Connection:
-        if self._ldap_client is None or not self._ldap_client.bound:
+        if self._ldap_client is None:
             self._ldap_client = self._create_ldap_connection()
         return self._ldap_client
+
+    @ldap_client.setter
+    def ldap_client(self, value: Connection) -> None:
+        self._ldap_client = value
+
+    def _reset_ldap_connection(self) -> None:
+        self._ldap_client = None

--- a/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
@@ -36,9 +36,9 @@ class LDAPClient:
     def ldap_client(self, value: Connection) -> None:
         self._ldap_client = value
 
-def _reset_ldap_connection(self) -> None:
-    if self._ldap_client is not None:
-        try:
-            self._ldap_client.unbind()
-        finally:
-            self._ldap_client = None
+    def _reset_ldap_connection(self) -> None:
+        if self._ldap_client is not None:
+            try:
+                self._ldap_client.unbind()
+            finally:
+                self._ldap_client = None

--- a/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
@@ -8,6 +8,8 @@ from microsoft_ad.models.common_models import MicrosoftADModule
 class LDAPClient:
     module: MicrosoftADModule
 
+    _ldap_client: Connection | None = None
+
     @cached_property
     def ldap_server(self) -> Server:
         return Server(
@@ -16,11 +18,16 @@ class LDAPClient:
             use_ssl=True,
         )
 
-    @cached_property
-    def ldap_client(self) -> Connection:
+    def _create_ldap_connection(self) -> Connection:
         return Connection(
             self.ldap_server,
             auto_bind=True,
             user=self.module.configuration.admin_username,
             password=self.module.configuration.admin_password,
         )
+
+    @property
+    def ldap_client(self) -> Connection:
+        if self._ldap_client is None or not self._ldap_client.bound:
+            self._ldap_client = self._create_ldap_connection()
+        return self._ldap_client

--- a/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
@@ -1,7 +1,6 @@
 from functools import cached_property
 
 from ldap3 import Connection, Server
-from ldap3.core.exceptions import LDAPSocketOpenError
 
 from microsoft_ad.models.common_models import MicrosoftADModule
 

--- a/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/client/ldap_client.py
@@ -36,5 +36,9 @@ class LDAPClient:
     def ldap_client(self, value: Connection) -> None:
         self._ldap_client = value
 
-    def _reset_ldap_connection(self) -> None:
-        self._ldap_client = None
+def _reset_ldap_connection(self) -> None:
+    if self._ldap_client is not None:
+        try:
+            self._ldap_client.unbind()
+        finally:
+            self._ldap_client = None


### PR DESCRIPTION
Linked issue: [issue](https://github.com/SekoiaLab/platform/issues/88990)

## Summary by Sourcery

Ensure the Microsoft Active Directory LDAP client automatically re-establishes connections and release a new patch version documenting the fix.

Bug Fixes:
- Reconnect the LDAP client when the existing connection is unbound or closed during asset fetch cycles.

Build:
- Bump the Microsoft Active Directory integration version to 1.5.6.

Documentation:
- Document the LDAP auto-reconnection fix in the Microsoft Active Directory changelog.