### PR TITLE
fix/aws_fetch_vpc_flow_logs

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-28 - 1.37.1
+
+### Fixed
+
+- Detect Apache Parquet-type VPC flow logs in the AWS S3 text flow logs trigger, and exit gracefully with a warning message instead of attempting a UTF-8 decoding
+
 ## 2026-06-19 - 1.37.0
 
 ### Added

--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Detect Apache Parquet-type VPC flow logs in the AWS S3 text flow logs trigger, and exit gracefully with a warning message instead of attempting a UTF-8 decoding
+- Detect Apache Parquet-type VPC flow logs in the AWS S3 text flow logs trigger, and exit gracefully with a warning message instead of attempting UTF-8 decoding
 
 ## 2026-06-19 - 1.37.0
 

--- a/AWS/aws_helpers/utils.py
+++ b/AWS/aws_helpers/utils.py
@@ -24,6 +24,20 @@ def is_gzip_compressed(content: bytes) -> bool:
     return content[0:2] == b"\x1f\x8b"
 
 
+def is_parquet_content(content: bytes) -> bool:
+    """
+    Check if the current object appears to be an Apache Parquet file.
+
+    Args:
+        content: bytes
+
+    Returns:
+        bool:
+    """
+    # Parquet files start and end with the magic bytes PAR1.
+    return len(content) >= 8 and content[0:4] == b"PAR1" and content[-4:] == b"PAR1"
+
+
 def get_content(obj: dict[str, Any]) -> bytes:
     """
     Return the content of the object.

--- a/AWS/connectors/s3/trigger_s3_flowlogs.py
+++ b/AWS/connectors/s3/trigger_s3_flowlogs.py
@@ -3,8 +3,9 @@
 import ipaddress
 from collections.abc import AsyncGenerator
 from itertools import islice
+from typing import Any, cast
 
-from aws_helpers.utils import AsyncReader, is_parquet_content, unescape_string
+from aws_helpers.utils import AsyncReader, is_parquet_content
 from connectors.metrics import DISCARDED_EVENTS
 from connectors.s3 import AbstractAwsS3QueuedConnector, AwsS3LogsBaseConfiguration, AwsS3QueuedConfiguration
 from connectors.s3.provider import AwsAccountProvider
@@ -21,6 +22,16 @@ class BaseAwsS3FlowLogsTrigger:
 
     configuration: AwsS3FlowLogsConfiguration
     name = "AWS S3 Flow Logs"
+
+    def _warn_parquet_content(self) -> None:
+        """Log a warning when Parquet content is sent to the text flow logs trigger."""
+        cast(Any, self).log(
+            message=(
+                "Parquet content detected in AWS S3 Flow Logs text trigger. "
+                "Use the AWS S3 parquet flow logs trigger for .parquet objects."
+            ),
+            level="warning",
+        )
 
     @staticmethod
     def check_all_ips_are_private(input_str: str) -> bool:
@@ -50,18 +61,12 @@ class BaseAwsS3FlowLogsTrigger:
             stream: AsyncReader
 
         Returns:
-             Generator:
+             AsyncGenerator[str, None]:
         """
         content = await stream.read()
 
         if is_parquet_content(content):
-            self.log(
-                message=(
-                    "Parquet content detected in AWS S3 Flow Logs text trigger. "
-                    "Use the AWS S3 parquet flow logs trigger for .parquet objects."
-                ),
-                level="warning",
-            )
+            self._warn_parquet_content()
             return
 
         records: list[str] = []

--- a/AWS/connectors/s3/trigger_s3_flowlogs.py
+++ b/AWS/connectors/s3/trigger_s3_flowlogs.py
@@ -28,7 +28,7 @@ class BaseAwsS3FlowLogsTrigger:
         cast(Any, self).log(
             message=(
                 "Parquet content detected in AWS S3 Flow Logs text trigger. "
-                "Use the AWS S3 parquet flow logs trigger for .parquet objects."
+                "Use the AWS S3 Parquet records trigger for .parquet objects."
             ),
             level="warning",
         )

