### PR TITLE
fix(MicrosoftDefender): stop device asset connector re-collecting the boundary device

### DIFF
--- a/MicrosoftDefender/CHANGELOG.md
+++ b/MicrosoftDefender/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-07-30 - 1.3.3
+
+### Fixed
+
+- Device asset connector: use a strict `lastSeen gt <checkpoint>` filter (instead of `ge`) and store the checkpoint with microsecond precision, so the most recently seen device is no longer re-collected on every cycle. This kept the connector running back-to-back (no idle sleep) and re-pushing the same devices, driving compliance ingestion lag.
+
 ## 2026-07-24 - 1.3.2
 
 ### Fixed

--- a/MicrosoftDefender/asset_connector/device_assets.py
+++ b/MicrosoftDefender/asset_connector/device_assets.py
@@ -342,7 +342,7 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
         machines: list[DefenderMachine] = []
         endpoint = self.MACHINES_ENDPOINT
         if self.most_recent_date_seen:
-            params = urlencode({"$filter": f"lastSeen ge {self.most_recent_date_seen}"})
+            params = urlencode({"$filter": f"lastSeen gt {self.most_recent_date_seen}"})
             endpoint = f"{endpoint}?{params}"
         url: str | None = urljoin(self.defender_client.base_url, endpoint)
 
@@ -420,4 +420,4 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
         if self._latest_time:
             dt_utc = self._latest_time.astimezone(timezone.utc).replace(tzinfo=None)
             with self.context as cache:
-                cache["most_recent_date_seen"] = dt_utc.isoformat(timespec="milliseconds") + "Z"
+                cache["most_recent_date_seen"] = dt_utc.isoformat(timespec="microseconds") + "Z"

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -50,6 +50,6 @@
   "categories": [
     "Endpoint"
   ],
-  "version": "1.3.2",
+  "version": "1.3.3",
   "supports_validation": true
 }

--- a/MicrosoftDefender/tests/asset_connector/test_device_assets.py
+++ b/MicrosoftDefender/tests/asset_connector/test_device_assets.py
@@ -325,7 +325,7 @@ class TestFetchMachines:
             connector._fetch_machines()
             called_url = mock_client.get.call_args[0][0]
 
-        assert "%24filter=lastSeen+ge+2024-01-01T00%3A00%3A00%2B00%3A00" in called_url
+        assert "%24filter=lastSeen+gt+2024-01-01T00%3A00%3A00%2B00%3A00" in called_url
 
     def test_no_filter_without_checkpoint(self, connector, sample_defender_machine):
         mock_response = MagicMock()
@@ -456,11 +456,11 @@ class TestGetAssets:
 class TestUpdateCheckpoint:
     @pytest.mark.asyncio
     async def test_updates_context(self, connector):
-        connector._latest_time = datetime(2025, 4, 20, 14, 22, 0, tzinfo=timezone.utc)
+        connector._latest_time = datetime(2025, 4, 20, 14, 22, 0, 123456, tzinfo=timezone.utc)
         await connector.update_checkpoint()
 
         with connector.context as cache:
-            assert cache["most_recent_date_seen"] == "2025-04-20T14:22:00.000Z"
+            assert cache["most_recent_date_seen"] == "2025-04-20T14:22:00.123456Z"
 
     @pytest.mark.asyncio
     async def test_no_update_when_no_latest(self, connector):


### PR DESCRIPTION
The Microsoft Defender device asset connector filtered machines with `lastSeen ge <checkpoint>` and stored the checkpoint as `max(lastSeen)` truncated to milliseconds.

With the inclusive `ge` filter, the most recently seen device (whose `lastSeen == checkpoint`) was re-collected on every cycle. And since the SDK only sleeps for `frequency` when a cycle returns **zero** assets (`asset_fetch_cycle`), the connector never went idle: it ran back-to-back and re-pushed the same devices continuously (observed ~1 run every 5s in prod, a single device re-ingested 615x in 8h), driving the compliance ingestion lag.

This changes the filter to a strict `gt` and stores the checkpoint with microsecond precision (Defender `lastSeen` has sub-millisecond precision, so `gt` on a millisecond-truncated checkpoint would still re-match the boundary device). When nothing is newer the cycle is empty and the connector sleeps for the configured `frequency`.

Related: SekoiaLab/platform#90667

## Summary by Sourcery

Prevent the Microsoft Defender device asset connector from continuously re-collecting the most recently seen device by tightening the collection filter and timestamp checkpoint precision.

Bug Fixes:
- Ensure device asset collection uses a strict `lastSeen > checkpoint` filter so the boundary device is not re-collected every cycle.
- Persist the device asset connector checkpoint with microsecond precision to align with Defender timestamps and avoid re-matching previously seen devices.

Documentation:
- Document the 1.3.3 fix in the Microsoft Defender connector changelog, including the updated filtering and checkpoint behavior.

Tests:
- Update device asset connector tests to assert the new strict `gt` filter and microsecond-precision checkpoint value.

Chores:
- Bump the Microsoft Defender connector manifest version from 1.3.2 to 1.3.3.