### PR TITLE
HarfangLab: Validate entrypoint arguments via Pydantic

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-09 - 1.31.7
+
+### Fixed
+
+- Validate `Hostname by IP` and `Get agent telemetry` action arguments with Pydantic, using `IPvAnyAddress` for `target_ip` and `UUID` for `agent_id` to reject missing, empty, or malformed values before issuing HarfangLab API requests
+
 ## 2026-07-03 - 1.31.6
 
 ### Fixed

--- a/HarfangLab/harfanglab/get_agent_telemetry.py
+++ b/HarfangLab/harfanglab/get_agent_telemetry.py
@@ -1,9 +1,20 @@
-# natives
 from datetime import datetime, timedelta
 from typing import Any
+from uuid import UUID
 
 import requests
+from pydantic import BaseModel, Field
 from sekoia_automation.action import Action
+
+
+class GetAgentTelemetryArguments(BaseModel):
+    agent_id: UUID = Field(..., description="Identifier of the HarfangLab agent")
+    alert_created: str = Field(..., description="ISO-8601 timestamp used as the center of the search timerange")
+    event_types: list[str] = Field(
+        default=["processes", "windows_authentications", "linux_authentications", "macos_authentications"],
+        description="Telemetry event types to retrieve",
+    )
+    timerange: int = Field(default=15, description="Number of minutes before/after alert_created to search")
 
 
 class GetAgentTelemetry(Action):
@@ -21,7 +32,7 @@ class GetAgentTelemetry(Action):
         resp.raise_for_status()
         return resp
 
-    def run(self, arguments) -> dict[str, Any]:
+    def run(self, arguments: GetAgentTelemetryArguments) -> dict[str, Any] | None:
 
         telemetry_urls = {
             "processes": "/api/data/telemetry/Processes/",
@@ -34,12 +45,10 @@ class GetAgentTelemetry(Action):
             "macos_authentications": "/api/data/telemetry/authentication/AuthenticationMacos/",
         }
 
-        agent_id = arguments.get("agent_id", "")
-        event_types = arguments.get(
-            "event_types", ["processes", "windows_authentications", "linux_authentications", "macos_authentications"]
-        )
-        alert_created = arguments.get("alert_created", "")
-        timerange = arguments.get("timerange", 15)
+        agent_id = arguments.agent_id
+        event_types = arguments.event_types
+        alert_created = arguments.alert_created
+        timerange = arguments.timerange
         dt = datetime.fromisoformat(alert_created.replace("Z", "+00:00"))
         start = (dt - timedelta(minutes=timerange)).isoformat().replace("+00:00", "Z")
         end = (dt + timedelta(minutes=timerange)).isoformat().replace("+00:00", "Z")
