### PR TITLE
fix(tenable): api model fix

### DIFF
--- a/Tenable/CHANGELOG.md
+++ b/Tenable/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-29 - 1.0.18
+
+### Fixed
+
+- Fix `AssetInfo` model to accept float values for `aes_score_v3` and `acr_score_v3` fields returned by the Tenable API
+- Fix `TagsObject` model to accept `None` for the `added_by` field
+
 ## 2026-05-20 - 1.0.17
 
 ### Changed

--- a/Tenable/manifest.json
+++ b/Tenable/manifest.json
@@ -30,7 +30,7 @@
   "description": "Tenable is a cybersecurity company specializing in vulnerability management and risk assessment solutions, known for its flagship product, Nessus. It helps organizations identify, assess, and prioritize security risks across their IT infrastructure.",
   "name": "Tenable Vulnerability Management",
   "uuid": "1214e603-6c86-4e86-896f-70198c9ade86",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "slug": "tenable",
   "categories": [
     "Endpoint"

--- a/Tenable/tenable_conn/asset_connector/model.py
+++ b/Tenable/tenable_conn/asset_connector/model.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class TagsObject(BaseModel):
     tag_uuid: str
     tag_key: str
     tag_value: str
-    added_by: str
+    added_by: Optional[str] = None
     added_at: str
 
 
@@ -35,8 +35,8 @@ class AssetInfo(BaseModel):
     updated_at: Optional[str] = None
     terminated_at: Optional[str] = None
     deleted_at: Optional[str] = None
-    aes_score_v3: Optional[str] = None
-    acr_score_v3: Optional[str] = None
+    aes_score_v3: Optional[float] = None
+    acr_score_v3: Optional[float] = None
     first_seen: Optional[str] = None
     last_seen: Optional[str] = None
     last_scan_target: Optional[str] = None

--- a/Tenable/tenable_conn/asset_connector/model.py
+++ b/Tenable/tenable_conn/asset_connector/model.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
 
 
 class TagsObject(BaseModel):

--- a/Tenable/tests/asset_connector/test_vulnerability_asset.py
+++ b/Tenable/tests/asset_connector/test_vulnerability_asset.py
@@ -1078,9 +1078,6 @@ def test_get_vulnerabilities_checkpoint_advances_when_all_vulns_have_no_cve(
     assert tenable_asset_connector._latest_time == expected_ts
 
 
-# ==================== Regression tests for model validation bug fixes ====================
-
-
 def test_asset_info_accepts_float_scores():
     """Regression: API returns float values for aes_score_v3/acr_score_v3 (e.g. 704.0, 5.0)."""
     asset = AssetInfo.model_validate({"id": "test-uuid", "aes_score_v3": 704.0, "acr_score_v3": 5.0})

--- a/Tenable/tests/asset_connector/test_vulnerability_asset.py
+++ b/Tenable/tests/asset_connector/test_vulnerability_asset.py
@@ -20,6 +20,7 @@ from tenable_conn.asset_connector.vulnerability_asset import (
 )
 from tenable_conn.asset_connector.model import (
     AssetInfo,
+    TagsObject,
     Vulnerability as TenableVulnerability,
     NetworkInterface as TenableNetworkInterface,
 )
@@ -37,7 +38,7 @@ def asset_info():
         "terminated_at": None,
         "deleted_at": None,
         "aes_score_v3": None,
-        "acr_score_v3": "one",
+        "acr_score_v3": 5.0,
         "first_seen": "2025-08-26T14:34:38.000Z",
         "last_seen": "2025-08-26T14:34:38.571Z",
         "last_scan_target": "97.195.198.2",
@@ -1075,3 +1076,79 @@ def test_get_vulnerabilities_checkpoint_advances_when_all_vulns_have_no_cve(
     assert len(results) == 0
     expected_ts = int(datetime.fromisoformat(ts2).timestamp())
     assert tenable_asset_connector._latest_time == expected_ts
+
+
+# ==================== Regression tests for model validation bug fixes ====================
+
+
+def test_asset_info_accepts_float_scores():
+    """Regression: API returns float values for aes_score_v3/acr_score_v3 (e.g. 704.0, 5.0)."""
+    asset = AssetInfo.model_validate({"id": "test-uuid", "aes_score_v3": 704.0, "acr_score_v3": 5.0})
+    assert asset.aes_score_v3 == 704.0
+    assert asset.acr_score_v3 == 5.0
+
+
+def test_asset_info_accepts_none_scores():
+    """Regression: API can return None for aes_score_v3/acr_score_v3."""
+    asset = AssetInfo.model_validate({"id": "test-uuid", "aes_score_v3": None, "acr_score_v3": None})
+    assert asset.aes_score_v3 is None
+    assert asset.acr_score_v3 is None
+
+
+def test_asset_info_scores_default_to_none():
+    """Scores default to None when not provided by the API."""
+    asset = AssetInfo(id="test-uuid")
+    assert asset.aes_score_v3 is None
+    assert asset.acr_score_v3 is None
+
+
+def test_tags_object_accepts_none_added_by():
+    """Regression: API can return None for TagsObject.added_by."""
+    tag = TagsObject.model_validate(
+        {
+            "tag_uuid": "uuid-1",
+            "tag_key": "env",
+            "tag_value": "production",
+            "added_by": None,
+            "added_at": "2025-01-01T00:00:00Z",
+        }
+    )
+    assert tag.added_by is None
+
+
+def test_tags_object_accepts_string_added_by():
+    """TagsObject.added_by accepts a regular string value."""
+    tag = TagsObject.model_validate(
+        {
+            "tag_uuid": "uuid-1",
+            "tag_key": "env",
+            "tag_value": "production",
+            "added_by": "user@example.com",
+            "added_at": "2025-01-01T00:00:00Z",
+        }
+    )
+    assert tag.added_by == "user@example.com"
+
+
+def test_asset_info_with_tags_none_added_by():
+    """Regression: AssetInfo with tags where added_by is None should validate correctly."""
+    asset = AssetInfo.model_validate(
+        {
+            "id": "c81eee07-2df7-47f3-954d-79cbffd7a890",
+            "aes_score_v3": 704.0,
+            "acr_score_v3": 5.0,
+            "tags": [
+                {
+                    "tag_uuid": "uuid-1",
+                    "tag_key": "env",
+                    "tag_value": "production",
+                    "added_by": None,
+                    "added_at": "2025-01-01T00:00:00Z",
+                }
+            ],
+        }
+    )
+    assert asset.id == "c81eee07-2df7-47f3-954d-79cbffd7a890"
+    assert asset.aes_score_v3 == 704.0
+    assert asset.acr_score_v3 == 5.0
+    assert asset.tags[0].added_by is None


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/integration/issues/1815)

## Summary by Sourcery

Update Tenable asset models to align with current API responses and prevent validation errors.

Bug Fixes:
- Allow AssetInfo aes_score_v3 and acr_score_v3 fields to accept float values from the Tenable API.
- Allow TagsObject.added_by to be null when the Tenable API omits or nulls this field.

Documentation:
- Document the Tenable AssetInfo and TagsObject model fixes in the changelog.

Tests:
- Add regression tests ensuring AssetInfo accepts float and null score fields and defaults them to None when absent.
- Add regression tests ensuring TagsObject.added_by accepts both null and string values, including when used within AssetInfo tags.

Chores:
- Bump Tenable connector manifest version to 1.0.18.