### PR TITLE
fix(MicrosoftAD): fix duplication of assets

### DIFF
--- a/MicrosoftActiveDirectory/CHANGELOG.md
+++ b/MicrosoftActiveDirectory/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-09 - 1.5.7
+
+### Fixed
+
+- Fix duplication of assets by adding a cache in the context
+
 ## 2026-07-07 - 1.5.6
 
 ### Fixed

--- a/MicrosoftActiveDirectory/manifest.json
+++ b/MicrosoftActiveDirectory/manifest.json
@@ -32,7 +32,7 @@
   "name": "Microsoft Active Directory",
   "uuid": "b2d96259-af89-4f7a-ae6e-a0af2d2400f3",
   "slug": "microsoft-ad",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -48,11 +48,17 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("context.json", self._data_path)
         self._latest_time: str | None = None
+        self._seen_sids: set[str] = set()
 
     @property
     def most_recent_datetime(self) -> str | None:
         with self.context as cache:
             return cache.get("most_recent_datetime", None)
+
+    @property
+    def seen_sids_at_checkpoint(self) -> set[str]:
+        with self.context as cache:
+            return set(cache.get("seen_sids_at_checkpoint", []))
 
     @property
     def user_ldap_query(self) -> str:
@@ -64,13 +70,15 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
         if self._latest_time is None:
             return
 
-        # Increment latest_time by 1 millisecond to avoid duplicates
-        to_datetime = datetime.datetime.strptime(self._latest_time, "%Y%m%d%H%M%S.0Z")
-        to_datetime += datetime.timedelta(milliseconds=1)
-        updated_time = to_datetime.strftime("%Y%m%d%H%M%S.0Z")
-
         with self.context as cache:
-            cache["most_recent_datetime"] = updated_time
+            previous_checkpoint = cache.get("most_recent_datetime")
+
+            if self._latest_time == previous_checkpoint:
+                existing_sids = set(cache.get("seen_sids_at_checkpoint", []))
+                cache["seen_sids_at_checkpoint"] = list(existing_sids | self._seen_sids)
+            else:
+                cache["most_recent_datetime"] = self._latest_time
+                cache["seen_sids_at_checkpoint"] = list(self._seen_sids)
 
     def user_metadata_object(self) -> Metadata:
         """
@@ -314,23 +322,40 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
 
         self.log("Starting LDAP paged search for users...", level="info")
 
+        checkpoint_time = self.most_recent_datetime
+        already_seen_sids = self.seen_sids_at_checkpoint
+
         for entry in self._entries():
             user_attributes = entry.get("attributes", {})
             if not user_attributes:
                 self.log("No user attributes found for user", level="error")
                 raise Exception("No user attributes found for user")
 
+            user_created_at = user_attributes.get("whenCreated")
+            if user_created_at:
+                user_created_str = user_created_at.strftime("%Y%m%d%H%M%S.0Z")
+                if user_created_str == checkpoint_time:
+                    sid = user_attributes.get("objectSid")
+                    if sid and sid in already_seen_sids:
+                        self.log(
+                            f"Skipping already-seen user (SID={sid}) at boundary second {checkpoint_time}",
+                            level="debug",
+                        )
+                        continue
+
             self.log(f"User with DN {entry.get('dn')} retrieved.", level="debug")
             yield entry
 
-            user_created_at = user_attributes.get("whenCreated")
             self.log(f"Start updating checkpoint with the new date {user_created_at}", level="debug")
 
-            # Update latest time for checkpointing
             if user_created_at:
                 user_created_str = user_created_at.strftime("%Y%m%d%H%M%S.0Z")
+                sid = user_attributes.get("objectSid")
                 if not self._latest_time or user_created_str > self._latest_time:
                     self._latest_time = user_created_str
+                    self._seen_sids = {sid} if sid else set()
+                elif user_created_str == self._latest_time and sid:
+                    self._seen_sids.add(sid)
 
     def get_assets(self) -> Generator[UserOCSFModel, None, None]:
         """

--- a/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
+++ b/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
@@ -24,6 +24,7 @@ def connector(tmp_path, mock_module):
     connector.log = Mock()
     connector.error = Mock()
     connector._latest_time = None
+    connector._seen_sids = set()
     connector.ldap_client = Mock()
     connector.context = MagicMock()
     return connector
@@ -50,7 +51,9 @@ def test_update_checkpoint_with_latest_time(connector):
 
     connector.update_checkpoint()
 
-    connector.context.__enter__().__setitem__.assert_called_once_with("most_recent_datetime", "20240101120000.0Z")
+    cache = connector.context.__enter__()
+    cache.__setitem__.assert_any_call("most_recent_datetime", "20240101120000.0Z")
+    cache.__setitem__.assert_any_call("seen_sids_at_checkpoint", [])
 
 
 def test_update_checkpoint_without_latest_time(connector):


### PR DESCRIPTION
linked issue: [issue](https://github.com/SekoiaLab/platform/issues/88990)

## Summary by Sourcery

Prevent duplication of Microsoft Active Directory user assets around checkpoint boundaries by tracking seen SIDs alongside the last processed creation timestamp.

Bug Fixes:
- Ensure users created at the checkpoint boundary second are not reprocessed by caching and checking their SIDs.
- Persist the set of SIDs seen at the latest checkpoint to avoid asset duplication across connector runs.

Enhancements:
- Add tracking of SIDs associated with the latest processed user creation time to improve checkpoint robustness.

Build:
- Bump Microsoft Active Directory integration version to 1.5.7 in the manifest.

Documentation:
- Update the Microsoft Active Directory changelog with version 1.5.7 and the asset duplication fix entry.

Tests:
- Extend user asset connector tests to cover the new checkpoint persistence behavior and seen SID caching.