### PR TITLE
fix dockerfile

### DIFF
--- a/Flare/CHANGELOG.md
+++ b/Flare/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-20 - 0.4.0
+
 ### Fixed
 
 - Reuse the connector's configured limiter as the SDK's per-event limiter (`_events_limiter`) to stop double-throttling events, and clarify the `throttle_seconds` description
 - Regenerate `poetry.lock` to match `pyproject.toml`
 - Fix `isort` ordering in `tests/conftest.py`
 - Modernize `pyproject.toml` (`tool.poetry.group.dev.dependencies`, `tool.mypy` strict config)
+- Redirect hardcoded SDK writes to `/tmp/tls` into writable `/dev/shm` in the container image to avoid read-only filesystem failures
 
 ### Added
 

--- a/Flare/Dockerfile
+++ b/Flare/Dockerfile
@@ -16,12 +16,11 @@ COPY . .
 
 RUN useradd -ms /bin/bash sekoiaio-runtime
 
-# Some dependencies (e.g. pyrate-limiter, used by requests-ratelimiter) resolve a temp
-# directory at import time via tempfile.gettempdir(). The default system temp directories
-# (/tmp, /var/tmp, /usr/tmp) may not be writable by the non-root runtime user in the
-# deployment environment, so provide a dedicated writable directory and point TMPDIR at it.
-RUN mkdir -p /app/tmp && chown sekoiaio-runtime:sekoiaio-runtime /app/tmp
-ENV TMPDIR=/app/tmp
+# The sekoia_automation SDK hardcodes writes to /tmp/tls.
+# Since the K8s environment enforces a read-only root filesystem,
+# we replace /tmp with a symlink to /dev/shm (which K8s always mounts as a writable tmpfs).
+# This transparently redirects all hardcoded /tmp writes into memory.
+RUN rm -rf /tmp && ln -s /dev/shm /tmp
 
 USER sekoiaio-runtime
 

--- a/Flare/manifest.json
+++ b/Flare/manifest.json
@@ -24,7 +24,7 @@
   "name": "Flare.io",
   "slug": "flare-io",
   "uuid": "90ec90da-8065-4229-ab3c-298ffe140772",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "supports_validation": true,
   "categories": [
     "Threat Intelligence"


### PR DESCRIPTION
## Summary by Sourcery

Fix container runtime temporary filesystem handling and bump the Flare connector version.

Bug Fixes:
- Redirect hardcoded SDK writes from /tmp to a writable in-memory filesystem in the container image to avoid failures on read-only roots.

Enhancements:
- Update the Flare connector version metadata to 0.4.0.

Documentation:
- Add a 0.4.0 changelog entry documenting the temp filesystem fix.