### PR TITLE
fix(microsoft_defender): fix duplication

### DIFF
--- a/MicrosoftDefender/CHANGELOG.md
+++ b/MicrosoftDefender/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-07-30 - 1.3.4
+
+### Fixed
+
+- Store the raw `lastSeen` string from the API directly as checkpoint instead of converting to `datetime` and back.
+
 ## 2026-07-30 - 1.3.3
 
 ### Fixed

--- a/MicrosoftDefender/asset_connector/device_assets.py
+++ b/MicrosoftDefender/asset_connector/device_assets.py
@@ -1,5 +1,5 @@
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
+from datetime import datetime
 from functools import cached_property
 from urllib.parse import urlencode, urljoin
 
@@ -87,6 +87,7 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("device_context.json", self._data_path)
+        self._latest_time_raw: str | None = None
 
     @property
     def most_recent_date_seen(self) -> str | None:
@@ -384,7 +385,7 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
 
     async def get_assets(self) -> AsyncGenerator[DeviceOCSFModel, None]:
         """Yield OCSF DeviceOCSFModel: fetch Defender machines, enrich with Graph managed devices."""
-        most_recent: datetime | None = None
+        most_recent_raw: str | None = None
 
         machines = self._fetch_machines()
 
@@ -406,18 +407,15 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
                 )
                 continue
 
-            # Track most recent lastSeen for checkpoint
             if machine.lastSeen:
-                last_seen_dt = isoparse(machine.lastSeen)
-                if most_recent is None or last_seen_dt > most_recent:
-                    most_recent = last_seen_dt
+                if most_recent_raw is None or isoparse(machine.lastSeen) > isoparse(most_recent_raw):
+                    most_recent_raw = machine.lastSeen
 
             yield ocsf_device
 
-        self._latest_time = most_recent
+        self._latest_time_raw = most_recent_raw
 
     async def update_checkpoint(self) -> None:
-        if self._latest_time:
-            dt_utc = self._latest_time.astimezone(timezone.utc).replace(tzinfo=None)
+        if self._latest_time_raw:
             with self.context as cache:
-                cache["most_recent_date_seen"] = dt_utc.isoformat(timespec="microseconds") + "Z"
+                cache["most_recent_date_seen"] = self._latest_time_raw

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -50,6 +50,6 @@
   "categories": [
     "Endpoint"
   ],
-  "version": "1.3.3",
+  "version": "1.3.4",
   "supports_validation": true
 }

--- a/MicrosoftDefender/tests/asset_connector/test_device_assets.py
+++ b/MicrosoftDefender/tests/asset_connector/test_device_assets.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -456,16 +456,97 @@ class TestGetAssets:
 class TestUpdateCheckpoint:
     @pytest.mark.asyncio
     async def test_updates_context(self, connector):
-        connector._latest_time = datetime(2025, 4, 20, 14, 22, 0, 123456, tzinfo=timezone.utc)
+        connector._latest_time_raw = "2025-04-20T14:22:00.123456Z"
         await connector.update_checkpoint()
 
         with connector.context as cache:
             assert cache["most_recent_date_seen"] == "2025-04-20T14:22:00.123456Z"
 
     @pytest.mark.asyncio
+    async def test_preserves_seven_digit_precision(self, connector):
+        # Defender timestamps can have 7 fractional digits (.NET 100-nanosecond precision).
+        # Storing the raw string avoids truncation to microseconds which would make the
+        # checkpoint slightly behind the real value and cause the last asset to pass the
+        # `gt` filter again on the next run (duplication).
+        raw = "2025-04-20T14:22:00.1234567Z"
+        connector._latest_time_raw = raw
+        await connector.update_checkpoint()
+
+        with connector.context as cache:
+            assert cache["most_recent_date_seen"] == raw
+
+    @pytest.mark.asyncio
     async def test_no_update_when_no_latest(self, connector):
-        connector._latest_time = None
+        connector._latest_time_raw = None
         await connector.update_checkpoint()
 
         with connector.context as cache:
             assert "most_recent_date_seen" not in cache
