### PR TITLE
Imp/fortigate verify certificate config

### DIFF
--- a/Fortigate/CHANGELOG.md
+++ b/Fortigate/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2026-07-15 - 1.31.0
+
+### Added
+
+- Added a configuration parameter to control TLS certificate verification for all Fortigate actions
+
 ## 2025-12-24 - 1.30.0
 
 ### Added

--- a/Fortigate/fortigate/action_fortigate_add_fqdn.py
+++ b/Fortigate/fortigate/action_fortigate_add_fqdn.py
@@ -53,7 +53,7 @@ class FortigateAddFQDNAction(Action):
                     },
                     params={"vdom": vdom},
                     data=json.dumps(payload),
-                    verify=False,
+                    verify=self.module.configuration.get("verify_certificate", True),
                     timeout=10,
                 )
                 response.raise_for_status()

--- a/Fortigate/fortigate/action_fortigate_add_fqdn.py
+++ b/Fortigate/fortigate/action_fortigate_add_fqdn.py
@@ -53,7 +53,7 @@ class FortigateAddFQDNAction(Action):
                     },
                     params={"vdom": vdom},
                     data=json.dumps(payload),
-                    verify=self.module.configuration.get("verify_certificate", True),
+                    verify=self.module.configuration.get("verify_certificate", False),
                     timeout=10,
                 )
                 response.raise_for_status()

--- a/Fortigate/fortigate/action_fortigate_add_group_address.py
+++ b/Fortigate/fortigate/action_fortigate_add_group_address.py
@@ -62,7 +62,7 @@ class FortigateAddGroupAddress(Action):
                 },
                 params={"vdom": self.vdom},
                 json=data,
-                verify=self.module.configuration.get("verify_certificate", True),
+                verify=self.module.configuration.get("verify_certificate", False),
                 timeout=2,
             )
             return response
@@ -91,7 +91,7 @@ class FortigateAddGroupAddress(Action):
                 },
                 params={"vdom": self.vdom},
                 json=data,
-                verify=self.module.configuration.get("verify_certificate", True),
+                verify=self.module.configuration.get("verify_certificate", False),
                 timeout=2,
             )
             return response
@@ -120,7 +120,7 @@ class FortigateAddGroupAddress(Action):
                 },
                 params={"vdom": self.vdom},
                 json=data,
-                verify=self.module.configuration.get("verify_certificate", True),
+                verify=self.module.configuration.get("verify_certificate", False),
                 timeout=2,
             )
             return response

--- a/Fortigate/fortigate/action_fortigate_add_group_address.py
+++ b/Fortigate/fortigate/action_fortigate_add_group_address.py
@@ -62,7 +62,7 @@ class FortigateAddGroupAddress(Action):
                 },
                 params={"vdom": self.vdom},
                 json=data,
-                verify=False,
+                verify=self.module.configuration.get("verify_certificate", True),
                 timeout=2,
             )
             return response
@@ -91,7 +91,7 @@ class FortigateAddGroupAddress(Action):
                 },
                 params={"vdom": self.vdom},
                 json=data,
-                verify=False,
+                verify=self.module.configuration.get("verify_certificate", True),
                 timeout=2,
             )
             return response
@@ -120,7 +120,7 @@ class FortigateAddGroupAddress(Action):
                 },
                 params={"vdom": self.vdom},
                 json=data,
-                verify=False,
+                verify=self.module.configuration.get("verify_certificate", True),
                 timeout=2,
             )
             return response

--- a/Fortigate/fortigate/action_fortigate_add_ip_address.py
+++ b/Fortigate/fortigate/action_fortigate_add_ip_address.py
@@ -54,7 +54,7 @@ class FortigateAddIPAction(Action):
                     },
                     params={"vdom": vdom},
                     data=json.dumps(payload),
-                    verify=False,
+                    verify=self.module.configuration.get("verify_certificate", True),
                     timeout=10,
                 )
                 response.raise_for_status()

--- a/Fortigate/fortigate/action_fortigate_add_ip_address.py
+++ b/Fortigate/fortigate/action_fortigate_add_ip_address.py
@@ -54,7 +54,7 @@ class FortigateAddIPAction(Action):
                     },
                     params={"vdom": vdom},
                     data=json.dumps(payload),
-                    verify=self.module.configuration.get("verify_certificate", True),
+                    verify=self.module.configuration.get("verify_certificate", False),
                     timeout=10,
                 )
                 response.raise_for_status()

--- a/Fortigate/fortigate/action_fortigate_disable_local_user.py
+++ b/Fortigate/fortigate/action_fortigate_disable_local_user.py
@@ -44,7 +44,7 @@ class FortigateDisableLocalUserAction(Action):
                     },
                     params={"vdom": vdom},
                     data=json.dumps(payload),
-                    verify=self.module.configuration.get("verify_certificate", True),
+                    verify=self.module.configuration.get("verify_certificate", False),
                     timeout=10,
                 )
                 response.raise_for_status()

--- a/Fortigate/fortigate/action_fortigate_disable_local_user.py
+++ b/Fortigate/fortigate/action_fortigate_disable_local_user.py
@@ -44,7 +44,7 @@ class FortigateDisableLocalUserAction(Action):
                     },
                     params={"vdom": vdom},
                     data=json.dumps(payload),
-                    verify=True,
+                    verify=self.module.configuration.get("verify_certificate", True),
                     timeout=10,
                 )
                 response.raise_for_status()

--- a/Fortigate/manifest.json
+++ b/Fortigate/manifest.json
@@ -34,6 +34,11 @@
             "base_port"
           ]
         }
+      },
+      "verify_certificate": {
+        "description": "Verify the firewall TLS certificate",
+        "type": "boolean",
+        "default": true
       }
     },
     "required": [
@@ -49,7 +54,7 @@
   "name": "Fortigate Firewalls",
   "uuid": "ca9a9497-bcd2-4d0c-b0c1-72699231feb2",
   "slug": "fortigate",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "categories": [
     "Network"
   ]

--- a/Fortigate/manifest.json
+++ b/Fortigate/manifest.json
@@ -38,7 +38,7 @@
       "verify_certificate": {
         "description": "Verify the firewall TLS certificate",
         "type": "boolean",
-        "default": true
+        "default": false
       }
     },
     "required": [

--- a/Fortigate/pyproject.toml
+++ b/Fortigate/pyproject.toml
@@ -35,3 +35,9 @@ omit = ["tests/*", "main.py"]
 mypy = "^0.991"
 isort = "^5.10.1"
 black = "^22.10.0"
+
+[tool.mypy]
+
+[[tool.mypy.overrides]]
+module = ["requests", "requests.*", "sekoia_automation", "sekoia_automation.*"]
+ignore_missing_imports = true


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1686
## Summary by Sourcery

Add configurable TLS certificate verification for Fortigate integration HTTP requests and update project metadata accordingly.

New Features:
- Introduce a verify_certificate boolean configuration option to control TLS verification for Fortigate actions.

Enhancements:
- Update all Fortigate HTTP requests to respect the configurable TLS certificate verification setting instead of hardcoded values.
- Configure mypy to ignore missing imports for external dependencies in the Fortigate project.

Build:
- Bump the Fortigate integration version to 1.31.0.

Documentation:
- Document the new TLS certificate verification configuration option in the Fortigate changelog.