### PR TITLE
Sekoia.io: consolidate GetAsset CHANGELOG entry into 2.74.2

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -12,17 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgraded `sekoia-automation-sdk` to `1.23.1` and migrated `GetAlert`, `CreateDataset`, `DeleteDataset`, `ExecuteAQuery`, and `ListQueries` action argument models from the `pydantic.v1` compatibility shim to native Pydantic v2, avoiding a v1/v2 model mixing error triggered by the newer SDK
+- `GetAsset` action now validates its `uuid` argument as a native `UUID` via Pydantic instead of a hand-written blank-check validator, and no longer issues an HTTP request when called with an empty, malformed, or missing `asset_uuid`
+- Migrate `AssetsMerge` and `SynchronizeAssetsWithAD` argument models from the `pydantic.v1` compatibility shim to native Pydantic v2, required to avoid a "Mixing V1 and V2 models" runtime error now that the SDK is bumped to `1.23.1`
 
 ### Fixed
 
 - `GetAlert` action no longer issues an HTTP request when called with an empty or missing `uuid`; it validates the argument via a Pydantic model, now using a proper `uuid.UUID` type instead of a hand-written blank-check validator, and fails with a clear error instead
-
-## 2026-07-11 - 2.74.3
-
-### Changed
-
-- `GetAsset` action now validates its `uuid` argument as a native `UUID` via Pydantic instead of a hand-written blank-check validator, and no longer issues an HTTP request when called with an empty, malformed, or missing `asset_uuid`
-- Migrate `AssetsMerge` and `SynchronizeAssetsWithAD` argument models from the `pydantic.v1` compatibility shim to native Pydantic v2, required to avoid a "Mixing V1 and V2 models" runtime error now that the SDK is bumped to `1.23.1`
 
 ## 2026-07-07 - 2.74.1
 


### PR DESCRIPTION
## What

Fixes a mistake introduced while resolving the rebase conflict on #2892.

## Changes

- `Sekoia.io/CHANGELOG.md`: merge the GetAsset Pydantic validation entry (and the AssetsMerge/SynchronizeAssetsWithAD Pydantic v2 migration bullet) back into the existing `2026-07-10 - 2.74.2` section, removing the orphan `2026-07-11 - 2.74.3` header.
- `Sekoia.io/manifest.json`: kept at `2.74.2` (no version bump).

## Why

While resolving #2892's rebase conflict, I renamed the conflicting CHANGELOG header to a new `2026-07-11 - 2.74.3` section but never bumped `manifest.json`'s version to match in that same commit. This repo's convention (see e.g. `9aa817b7`, `c5eea5d7`, `fdaa7d0c`) is that a dated CHANGELOG entry and a manifest version bump always land together in the same commit — a dated entry with no corresponding manifest bump is invalid/orphaned.

My first attempt at fixing this (this PR, previously) went the wrong way: it bumped `manifest.json` to `2.74.3` to match the incorrect CHANGELOG entry. The correct fix is the opposite — since no real `2.74.3` release ever happened, the CHANGELOG entry itself was wrong and should be folded back into the `2.74.2` section that already shipped (alongside the GetAlert fix), while `manifest.json` stays at `2.74.2`.

## Testing

- Verified `manifest.json` is still valid JSON.
- Verified no remaining references to `2.74.3` anywhere in the module.
- Branch squashed to a single commit.
