### PR TITLE
Salesforce: increase file processing threshold

### DIFF
--- a/Salesforce/CHANGELOG.md
+++ b/Salesforce/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-24 - 1.8.4
+
+### Changed
+
+- Increase file processing, in memory, to 500Mb
+
 ## 2026-05-04 - 1.8.3
 
 ### Changed

--- a/Salesforce/manifest.json
+++ b/Salesforce/manifest.json
@@ -39,7 +39,7 @@
   "name": "Salesforce",
   "uuid": "f811e134-2548-11ee-be56-0242ac120002",
   "slug": "salesforce",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "categories": [
     "Applicative"
   ]

--- a/Salesforce/salesforce/connector.py
+++ b/Salesforce/salesforce/connector.py
@@ -55,7 +55,7 @@ class SalesforceConnector(AsyncConnector):
     LOG_FILE_CACHE_SIZE = 100
 
     # Thresholds for log processing
-    SIZE_TO_PROCESS_DEFAULT = 20 * 1024 * 1024  # 20MB
+    SIZE_TO_PROCESS_DEFAULT = 500 * 1024 * 1024  # 500MB
     CHUNK_SIZE_DEFAULT = 1024 * 1024  # 1MB
 
     def __init__(self, *args: Any, **kwargs: Optional[Any]) -> None:


### PR DESCRIPTION
Increase the threshold that define in the file is processed in memory or on the filesystem to 500Mb

## Summary by Sourcery

Increase the Salesforce connector log processing threshold and release version 1.8.4.

Enhancements:
- Raise in-memory log file processing threshold from 20MB to 500MB in the Salesforce connector.

Build:
- Bump the Salesforce package version from 1.8.3 to 1.8.4 in the manifest.

Documentation:
- Record the new 1.8.4 release and the updated file processing threshold in the Salesforce changelog.