### PR TITLE
fix(MicrosoftAD): fix LDAP connection errors

### DIFF
--- a/MicrosoftActiveDirectory/CHANGELOG.md
+++ b/MicrosoftActiveDirectory/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-13 - 1.5.8
+
+### Fixed
+
+- Reconnect LDAP connection on any `LDAPException` (including `LDAPSessionTerminatedByServerError`) during paged search, not only on socket errors
+
 ## 2026-07-09 - 1.5.7
 
 ### Fixed

--- a/MicrosoftActiveDirectory/manifest.json
+++ b/MicrosoftActiveDirectory/manifest.json
@@ -32,7 +32,7 @@
   "name": "Microsoft Active Directory",
   "uuid": "b2d96259-af89-4f7a-ae6e-a0af2d2400f3",
   "slug": "microsoft-ad",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -3,7 +3,7 @@ from collections.abc import Generator
 from typing import Any
 
 from ldap3 import ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES
-from ldap3.core.exceptions import LDAPSocketOpenError
+from ldap3.core.exceptions import LDAPException
 from sekoia_automation.asset_connector import AssetConnector
 from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product
 from sekoia_automation.asset_connector.models.ocsf.group import Group
@@ -312,10 +312,10 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
                         seen_dn.add(dn)
                     yield entry
                 return
-            except LDAPSocketOpenError as exc:
+            except LDAPException as exc:
                 if attempt == 1:
                     raise
-                self.log(f"LDAP socket closed, reconnecting... ({exc})", level="warning")
+                self.log(f"LDAP error, reconnecting... ({exc})", level="warning")
                 self._reset_ldap_connection()
 
     def get_users_generator(self) -> Generator[dict[str, Any], None, None]:

--- a/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
+++ b/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from ldap3.core.exceptions import LDAPException, LDAPSessionTerminatedByServerError
 from ldap3.core.timezone import OffsetTzInfo
 from sekoia_automation.asset_connector.models.ocsf.user import AccountTypeId, UserOCSFModel, UserTypeId, UserTypeStr
 
@@ -285,3 +286,70 @@ def test_get_assets_handles_exception(connector):
     assets = list(connector.get_assets())
 
     assert len(assets) == 0
+
+
+@pytest.fixture
+def mock_entry():
+    return {"dn": "CN=User1,DC=example,DC=com", "attributes": {"userPrincipalName": "user1@example.com"}}
+
+
+def test_entries_reconnects_on_ldap_exception_and_succeeds(connector, mock_entry):
+    """On LDAPException at attempt 0, should reconnect and yield entries on retry."""
+    connector._reset_ldap_connection = Mock()
+    connector.context.__enter__().get.return_value = None
+
+    call_count = 0
+
+    def paged_search_side_effect(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise LDAPSessionTerminatedByServerError("session terminated by server")
+        return iter([mock_entry])
+
+    connector.ldap_client.extend.standard.paged_search.side_effect = paged_search_side_effect
+
+    entries = list(connector._entries())
+
+    assert entries == [mock_entry]
+    connector._reset_ldap_connection.assert_called_once()
+    connector.log.assert_any_call(
+        "LDAP error, reconnecting... (session terminated by server)", level="warning"
+    )
+
+
+def test_entries_raises_on_second_ldap_exception(connector):
+    """If both attempts fail with LDAPException, the exception should propagate."""
+    connector._reset_ldap_connection = Mock()
+    connector.context.__enter__().get.return_value = None
+
+    connector.ldap_client.extend.standard.paged_search.side_effect = LDAPException("persistent error")
+
+    with pytest.raises(LDAPException, match="persistent error"):
+        list(connector._entries())
+
+    assert connector._reset_ldap_connection.call_count == 1
+
+
+def test_entries_succeeds_without_error(connector, mock_entry):
+    """Normal path: no exception, all entries yielded."""
+    connector.context.__enter__().get.return_value = None
+
+    connector.ldap_client.extend.standard.paged_search.return_value = iter([mock_entry])
+
+    entries = list(connector._entries())
+
+    assert entries == [mock_entry]
+
+
+def test_entries_deduplicates_by_dn(connector):
+    """Duplicate DNs across pages should only be yielded once."""
+    connector.context.__enter__().get.return_value = None
+
+    entry = {"dn": "CN=User1,DC=example,DC=com", "attributes": {}}
+    connector.ldap_client.extend.standard.paged_search.return_value = iter([entry, entry])
+
+    entries = list(connector._entries())
+
+    assert len(entries) == 1
+

--- a/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
+++ b/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
@@ -313,9 +313,7 @@ def test_entries_reconnects_on_ldap_exception_and_succeeds(connector, mock_entry
 
     assert entries == [mock_entry]
     connector._reset_ldap_connection.assert_called_once()
-    connector.log.assert_any_call(
-        "LDAP error, reconnecting... (session terminated by server)", level="warning"
-    )
+    connector.log.assert_any_call("LDAP error, reconnecting... (session terminated by server)", level="warning")
 
 
 def test_entries_raises_on_second_ldap_exception(connector):
@@ -352,4 +350,3 @@ def test_entries_deduplicates_by_dn(connector):
     entries = list(connector._entries())
 
     assert len(entries) == 1
-

--- a/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
+++ b/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from ldap3.core.exceptions import LDAPException, LDAPSessionTerminatedByServerError


### PR DESCRIPTION
Linked issue: [issue](https://github.com/SekoiaLab/platform/issues/88990)

## Summary by Sourcery

Handle LDAP connection errors more robustly in Microsoft Active Directory user asset connector and bump version.

Bug Fixes:
- Reconnect the LDAP client on any LDAPException during paged search instead of only LDAP socket errors.
- Ensure duplicate LDAP entries with the same DN are returned only once from the user asset connector.

Build:
- Update the Microsoft Active Directory connector manifest version to 1.5.8.

Documentation:
- Update the changelog with version 1.5.8 and the LDAP error handling fix.

Tests:
- Add tests covering LDAP reconnection behavior, error propagation, successful entry retrieval, and DN-based deduplication in the user asset connector.