### PR TITLE
fix xdr incidents

### DIFF
--- a/MicrosoftDefender/CHANGELOG.md
+++ b/MicrosoftDefender/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-07-24 - 1.3.2
+
+### Fixed
+
+- Limit incidents connector `$top` query size to 50 (while keeping alerts at 1000) to match Microsoft Graph API limits and prevent incidents request failures.
+
 ## 2026-07-20 - 1.3.1
 
 ### Fixed

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -50,6 +50,6 @@
   "categories": [
     "Endpoint"
   ],
-  "version": "1.3.1",
+  "version": "1.3.2",
   "supports_validation": true
 }

--- a/MicrosoftDefender/microsoftdefender_modules/connector_base.py
+++ b/MicrosoftDefender/microsoftdefender_modules/connector_base.py
@@ -44,6 +44,7 @@ class BaseMicrosoftDefenderGraphAPIConnector(Connector):
     id_field: str = "id"
     context_cursor_key: str = "most_recent_date_requested"
     events_cache_context_key: str = "events_cache"
+    top_query_limit: int = 1000
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -137,7 +138,7 @@ class BaseMicrosoftDefenderGraphAPIConnector(Connector):
                 f"{self.timestamp_field} gt {start.strftime(self.RFC3339_STRICT_FORMAT)}"
                 f" and {self.timestamp_field} le {end.strftime(self.RFC3339_STRICT_FORMAT)}"
             ),
-            "$top": 1000,
+            "$top": self.top_query_limit,
         }
         params.update(self.extra_query_params())
         return params

--- a/MicrosoftDefender/microsoftdefender_modules/connector_defender_incidents.py
+++ b/MicrosoftDefender/microsoftdefender_modules/connector_defender_incidents.py
@@ -23,3 +23,4 @@ class MicrosoftDefenderGraphAPIIncidents(BaseMicrosoftDefenderGraphAPIConnector)
     id_field = "id"
     context_cursor_key = "most_recent_date_requested_incidents"
     events_cache_context_key = "incidents_events_cache"
+    top_query_limit = 50

--- a/MicrosoftDefender/tests/test_connector_defender_incidents.py
+++ b/MicrosoftDefender/tests/test_connector_defender_incidents.py
@@ -86,6 +86,7 @@ def test_fetch_events_hits_incidents_endpoint(trigger, requests_mock, start_time
         # requests_mock lowercases qs keys and values
         assert "createddatetime gt" in call.qs["$filter"][0]
         assert "createddatetime le" in call.qs["$filter"][0]
+        assert call.qs["$top"][0] == "50"
         # incidents are never expanded with nested alerts
         assert "$expand" not in call.qs
 

--- a/MicrosoftDefender/tests/test_connector_microsoft_defender_xdr.py
+++ b/MicrosoftDefender/tests/test_connector_microsoft_defender_xdr.py
@@ -217,6 +217,9 @@ def test_fetch_events(trigger, requests_mock, message, start_time, end_time):
         for events in gen:
             assert type(events) is list
 
+        call = requests_mock.last_request
+        assert call.qs["$top"][0] == "1000"
+
 
 def test_fetch_events_wrong_json(trigger, requests_mock, start_time, end_time):
     with patch("microsoftdefender_modules.client.auth.msal.ConfidentialClientApplication") as mock_msal:


### PR DESCRIPTION
## Summary by Sourcery

Adjust Microsoft Defender connector query limits and add tests to validate correct pagination configuration.

Bug Fixes:
- Ensure XDR incidents connector uses a reduced $top limit to avoid over-fetching incidents.

Enhancements:
- Introduce a configurable top_query_limit on the base Microsoft Defender connector used by all graph API queries.

Tests:
- Add assertions in XDR and incidents connector tests to verify the expected $top query parameter values.