### PR TITLE
feat(harfanglab): add feature flag

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-07 - 1.31.7
+
+### Changed
+
+- Add `feature-flag` to the software asset connector
+
 ## 2026-07-03 - 1.31.6
 
 ### Fixed

--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2026-07-07 - 1.31.7
 
-### Changed
+### Added
 
 - Add `feature-flag` to the software asset connector
 

--- a/HarfangLab/connector_harfanglab_software_assets.json
+++ b/HarfangLab/connector_harfanglab_software_assets.json
@@ -33,5 +33,6 @@
     "required": ["sekoia_api_key"],
     "secrets": ["sekoia_api_key"],
     "internal": ["sekoia_base_url", "sekoia_api_key", "frequency", "batch_size"]
-  }
+  },
+  "feature-flag": true
 }

--- a/HarfangLab/connector_harfanglab_software_assets.json
+++ b/HarfangLab/connector_harfanglab_software_assets.json
@@ -34,5 +34,5 @@
     "secrets": ["sekoia_api_key"],
     "internal": ["sekoia_base_url", "sekoia_api_key", "frequency", "batch_size"]
   },
-  "feature-flag": true
+  "feature-flag": ["reveal-application-discovery"]
 }

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.31.6",
+  "version": "1.31.7",
   "categories": [
     "Endpoint"
   ],


### PR DESCRIPTION
Linked issue : [issue](https://github.com/SekoiaLab/platform/issues/88780#issuecomment-4903791235)

Test with the first asset connector

## Summary by Sourcery

Add a feature-flag capability to the HarfangLab software asset connector and bump its version.

New Features:
- Introduce a feature-flag configuration on the HarfangLab software asset connector.

Documentation:
- Document the new feature-flag support in the HarfangLab changelog.