### PR TITLE
fix(sentinelone): duplication of events

### DIFF
--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-29 - 1.23.1
+
+### Fixed
+
+- Fix event duplication after unexpected pod restart by persisting the events cache to disk after each pagination page instead of only on clean shutdown
+
 ## 2026-03-20 - 1.23.0
 
 ### Added

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -27,7 +27,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "categories": [
     "Endpoint"
   ],

--- a/SentinelOne/sentinelone_module/logs/connector.py
+++ b/SentinelOne/sentinelone_module/logs/connector.py
@@ -187,9 +187,6 @@ class SentinelOneLogsConsumer(Thread):
         while self.running:
             self.next_batch()
 
-        # save sessions cache to the context
-        self.save_events_cache(self.session_events_cache)
-
         self.connector._executor.shutdown(wait=True)
 
 
@@ -252,6 +249,9 @@ class SentinelOneActivityLogsConsumer(SentinelOneLogsConsumer):
                 current_lag = int((datetime.now(UTC) - latest_event_timestamp).total_seconds())
 
             EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="activities").set(current_lag)
+
+            # Persist cache after each page so it survives unexpected pod restarts
+            self.save_events_cache(self.session_events_cache)
 
             if activities_response.pagination["nextCursor"] is None:
                 break
@@ -318,6 +318,9 @@ class SentinelOneThreatLogsConsumer(SentinelOneLogsConsumer):
                 current_lag = int((datetime.now(UTC) - latest_event_timestamp).total_seconds())
 
             EVENTS_LAG.labels(intake_key=self.configuration.intake_key, type="threats").set(current_lag)
+
+            # Persist cache after each page so it survives unexpected pod restarts
+            self.save_events_cache(self.session_events_cache)
 
             if threat_response.pagination["nextCursor"] is None:
                 break


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/platform/issues/89962)

## Summary by Sourcery

Prevent duplicate SentinelOne events by persisting the events cache after each paginated API page instead of only on connector shutdown.

Bug Fixes:
- Avoid event duplication after unexpected pod restarts by saving the session events cache incrementally during event pulling.

Enhancements:
- Improve resilience of the SentinelOne connector by ensuring the events cache survives unclean shutdowns.

Build:
- Bump SentinelOne integration manifest version from 1.23.0 to 1.23.1.

Documentation:
- Update SentinelOne changelog with version 1.23.1 and the corresponding fix description.