@@ -57,7 +66,7 @@ class GetAgentTelemetry(Action):
                     api_endpoint=telemetry_urls[event_type],
                     api_token=api_token,
                     params={
-                        "agent.agentid": agent_id,
+                        "agent.agentid": str(agent_id),
                         "@event_create_date__gte": start,
                         "@event_create_date__lte": end,
                         "limit": 50,

--- a/HarfangLab/harfanglab/get_hostnames_by_ip_action.py
+++ b/HarfangLab/harfanglab/get_hostnames_by_ip_action.py
@@ -1,7 +1,13 @@
+from pydantic import BaseModel, Field, IPvAnyAddress
 from sekoia_automation.action import Action
 
 from .client import ApiClient
 from .models import HostnameEntry, HostnamesResult
+
+
+class GetHostnamesByIPArguments(BaseModel):
+    target_ip: IPvAnyAddress = Field(..., description="IP address to look up")
+    get_only_last_seen: bool = Field(default=False, description="Only return the most recently seen hostname")
 
 
 class GetHostnamesByIP(Action):
@@ -9,16 +15,16 @@ class GetHostnamesByIP(Action):
     Action to analyze a HarfangLab job that lists the process
     """
 
-    def run(self, arguments) -> dict:
-        target_ip = arguments.get("target_ip", "")
-        get_only_last_seen = arguments.get("get_only_last_seen", False)
+    def run(self, arguments: GetHostnamesByIPArguments) -> dict | None:
+        target_ip = arguments.target_ip
+        get_only_last_seen = arguments.get_only_last_seen
 
         client: ApiClient = ApiClient(
             instance_url=self.module.configuration["url"], token=self.module.configuration["api_token"]
         )
 
         job_url = f"{client.instance_url}/api/data/endpoint/Agent/"
-        params: dict = {"ipaddress": target_ip}
+        params: dict = {"ipaddress": str(target_ip)}
 
         response = client.get(url=job_url, params=params)
         response.raise_for_status()

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.31.6",
+  "version": "1.31.7",
   "categories": [
     "Endpoint"
   ],

--- a/HarfangLab/tests/test_get_agent_telemetry.py
+++ b/HarfangLab/tests/test_get_agent_telemetry.py
@@ -1,5 +1,6 @@
 import pytest
 import requests_mock
+from pydantic import ValidationError
 
 from harfanglab.get_agent_telemetry import GetAgentTelemetry
 
@@ -111,3 +112,52 @@ def test_integration_get_agent_telemetry_wrong_event_type():
     }
     with pytest.raises(ValueError):
         action.run(arguments)
+
+
+@pytest.mark.parametrize("agent_id", ["", "   "])
+def test_integration_get_agent_telemetry_requires_agent_id(agent_id):
+    instance_url = "https://test.hurukau.io"
+    api_token = "sss"
+
+    module_configuration = {
+        "api_token": api_token,
+        "url": instance_url,
+    }
+    action = GetAgentTelemetry()
+    action.module.configuration = module_configuration
+
+    arguments = {
+        "agent_id": agent_id,
+        "alert_created": "2025-04-29T17:54:49.326Z",
+        "event_types": ["processes"],
+    }
+
+    with requests_mock.Mocker() as mock:
+        with pytest.raises(ValidationError):
+            action.run(arguments)
+
+    assert len(mock.request_history) == 0
+
+
+def test_integration_get_agent_telemetry_rejects_invalid_agent_id_shape():
+    instance_url = "https://test.hurukau.io"
+    api_token = "sss"
+
+    module_configuration = {
+        "api_token": api_token,
+        "url": instance_url,
+    }
+    action = GetAgentTelemetry()
+    action.module.configuration = module_configuration
+
+    arguments = {
+        "agent_id": "not-a-uuid",
+        "alert_created": "2025-04-29T17:54:49.326Z",
+        "event_types": ["processes"],
+    }
+
+    with requests_mock.Mocker() as mock:
+        with pytest.raises(ValidationError):
+            action.run(arguments)
+
+    assert len(mock.request_history) == 0

--- a/HarfangLab/tests/test_get_hostnames_by_ip.py
+++ b/HarfangLab/tests/test_get_hostnames_by_ip.py
@@ -3,7 +3,10 @@
 # coding: utf-8
 
 # natives
+
+import pytest
 import requests_mock
+from pydantic import ValidationError
 
 # internals
 from harfanglab.get_hostnames_by_ip_action import GetHostnamesByIP
@@ -80,3 +83,32 @@ def test_get_hostnames_by_ip():
             ]
         ).dict()
         assert res == expected_result
+
+
+@pytest.mark.parametrize("target_ip", ["", "   "])
+def test_get_hostnames_by_ip_requires_target_ip(target_ip):
+    instance_url = "https://test.hurukau.io"
+    api_token = "11111111111111111111111111111111"
+
+    action = GetHostnamesByIP()
+    action.module.configuration = {"url": instance_url, "api_token": api_token}
+
+    with requests_mock.Mocker() as mock:
+        with pytest.raises(ValidationError):
+            action.run({"target_ip": target_ip, "get_only_last_seen": False})
+
+    assert len(mock.request_history) == 0
+
+
+def test_get_hostnames_by_ip_rejects_invalid_target_ip_shape():
+    instance_url = "https://test.hurukau.io"
+    api_token = "11111111111111111111111111111111"
+
+    action = GetHostnamesByIP()
+    action.module.configuration = {"url": instance_url, "api_token": api_token}
+
+    with requests_mock.Mocker() as mock:
+        with pytest.raises(ValidationError):
+            action.run({"target_ip": "not-an-ip", "get_only_last_seen": False})
+
+    assert len(mock.request_history) == 0


### PR DESCRIPTION
## What

Validate HarfangLab's action arguments via Pydantic v2 models before each action runs, so a missing/malformed agent ID or IP fails immediately with a clear validation error instead of calling the API with bad data.

## Changes

- `agent_id` → `uuid.UUID` (get_agent_telemetry)
- `target_ip` → `IPvAnyAddress` (get_hostnames_by_ip)

## Testing

- `pytest` and `ruff format` pass.
