### PR TITLE
fix(microsoft_xdr): add frequency

### DIFF
--- a/MicrosoftDefender/CHANGELOG.md
+++ b/MicrosoftDefender/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-07-30 - 1.3.5
+
+### Changed
+
+- Device asset connector: change default `frequency` from 60 s to 86400 s (24 h).
+
 ## 2026-07-30 - 1.3.4
 
 ### Fixed

--- a/MicrosoftDefender/connector_microsoft_defender_device_assets.json
+++ b/MicrosoftDefender/connector_microsoft_defender_device_assets.json
@@ -17,7 +17,7 @@
         "type": "integer",
         "description": "Batch frequency in seconds",
         "minimum": 1,
-        "default": 60
+        "default": 86400
       },
       "sekoia_api_key": {
         "description": "API key to use from sekoia.io",

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -50,6 +50,6 @@
   "categories": [
     "Endpoint"
   ],
-  "version": "1.3.4",
+  "version": "1.3.5",
   "supports_validation": true
 }


### PR DESCRIPTION
## Summary by Sourcery

Update Microsoft Defender device asset connector configuration for the 1.3.5 release.

Enhancements:
- Adjust device asset connector default polling frequency from 60 seconds to 24 hours.

Build:
- Bump Microsoft Defender integration version from 1.3.4 to 1.3.5 in the manifest.

Documentation:
- Add 1.3.5 release notes describing the updated device asset connector frequency.