+
+
+class TestGetAssetsCheckpointTracking:
+    def _make_mock_response(self, machines: list):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"value": [m.dict() for m in machines]}
+        return mock_response
+
+    @pytest.mark.asyncio
+    async def test_latest_time_raw_set_to_most_recent_last_seen(self, connector):
+        machines = [
+            DefenderMachine(id="a", lastSeen="2024-06-01T10:00:00.0000000Z"),
+            DefenderMachine(id="b", lastSeen="2024-06-03T10:00:00.0000000Z"),
+            DefenderMachine(id="c", lastSeen="2024-06-02T10:00:00.0000000Z"),
+        ]
+
+        with patch.object(connector, "defender_client", create=True) as mock_client:
+            mock_client.base_url = "https://api.securitycenter.microsoft.com"
+            mock_client.get = Mock(return_value=self._make_mock_response(machines))
+            async for _ in connector.get_assets():
+                pass
+
+        assert connector._latest_time_raw == "2024-06-03T10:00:00.0000000Z"
+
+    @pytest.mark.asyncio
+    async def test_latest_time_raw_preserves_seven_digit_precision(self, connector):
+        # Ensure the raw string with 7 fractional digits is kept verbatim.
+        raw = "2024-12-01T10:00:00.1234567Z"
+        machine = DefenderMachine(id="precise", lastSeen=raw)
+
+        with patch.object(connector, "defender_client", create=True) as mock_client:
+            mock_client.base_url = "https://api.securitycenter.microsoft.com"
+            mock_client.get = Mock(return_value=self._make_mock_response([machine]))
+            async for _ in connector.get_assets():
+                pass
+
+        assert connector._latest_time_raw == raw
+
+    @pytest.mark.asyncio
+    async def test_latest_time_raw_none_when_no_last_seen(self, connector):
+        machine = DefenderMachine(id="no-date")
+
+        with patch.object(connector, "defender_client", create=True) as mock_client:
+            mock_client.base_url = "https://api.securitycenter.microsoft.com"
+            mock_client.get = Mock(return_value=self._make_mock_response([machine]))
+            async for _ in connector.get_assets():
+                pass
+
+        assert connector._latest_time_raw is None
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_persisted_after_get_assets_and_update(self, connector):
+        # Full cycle: get_assets sets _latest_time_raw, update_checkpoint persists it,
+        # next _fetch_machines call uses it as filter.
+        raw = "2024-12-01T10:00:00.1234567Z"
+        machine = DefenderMachine(id="m1", lastSeen=raw)
+
+        response = self._make_mock_response([machine])
+        with patch.object(connector, "defender_client", create=True) as mock_client:
+            mock_client.base_url = "https://api.securitycenter.microsoft.com"
+            mock_client.get = Mock(return_value=response)
+            async for _ in connector.get_assets():
+                pass
+            await connector.update_checkpoint()
+
+        with connector.context as cache:
+            assert cache["most_recent_date_seen"] == raw

--- a/MicrosoftDefender/tests/asset_connector/test_device_assets.py
+++ b/MicrosoftDefender/tests/asset_connector/test_device_assets.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest


### PR DESCRIPTION
main issue : [issue](https://github.com/SekoiaLab/platform/issues/90667)

## Summary by Sourcery

Preserve Microsoft Defender asset connector checkpoints using the raw lastSeen timestamp string to avoid asset duplication caused by precision loss.

Bug Fixes:
- Prevent duplicated assets by storing the Defender lastSeen timestamp checkpoint as the original ISO string instead of converting to datetime and truncating precision.

Enhancements:
- Track the most recent lastSeen value in get_assets using string-based comparison via parsed timestamps while retaining the exact original value.

Build:
- Bump the Microsoft Defender connector manifest version from 1.3.3 to 1.3.4.

Documentation:
- Update the changelog with a new 1.3.4 entry describing the timestamp checkpoint fix.

Tests:
- Extend device asset connector tests to cover raw lastSeen checkpoint storage, precision preservation, and end-to-end checkpoint usage across get_assets and update_checkpoint.