### PR TITLE
Sekoia.io: allow short id for the GetAlert action

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-22 - 2.74.4
+
+### Fixed
+
+- Allow short ids when validating the arguments for the GetAlert action
+
 ## 2026-07-20 - 2.74.3
 
 ### Fixed

--- a/Sekoia.io/action_get_an_alert.json
+++ b/Sekoia.io/action_get_an_alert.json
@@ -11,7 +11,7 @@
       "uuid": {
         "type": "string",
         "in": "path",
-        "description": "UUID of the alert to retrieve."
+        "description": "The identifier (UUID or short id) of the alert to retrieve."
       },
       "stix": {
         "in": "query",

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.74.3",
+  "version": "2.74.4",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/get_alert.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_alert.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from sekoia_automation.action import GenericAPIAction
 
@@ -9,9 +9,29 @@ from sekoiaio.operation_center.constants import base_url
 
 
 class GetAlertArguments(BaseModel):
-    uuid: UUID = Field(..., description="UUID of the alert to retrieve")
+    uuid: str = Field(..., description="UUID of the alert to retrieve")
     stix: Optional[bool] = None
     cases: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def validate_uuid(self) -> "GetAlertArguments":
+
+        # emptyness check
+        if not self.uuid:
+            raise ValueError("UUID must not be empty")
+
+        # short id validation
+        if self.uuid.startswith("AL") and len(self.uuid) == 12:
+            # If the UUID starts with "AL", we assume it's a short ID
+            return self
+
+        # UUID validation
+        try:
+            UUID(self.uuid)
+        except ValueError:
+            raise ValueError(f"Invalid UUID: {self.uuid}")
+
+        return self
 
 
 class GetAlert(GenericAPIAction):

--- a/Sekoia.io/sekoiaio/operation_center/get_alert.py
+++ b/Sekoia.io/sekoiaio/operation_center/get_alert.py
@@ -9,19 +9,19 @@ from sekoiaio.operation_center.constants import base_url
 
 
 class GetAlertArguments(BaseModel):
-    uuid: str = Field(..., description="UUID of the alert to retrieve")
+    uuid: str = Field(..., description="The identifier (UUID or short id) of the alert to retrieve")
     stix: Optional[bool] = None
     cases: Optional[bool] = None
 
     @model_validator(mode="after")
     def validate_uuid(self) -> "GetAlertArguments":
 
-        # emptyness check
-        if not self.uuid:
-            raise ValueError("UUID must not be empty")
+        # emptiness check
+        if self.uuid is None or not self.uuid.strip():
+            raise ValueError("The alert identifier must not be empty")
 
         # short id validation
-        if self.uuid.startswith("AL") and len(self.uuid) == 12:
+        if self.uuid.startswith("AL"):
             # If the UUID starts with "AL", we assume it's a short ID
             return self
 
@@ -29,7 +29,7 @@ class GetAlertArguments(BaseModel):
         try:
             UUID(self.uuid)
         except ValueError:
-            raise ValueError(f"Invalid UUID: {self.uuid}")
+            raise ValueError(f"Invalid alert identifier: {self.uuid}")
 
         return self
 

--- a/Sekoia.io/tests/operation_center_action/test_get_alert.py
+++ b/Sekoia.io/tests/operation_center_action/test_get_alert.py
@@ -10,10 +10,10 @@ base_url = module_base_url + "api/v1/sic/alerts/"
 apikey = "fake_api_key"
 
 
-def test_get_alert_by_uuid(requests_mock):
+@pytest.mark.parametrize("alert_uuid", ["781b21f0-4961-450e-b7ed-80e66b04ac87", "ALEhcq5cVfVZ"])
+def test_get_alert_by_uuid(requests_mock, alert_uuid):
     action = GetAlert()
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
-    alert_uuid = uuid.uuid4()
     arguments = {"uuid": str(alert_uuid), "stix": True, "cases": True}
     expected_response = {"uuid": str(alert_uuid), "short_id": "ALtest", "status": {"name": "Ongoing"}}
 


### PR DESCRIPTION
Allow short ids when validating the arguments for the GetAlert action

## Summary by Sourcery

Allow GetAlert action to accept and validate both full UUIDs and short alert IDs.

Bug Fixes:
- Relax argument validation in GetAlert to support short alert IDs alongside full UUIDs.

Documentation:
- Update changelog with version 2.74.4 entry describing the GetAlert short ID fix.

Tests:
- Extend GetAlert tests to cover retrieval by both full UUID and short alert ID.

Chores:
- Bump Sekoia.io manifest version to 2.74.4.