--- a/AWS/connectors/s3/trigger_s3_flowlogs.py
+++ b/AWS/connectors/s3/trigger_s3_flowlogs.py
@@ -28,7 +28,8 @@ class BaseAwsS3FlowLogsTrigger:
         cast(Any, self).log(
             message=(
                 "Parquet content detected in AWS S3 Flow Logs text trigger. "
-                "Use the AWS S3 Parquet records trigger for .parquet objects."
+                "Use the AWS S3 Parquet records trigger (Fetch new FlowLogs Parquet records on S3) "
+                "for .parquet objects."
             ),
             level="warning",
         )

--- a/AWS/connectors/s3/trigger_s3_flowlogs.py
+++ b/AWS/connectors/s3/trigger_s3_flowlogs.py
@@ -4,7 +4,7 @@ import ipaddress
 from collections.abc import AsyncGenerator
 from itertools import islice
 
-from aws_helpers.utils import AsyncReader, unescape_string
+from aws_helpers.utils import AsyncReader, is_parquet_content, unescape_string
 from connectors.metrics import DISCARDED_EVENTS
 from connectors.s3 import AbstractAwsS3QueuedConnector, AwsS3LogsBaseConfiguration, AwsS3QueuedConfiguration
 from connectors.s3.provider import AwsAccountProvider
@@ -53,6 +53,16 @@ class BaseAwsS3FlowLogsTrigger:
              Generator:
         """
         content = await stream.read()
+
+        if is_parquet_content(content):
+            self.log(
+                message=(
+                    "Parquet content detected in AWS S3 Flow Logs text trigger. "
+                    "Use the AWS S3 parquet flow logs trigger for .parquet objects."
+                ),
+                level="warning",
+            )
+            return
 
         records: list[str] = []
         for record in content.decode("utf-8").split(self.configuration.sep):

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -30,7 +30,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "categories": ["Cloud Providers"],
   "supports_validation": true
 }

--- a/AWS/tests/aws_helpers/test_utils.py
+++ b/AWS/tests/aws_helpers/test_utils.py
@@ -8,7 +8,14 @@ import aiofiles
 import pytest
 from faker import Faker
 
-from aws_helpers.utils import async_gzip_open, get_content, is_gzip_compressed, normalize_s3_key, unescape_string
+from aws_helpers.utils import (
+    async_gzip_open,
+    get_content,
+    is_gzip_compressed,
+    is_parquet_content,
+    normalize_s3_key,
+    unescape_string,
+)
 
 
 def test_normalize_s3_key():
@@ -55,6 +62,16 @@ def test_is_gzip_compressed():
     assert is_gzip_compressed(b"") is False
     assert is_gzip_compressed(parquet_content) is False
     assert is_gzip_compressed(gzip_content) is True
+
+
+def test_is_parquet_content():
+    """Test is_parquet_content function."""
+    parquet_content = b"PAR1\x15\x04\x15\x08\x150cbPAR1"
+    not_parquet_content = b"PAR1\x15\x04\x15\x08\x150cb"
+
+    assert is_parquet_content(b"") is False
+    assert is_parquet_content(not_parquet_content) is False
+    assert is_parquet_content(parquet_content) is True
 
 
 @pytest.mark.asyncio

--- a/AWS/tests/connectors/s3/test_trigger_s3_flowlogs.py
+++ b/AWS/tests/connectors/s3/test_trigger_s3_flowlogs.py
@@ -111,7 +111,8 @@ async def test_aws_s3_logs_trigger_parse_parquet_data(connector: AwsS3FlowLogsTr
     connector.log.assert_called_once_with(
         message=(
             "Parquet content detected in AWS S3 Flow Logs text trigger. "
-            "Use the AWS S3 Parquet records trigger for .parquet objects."
+            "Use the AWS S3 Parquet records trigger (Fetch new FlowLogs Parquet records on S3) "
+            "for .parquet objects."
         ),
         level="warning",
     )

--- a/AWS/tests/connectors/s3/test_trigger_s3_flowlogs.py
+++ b/AWS/tests/connectors/s3/test_trigger_s3_flowlogs.py
@@ -1,6 +1,7 @@
 """Tests related to AwsS3FlowLogsTrigger."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from faker import Faker
