### PR TITLE
Sekoia.io: Guard GetAsset.run() against empty asset_uuid

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-07 - 2.74.1
+
+### Fixed
+
+- `GetAsset` action no longer issues an HTTP request when called with an empty `asset_uuid`; it now returns `None` with an error instead
+
 ## 2026-06-23 - 2.74.0
 
 ### Added

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.74.0",
+  "version": "2.74.1",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/get_asset.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_asset.py
@@ -87,4 +87,7 @@ class GetAsset(Action):
 
     def run(self, arguments: dict):
         asset_uuid = arguments.get("uuid")
+        if not asset_uuid:
+            self.error("Asset uuid is required")
+            return None
         return self.transform_asset(self.perform_request(asset_uuid))

--- a/Sekoia.io/tests/operation_center_action/test_get_asset.py
+++ b/Sekoia.io/tests/operation_center_action/test_get_asset.py
@@ -80,6 +80,16 @@ def test_get_asset_by_uuid_returns_none_if_http_error(requests_mock):
     assert results == None
 
 
+def test_get_asset_by_uuid_returns_none_if_uuid_empty(requests_mock):
+    action = GetAsset()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    arguments = {"uuid": ""}
+
+    results: dict = action.run(arguments)
+    assert results is None
+    assert requests_mock.call_count == 0
+
+
 def test_get_asset_transforms_criticity_levels(requests_mock):
     action = GetAsset()
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}


### PR DESCRIPTION
## Summary
- `GetAsset.perform_request()` was called even when `asset_uuid` was empty/missing, issuing an HTTP GET with an empty uuid segment in the URL.
- Added an early guard in `GetAsset.run()`: if `asset_uuid` is empty, call `self.error("Asset uuid is required")` and return `None` immediately, without invoking `perform_request()`.
- Added a unit test asserting `run()` returns `None` and no HTTP request is made when `uuid` is empty.

## Testing
- `poetry run pytest tests/operation_center_action/test_get_asset.py` — all 4 tests pass.

## Summary by Sourcery

Guard the Sekoia.io GetAsset action against empty asset UUID inputs to avoid issuing invalid HTTP requests and surface a clear error instead.

Bug Fixes:
- Prevent GetAsset from performing an HTTP request when the provided asset UUID is empty or missing.

Tests:
- Add a unit test verifying GetAsset.run() returns None and performs no HTTP requests when called with an empty UUID argument.