### PR TITLE
fix(MicrosoftEntraID): use a valid capability for the user asset connector

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-29 - 2.10.25
+
+### Fixed
+
+- Update the capability of the user asset connector
+
 ## 2026-07-08 - 2.10.24
 
 ### Fixed

--- a/MicrosoftEntraID/connector_entra_id_user_assets.json
+++ b/MicrosoftEntraID/connector_entra_id_user_assets.json
@@ -4,7 +4,7 @@
   "uuid": "b6e2e2e2-4c3a-4b7a-9e2a-1f2c3d4e5f6a",
   "docker_parameters": "entra_id_asset_connector",
   "type": "asset",
-  "capability": "user",
+  "capability": "account_detection",
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.10.24",
+  "version": "2.10.25",
   "categories": [
     "IAM"
   ],


### PR DESCRIPTION
The Entra ID user asset connector declared `"capability": "user"`, which is not part of the enum accepted by the platform (`account_detection`, `host_detection`, `vulnerability_enrichment`, `software_enrichment`). The value is rejected on sync, so the connector ends up with `capability = NULL` and the Asset connectors listing shows no count for it.

Same fix as #1600 did for Microsoft Active Directory.

Related: SekoiaLab/integration#1829

## Summary by Sourcery

Fix Microsoft Entra ID user asset connector capability and bump integration version.

Bug Fixes:
- Set the Microsoft Entra ID user asset connector capability to a platform-supported value so it is correctly recognized and counted.

Enhancements:
- Bump Microsoft Entra ID integration version to 2.10.25 and document the change in the changelog.