@@ -100,7 +101,17 @@ async def test_aws_s3_logs_trigger_parse_empty_data(connector: AwsS3FlowLogsTrig
 
 @pytest.mark.asyncio
 async def test_aws_s3_logs_trigger_parse_parquet_data(connector: AwsS3FlowLogsTrigger):
-    parquet_content = b"PAR1\x15\x04\x15\x08\x150cbPAR1"
+    # Include invalid UTF-8 bytes to ensure text decoding is never attempted.
+    parquet_content = b"PAR1\xc2\x15\x04\x15\x08\x150cbPAR1"
+    connector.log = MagicMock()
 
     async with async_temporary_file(parquet_content) as f:
         assert await async_list(connector._parse_content(f)) == []
+
+    connector.log.assert_called_once_with(
+        message=(
+            "Parquet content detected in AWS S3 Flow Logs text trigger. "
+            "Use the AWS S3 parquet flow logs trigger for .parquet objects."
+        ),
+        level="warning",
+    )

--- a/AWS/tests/connectors/s3/test_trigger_s3_flowlogs.py
+++ b/AWS/tests/connectors/s3/test_trigger_s3_flowlogs.py
@@ -96,3 +96,11 @@ async def test_aws_s3_logs_trigger_parse_data(connector: AwsS3FlowLogsTrigger, t
 async def test_aws_s3_logs_trigger_parse_empty_data(connector: AwsS3FlowLogsTrigger):
     async with async_temporary_file(b"") as f:
         assert await async_list(connector._parse_content(f)) == []
+
+
+@pytest.mark.asyncio
+async def test_aws_s3_logs_trigger_parse_parquet_data(connector: AwsS3FlowLogsTrigger):
+    parquet_content = b"PAR1\x15\x04\x15\x08\x150cbPAR1"
+
+    async with async_temporary_file(parquet_content) as f:
+        assert await async_list(connector._parse_content(f)) == []

--- a/AWS/tests/connectors/s3/test_trigger_s3_flowlogs.py
+++ b/AWS/tests/connectors/s3/test_trigger_s3_flowlogs.py
@@ -111,7 +111,7 @@ async def test_aws_s3_logs_trigger_parse_parquet_data(connector: AwsS3FlowLogsTr
     connector.log.assert_called_once_with(
         message=(
             "Parquet content detected in AWS S3 Flow Logs text trigger. "
-            "Use the AWS S3 parquet flow logs trigger for .parquet objects."
+            "Use the AWS S3 Parquet records trigger for .parquet objects."
         ),
         level="warning",
     )


### PR DESCRIPTION
## Description

Fixes https://github.com/SekoiaLab/integration/issues/1827

### Fixed

- Detect Apache Parquet-type VPC flow logs in the AWS S3 text flow logs trigger, and exit gracefully with a warning message instead of attempting a UTF-8 decoding

## Summary by Sourcery

Handle Apache Parquet VPC flow log objects in the AWS S3 text flow logs trigger without attempting to decode them as UTF-8.

Bug Fixes:
- Detect Parquet-formatted VPC flow logs in the AWS S3 text flow logs trigger and skip processing them with a clear warning instead of failing on UTF-8 decoding.

Documentation:
- Update the AWS changelog with the Parquet VPC flow logs handling fix.

Tests:
- Add unit tests for Parquet content detection and for skipping Parquet data in the AWS S3 flow logs trigger.