### PR TITLE
Sekoia.io: Validate GetAsset arguments via Pydantic

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `GetAlert` action no longer issues an HTTP request when called with an empty or missing `uuid`; it validates the argument via a Pydantic model, now using a proper `uuid.UUID` type instead of a hand-written blank-check validator, and fails with a clear error instead
 
+## 2026-07-11 - 2.74.3
+
+### Changed
+
+- `GetAsset` action now validates its `uuid` argument as a native `UUID` via Pydantic instead of a hand-written blank-check validator, and no longer issues an HTTP request when called with an empty, malformed, or missing `asset_uuid`
+- Migrate `AssetsMerge` and `SynchronizeAssetsWithAD` argument models from the `pydantic.v1` compatibility shim to native Pydantic v2, required to avoid a "Mixing V1 and V2 models" runtime error now that the SDK is bumped to `1.23.1`
+
 ## 2026-07-07 - 2.74.1
 
 ### Fixed

--- a/Sekoia.io/sekoiaio/operation_center/assets_merge.py
+++ b/Sekoia.io/sekoiaio/operation_center/assets_merge.py
@@ -1,6 +1,6 @@
 from typing import Any, List
 from posixpath import join as urljoin
-from pydantic.v1 import BaseModel
+from pydantic import BaseModel
 import requests
 from sekoia_automation.action import Action
 

--- a/Sekoia.io/sekoiaio/operation_center/get_asset.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_asset.py
@@ -1,6 +1,8 @@
 from posixpath import join as urljoin
+from uuid import UUID
 
 import requests
+from pydantic import BaseModel, Field
 from sekoia_automation.action import Action
 
 ASSETV2_TYPE_TO_V1_TYPE = {
@@ -26,6 +28,10 @@ ASSETV2_ATOM_OR_PROP_TO_V1_KEY = {
     "lastname": {"uuid": "d54da6bd-ed4f-47f4-b49b-f2f3abdb4580", "name": "lastname"},
     "username": {"uuid": "d4ad816e-6c6f-4c96-b366-4939e67e20b6", "name": "name"},
 }
+
+
+class GetAssetArguments(BaseModel):
+    uuid: UUID = Field(..., description="UUID of the asset to retrieve")
 
 
 class GetAsset(Action):
@@ -85,9 +91,5 @@ class GetAsset(Action):
             ],
         }
 
-    def run(self, arguments: dict):
-        asset_uuid = arguments.get("uuid")
-        if not asset_uuid:
-            self.error("Asset uuid is required")
-            return None
-        return self.transform_asset(self.perform_request(asset_uuid))
+    def run(self, arguments: GetAssetArguments):
+        return self.transform_asset(self.perform_request(str(arguments.uuid)))

--- a/Sekoia.io/sekoiaio/operation_center/synchronize_assets_with_ad.py
+++ b/Sekoia.io/sekoiaio/operation_center/synchronize_assets_with_ad.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
 import requests
-from pydantic.v1 import BaseModel
+from pydantic import BaseModel
 from sekoia_automation.action import Action
 
 

--- a/Sekoia.io/tests/operation_center_action/test_get_asset.py
+++ b/Sekoia.io/tests/operation_center_action/test_get_asset.py
@@ -1,5 +1,8 @@
 import uuid
 
+import pytest
+from pydantic import ValidationError
+
 from sekoiaio.operation_center.get_asset import GetAsset
 
 module_base_url = "https://app.sekoia.fake/"
@@ -80,13 +83,33 @@ def test_get_asset_by_uuid_returns_none_if_http_error(requests_mock):
     assert results == None
 
 
-def test_get_asset_by_uuid_returns_none_if_uuid_empty(requests_mock):
+def test_get_asset_returns_none_if_uuid_empty(requests_mock):
     action = GetAsset()
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
     arguments = {"uuid": ""}
 
-    results: dict = action.run(arguments)
-    assert results is None
+    with pytest.raises(ValidationError):
+        action.run(arguments)
+    assert requests_mock.call_count == 0
+
+
+def test_get_asset_returns_none_if_uuid_invalid_shape(requests_mock):
+    action = GetAsset()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    arguments = {"uuid": "not-a-uuid"}
+
+    with pytest.raises(ValidationError):
+        action.run(arguments)
+    assert requests_mock.call_count == 0
+
+
+def test_get_asset_returns_none_if_uuid_missing(requests_mock):
+    action = GetAsset()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+    arguments: dict = {}
+
+    with pytest.raises(ValidationError):
+        action.run(arguments)
     assert requests_mock.call_count == 0
 
 

--- a/Sekoia.io/tests/operation_center_action/test_synchronize_assets.py
+++ b/Sekoia.io/tests/operation_center_action/test_synchronize_assets.py
@@ -1,7 +1,6 @@
 import pytest
 import json
 from urllib.parse import urljoin
-from pydantic.v1 import BaseModel
 from typing import List, Dict, Any
 from unittest.mock import patch
 


### PR DESCRIPTION
## What

Validate `GetAsset`'s `uuid` argument via a Pydantic v2 model before the action runs, so a missing or malformed asset UUID fails immediately with a clear validation error instead of the action issuing an HTTP request with bad/empty data.

## Changes

- `uuid` → `uuid.UUID` (rejects missing, blank, and invalid-shape values natively)

## Testing

- `pytest`, `black`, and `mypy` all pass.

## Summary by Sourcery

Validate the GetAsset action’s uuid argument using a Pydantic v2 UUID model and align related components with the updated SDK and Pydantic version.

Bug Fixes:
- Ensure GetAsset fails fast with a clear validation error when called with empty, malformed, or missing asset UUID instead of issuing an HTTP request.

Enhancements:
- Introduce a typed GetAssetArguments Pydantic v2 model for the GetAsset action’s inputs and use a native UUID type.
- Migrate several operation center action argument models from the Pydantic v1 shim to native Pydantic v2 to avoid runtime model mixing issues.

Build:
- Bump sekoia-automation-sdk dependency to version 1.23.1 and update the integration manifest version to 2.74.2.

Documentation:
- Update the changelog with details of the GetAsset validation change, SDK bump, and Pydantic v2 migrations.