### PR TITLE
chore(ci): sync GitHub workflows from develop into production

### DIFF
--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -2,10 +2,11 @@ name: Build Modules
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+      - develop
   workflow_dispatch:
 
 env:
@@ -13,23 +14,26 @@ env:
   SECONDARY_REGISTRY: registry.sekoia.io
   IMAGE_PREFIX_NAME: sekoia-io
 
-jobs:
+permissions: {}
 
+jobs:
   find-modules:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     name: Find modules in repo
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.list-modules.outputs.matrix }}
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
       - id: list-modules
         name: List modules having changed files
         run: |
           if ${{ github.event_name == 'workflow_dispatch' }}; then
-            echo "matrix=$(cut -d "/" -f1 <<< "$(ls -a */manifest.json)" | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+            echo "matrix=$(cut -d "/" -f1 <<< "$(ls -a -- */manifest.json)" | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ${{ github.event_name == 'pull_request' }}; then
@@ -39,9 +43,11 @@ jobs:
             start=${{ github.event.before }}
             end=${{ github.event.after }}
           fi
-          echo "matrix=$(comm -12  <(cut -d "/" -f1 <<< "$(git diff --name-only -r $start $end)" | sort | uniq) <(cut -d "/" -f1 <<< "$(ls -a */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo "matrix=$(comm -12  <(cut -d "/" -f1 <<< "$(git diff --name-only -r "$start" "$end")" | sort | uniq) <(cut -d "/" -f1 <<< "$(ls -a -- */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
 
   test:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     name: Test module ${{ matrix.module }}
     runs-on: ubuntu-latest
     needs: find-modules
@@ -52,65 +58,62 @@ jobs:
       fail-fast: false
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
-      - name: Install Poetry
+      - name: Detect package manager
+        id: detect-pm
         run: |
-          pip install poetry
-          poetry config virtualenvs.in-project true
+          if [ -f "${MODULE_PATH}/uv.lock" ]; then
+            echo "package_manager=uv" >> "$GITHUB_OUTPUT"
+            echo "Detected uv project"
+          else
+            echo "package_manager=poetry" >> "$GITHUB_OUTPUT"
+            echo "Defaulting to Poetry"
+          fi
+        env:
+          MODULE_PATH: ${{ matrix.module }}
 
-      - name: Install Dependencies
-        id: install-dependencies
-        run: |
-          poetry install
-        working-directory: ${{ matrix.module }}
-
-      - name: Execute Black
-        uses: psf/black@stable
+      - name: Test with Poetry
+        if: steps.detect-pm.outputs.package_manager == 'poetry'
+        uses: ./.github/actions/test-with-poetry
         with:
-          options: "--check --verbose"
-          src: ./"${{ matrix.module }}"
+          module: ${{ matrix.module }}
 
-      - name: Execute Mypy
-        run: |
-          poetry run pip install mypy
-          mkdir -p .mypy_cache
-          poetry run mypy  --install-types --non-interactive --ignore-missing-imports --show-column-numbers --hide-error-context .
-        working-directory: "${{ matrix.module }}"
-
-      - name: Execute Python tests
-        id: execute-tests
-        run: |
-          poetry run python -m pytest --junit-xml=junit.xml --cov-report term --cov-report xml:coverage.xml --cov . --cov-config pyproject.toml
-        working-directory: "${{ matrix.module }}"
+      - name: Test with uv
+        if: steps.detect-pm.outputs.package_manager == 'uv'
+        uses: ./.github/actions/test-with-uv
+        with:
+          module: ${{ matrix.module }}
 
       - name: Upload Event
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Event File (${{ matrix.module }})
           path: ${{ github.event_path }}
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Unit Test Results (${{ matrix.module }})
           path: "${{ matrix.module }}/junit.xml"
 
       - name: Code Coverage Flag
         run: |
-          FLAG="${{ matrix.module }}"
+          FLAG="${MATRIX_MODULE}"
           FLAG=${FLAG// } # replace spaces
-          echo FLAG=${FLAG} >> $GITHUB_ENV # update GitHub ENV vars
+          echo "FLAG=${FLAG}" >> "$GITHUB_ENV" # update GitHub ENV vars
+        env:
+          MATRIX_MODULE: ${{ matrix.module }}
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.module }}/coverage.xml
@@ -118,33 +121,37 @@ jobs:
           fail_ci_if_error: true
 
   build-docker:
+    permissions:
+      contents: read  # for docker/build-push-action to access repository contents
+      packages: write  # for docker/login-action to push images to GHCR
     name: Build ${{ matrix.module }} docker image
     runs-on: ubuntu-latest
     needs: find-modules
-    if: needs.find-modules.outputs.matrix != '[]'
+    if: needs.find-modules.outputs.matrix != '[]' && github.actor != 'dependabot[bot]'
     strategy:
       matrix:
         module: ${{fromJSON(needs.find-modules.outputs.matrix)}}
       fail-fast: false
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Read Module Manifest
         id: read-module-manifest
         run: |
-          content=`cat "${{ matrix.module }}/manifest.json"`
+          content=$(cat "${MATRIX_MODULE}/manifest.json")
           # the following lines are only required for multi line json
           content="${content//$'\n'/''}"
           content="${content//$'\r'/''}"
           # end of optional handling for multi line json
-          echo $content
           echo "$content"
-          echo "manifest=$content" >> $GITHUB_OUTPUT
+          echo "manifest=$content" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_MODULE: ${{ matrix.module }}
 
       - name: Log in to the Container registry
         if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -152,7 +159,7 @@ jobs:
 
       - name: Log in to the secondary Container registry
         if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.SECONDARY_REGISTRY }}
           username: ${{ secrets.SECONDARY_REGISTRY_USERNAME }}
