### PR TITLE
feat(locaterisk): move scan settings to connector and bump 0.6.0

### DIFF
--- a/LocateRisk/CHANGELOG.md
+++ b/LocateRisk/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-23 - 0.6.0
+
+### Changed
+
+- Moved `scan_id` from module configuration to the LocateRisk scan connector/trigger configuration.
+- Replaced the module-level `report_url` setting with `base_url` (default: `https://app.locaterisk.com/`) and added `report_url` to connector/trigger arguments for report export configuration.
+
 ## 2026-07-22 - 0.5.0
 
 ### Changed

--- a/LocateRisk/connector_locaterisk_scan_report.json
+++ b/LocateRisk/connector_locaterisk_scan_report.json
@@ -16,14 +16,23 @@
         "description": "Intake key to use when sending events",
         "type": "string"
       },
+      "scan_id": {
+        "description": "Scan ID",
+        "type": "string"
+      },
+      "report_url": {
+        "description": "Report export URL used to fetch scan findings",
+        "default": "https://app.locaterisk.com/api/rest/report/export",
+        "type": "string"
+      },
       "polling_interval": {
         "description": "Polling interval in minutes",
         "default": 5,
         "type": "integer"
       }
     },
-    "required": ["intake_key"],
-    "secrets": ["intake_key"],
+    "required": ["intake_key", "scan_id"],
+    "secrets": ["intake_key", "scan_id"],
     "title": "LocateRisk Scan Report configuration"
   }
 }

--- a/LocateRisk/locaterisk_modules/connector_locaterisk_scan_report.py
+++ b/LocateRisk/locaterisk_modules/connector_locaterisk_scan_report.py
@@ -5,7 +5,7 @@ import json
 import time
 
 import requests
-from pydantic import Field
+from pydantic import Field, field_validator
 from requests.adapters import HTTPAdapter
 from sekoia_automation.connector import Connector, DefaultConnectorConfiguration
 from sekoia_automation.storage import PersistentJSON
@@ -19,6 +19,18 @@ class LocateRiskScanReportConnectorConfiguration(DefaultConnectorConfiguration):
     """Connector-specific configuration for the LocateRisk scan report poller."""
 
     polling_interval: int = Field(5, description="Polling interval in minutes")
+    scan_id: str = Field(..., description="Scan ID", json_schema_extra={"secret": True})
+    report_url: str = Field(
+        "https://app.locaterisk.com/api/rest/report/export",
+        description="Report export URL used to fetch scan findings",
+    )
+
+    @field_validator("report_url")
+    @classmethod
+    def _require_https_report_url(cls, value: str) -> str:
+        if not value.lower().startswith("https://"):
+            raise ValueError("report_url must use HTTPS")
+        return value
 
 
 class LocateRiskScanReportConnector(Connector):
@@ -44,7 +56,7 @@ class LocateRiskScanReportConnector(Connector):
 
     def _build_report_url(self) -> str:
         """Build the CSV report URL for the configured scan."""
-        return f"{self.module.configuration.report_url}/{self.module.configuration.scan_id}/csv"
+        return f"{self.configuration.report_url.rstrip('/')}/{self.configuration.scan_id}/csv"
 
     @staticmethod
     def _row_hash(row: dict) -> str:

--- a/LocateRisk/locaterisk_modules/models.py
+++ b/LocateRisk/locaterisk_modules/models.py
@@ -3,17 +3,16 @@ from pydantic import BaseModel, Field, field_validator
 
 class LocateRiskModuleConfiguration(BaseModel):
     api_key: str = Field(..., description="API Key", json_schema_extra={"secret": True})
-    scan_id: str = Field(..., description="Scan ID", json_schema_extra={"secret": True})
-    report_url: str = Field(
-        "https://app.locaterisk.com/api/rest/report/export",
-        description="Base URL of the LocateRisk report export endpoint",
+    base_url: str = Field(
+        "https://app.locaterisk.com/",
+        description="Base URL of the LocateRisk platform",
     )
 
-    @field_validator("report_url")
+    @field_validator("base_url")
     @classmethod
     def _require_https(cls, value: str) -> str:
-        # Reject non-HTTPS report URLs at configuration time so the API key
+        # Reject non-HTTPS base URLs at configuration time so the API key
         # (sent as a Bearer token) is never transmitted in cleartext.
         if not value.lower().startswith("https://"):
-            raise ValueError("report_url must use HTTPS")
+            raise ValueError("base_url must use HTTPS")
         return value

--- a/LocateRisk/manifest.json
+++ b/LocateRisk/manifest.json
@@ -6,27 +6,22 @@
         "title": "Api Key",
         "type": "string"
       },