@@ -161,7 +168,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         if: ${{ github.event_name == 'push' }}
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX_NAME }}/automation-module-${{fromJson(steps.read-module-manifest.outputs.manifest).slug}}
@@ -174,10 +181,10 @@ jobs:
             type=pep440,pattern={{version}},value=${{fromJson(steps.read-module-manifest.outputs.manifest).version}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           push: ${{ github.event_name == 'push' }}
           context: ${{ matrix.Module }}
@@ -191,13 +198,13 @@ jobs:
     if: always()
 
     steps:
-    - name: Success
-      if: ${{ !(contains(needs.*.result, 'failure')) || needs.find-modules.outputs.matrix == '[]' }}
-      run: exit 0
-    - name: Failure
-      if: ${{ contains(needs.*.result, 'failure') && needs.find-modules.outputs.matrix != '[]' }}
-      run: |
-        exit 1
+      - name: Success
+        if: ${{ !(contains(needs.*.result, 'failure')) || needs.find-modules.outputs.matrix == '[]' }}
+        run: exit 0
+      - name: Failure
+        if: ${{ contains(needs.*.result, 'failure') && needs.find-modules.outputs.matrix != '[]' }}
+        run: |
+          exit 1
 
   deploy-module:
     name: Deploy modules
@@ -211,13 +218,13 @@ jobs:
     steps:
       - name: my-app-install token
         id: my-app
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789 # v4.0.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.my-app.outputs.token }}
           event-type: publish-automation-modules

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,9 +4,9 @@ name: Check Automation Modules
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -15,17 +15,21 @@ defaults:
   run:
     working-directory: _utils
 
+permissions: {}
+
 jobs:
   check_modules:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.10"

--- a/.github/workflows/generate-modules-list.yml
+++ b/.github/workflows/generate-modules-list.yml
@@ -5,28 +5,34 @@ on:
   push:
     branches:
       - main
+      - develop
+
+permissions: {}
 
 jobs:
   generate-modules-list:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: list-modules
         name: List modules
         run: |
-          echo "modules=$((cut -d "/" -f1 <<< "$(ls -a */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_ENV
+          echo "modules=$( (cut -d "/" -f1 <<< "$(ls -a -- */manifest.json)") | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_ENV"
 
       - name: my-app-install token
         id: my-app
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789 # v4.0.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.my-app.outputs.token }}
           event-type: refresh-automation-modules-list

--- a/.github/workflows/release_auto_approve.yml
+++ b/.github/workflows/release_auto_approve.yml
@@ -1,0 +1,24 @@
+name: Integration release auto-approve
+
+# Controls when the action will run.
+on:
+  pull_request:
+    branches: [production]
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  auto-approve:
+    permissions:
+      pull-requests: write  # for run step (declared via comment)
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login == 'integration-release-to-production' &&
+      github.event.pull_request.user.type == 'Bot'
+    steps:
+      - name: Approve a PR
+        run: gh pr review --repo "${{ github.repository }}" --approve "$PR_NUMBER"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # gha-perms:permissions=pull-requests:write

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -1,17 +1,21 @@
 name: Check linting
 on: push
 
+permissions: {}
+
 jobs:
   linter:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.10"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run
         working-directory: .

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -6,25 +6,28 @@ on:
     types:
       - completed
 
-permissions:
-  checks: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   unit-test-results:
+    permissions:
+      actions: read  # for dawidd6/action-download-artifact to query and download artifacts
+      checks: write  # for EnricoMi/publish-unit-test-result-action to create and update check runs
+      contents: read  # for EnricoMi/publish-unit-test-result-action to read commits and compare branches
+      pull-requests: write  # for EnricoMi/publish-unit-test-result-action to post and update PR comments
     name: Unit Test Results
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
       - name: Download Test Report
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File (*)/event.json


### PR DESCRIPTION
## Summary
This PR syncs GitHub Actions workflows from `develop` into `production` to keep CI/CD behavior aligned between the two branches.

## Changed workflows
- .github/workflows/build-modules.yml
- .github/workflows/checks.yml
- .github/workflows/generate-modules-list.yml
- .github/workflows/release_auto_approve.yml (new)
- .github/workflows/test_linting.yml
- .github/workflows/test_results.yml

## Notable updates
- Adds `develop` as trigger branch where applicable.
- Pins multiple actions to explicit SHAs.
- Introduces explicit least-privilege `permissions` blocks at workflow/job level.
- Adds package-manager detection in module tests (Poetry vs uv) and uses reusable local test actions.
- Adds auto-approve workflow for integration release PRs into `production`.
- Keeps scope strictly to workflow files (no module/runtime code changes).

## Validation
- Compared `.github/workflows` between `origin/production` and `origin/develop`.
- Copied workflow directory state from `origin/develop` onto a branch based on `origin/production`.
- Committed only workflow file changes.

## Summary by Sourcery

Align CI workflows between branches and tighten GitHub Actions security and behavior.

CI:
- Extend module build, checks, and modules-list workflows to run on both main and develop branches and skip certain jobs for Dependabot.
- Introduce least-privilege permissions blocks at workflow and job level across CI workflows.
- Pin all third-party GitHub Actions (checkout, setup-python, artifact handling, docker, Codecov, app token, repository dispatch, test result publishing) to specific SHAs.
- Add package-manager detection for module tests and delegate testing to reusable Poetry/uv local actions.
- Add an auto-approve workflow for integration release pull requests targeting the production branch.
- Refine module list generation and module diffing scripts to be more robust and shell-safe in CI jobs.