-      "scan_id": {
-        "description": "Scan ID",
-        "title": "Scan Id",
-        "type": "string"
-      },
-      "report_url": {
-        "default": "https://app.locaterisk.com/api/rest/report/export",
-        "description": "Base URL of the LocateRisk report export endpoint",
-        "title": "Report Url",
+      "base_url": {
+        "default": "https://app.locaterisk.com/",
+        "description": "Base URL of the LocateRisk platform",
+        "title": "Base Url",
         "type": "string"
       }
     },
-    "required": ["api_key", "scan_id"],
+    "required": ["api_key"],
     "title": "LocateRiskModuleConfiguration",
     "type": "object",
-    "secrets": ["api_key", "scan_id"]
+    "secrets": ["api_key"]
   },
   "description": "Specialist for automated IT risk analysis and monitoring",
   "name": "LocateRisk",
   "slug": "locaterisk",
   "categories": ["Threat Intelligence"],
   "uuid": "5173f31f-13b7-4418-bf3b-3b18b196a8e2",
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/LocateRisk/tests/test_connector.py
+++ b/LocateRisk/tests/test_connector.py
@@ -7,7 +7,8 @@ from locaterisk_modules import LocateRiskModule
 from locaterisk_modules.connector_locaterisk_scan_report import LocateRiskScanReportConnector
 from locaterisk_modules.metrics import INCOMING_MESSAGES, OUTCOMING_EVENTS
 
-REPORT_URL = "https://app.locaterisk.com/api/rest/report/export"
+BASE_URL = "https://app.locaterisk.com/api/rest/report"
+REPORT_URL = f"{BASE_URL}/export"
 SCAN_ID = "scan-123"
 CSV_URL = f"{REPORT_URL}/{SCAN_ID}/csv"
 
@@ -21,10 +22,14 @@ def connector(data_storage):
     connector.push_events_to_intakes = MagicMock()
     connector.module.configuration = {
         "api_key": "test-api-key",
+        "base_url": BASE_URL,
+    }
+    connector.configuration = {
+        "intake_key": "intake-key",
         "scan_id": SCAN_ID,
         "report_url": REPORT_URL,
+        "polling_interval": 1,
     }
-    connector.configuration = {"intake_key": "intake-key", "polling_interval": 1}
     yield connector
 
 

--- a/LocateRisk/trigger_locaterisk_scan_report.json
+++ b/LocateRisk/trigger_locaterisk_scan_report.json
@@ -16,14 +16,23 @@
         "description": "Intake key to use when sending events",
         "type": "string"
       },
+      "scan_id": {
+        "description": "Scan ID",
+        "type": "string"
+      },
+      "report_url": {
+        "description": "Report export URL used to fetch scan findings",
+        "default": "https://app.locaterisk.com/api/rest/report/export",
+        "type": "string"
+      },
       "polling_interval": {
         "description": "Polling interval in minutes",
         "default": 5,
         "type": "integer"
       }
     },
-    "required": ["intake_key"],
-    "secrets": ["intake_key"],
+    "required": ["intake_key", "scan_id"],
+    "secrets": ["intake_key", "scan_id"],
     "title": "LocateRisk Scan Report configuration"
   },
   "results": {


### PR DESCRIPTION
## Summary by Sourcery

Move LocateRisk scan-specific settings from the module configuration into the scan report connector/trigger configuration and bump the module version to 0.6.0.

New Features:
- Introduce connector-level configuration fields for LocateRisk scan ID and report export URL in the scan report connector.

Enhancements:
- Replace module-level report URL with a generic base URL setting for the LocateRisk platform, enforcing HTTPS validation.
- Update connector URL construction to use connector configuration instead of module configuration for report exports.
- Add HTTPS validation for the connector-level report URL to ensure secure access to scan exports.

Documentation:
- Document the 0.6.0 changes in the LocateRisk changelog, including configuration moves and defaults.

Tests:
- Adjust connector tests to reflect the new separation between module base URL configuration and connector-level scan/report settings.