### PR TITLE
Fix: Aws Include Necessary Events (1844)

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-31 - 1.38.0
+
+### Added
+
+- Collect reconnaissance events in the AWS S3 CloudTrail records trigger that were previously filtered out by the
+  `List`/`Describe` prefix filters: `ec2:DescribeInstances`, `iam:ListRoles`, `iam:ListUsers`, `iam:ListAccessKeys`,
+  `secretsmanager:ListSecrets` and `ssm:DescribeParameters`
+
 ## 2026-07-28 - 1.37.1
 
 ### Fixed

--- a/AWS/connectors/s3/trigger_s3_records.py
+++ b/AWS/connectors/s3/trigger_s3_records.py
@@ -37,7 +37,8 @@ class BaseAwsS3RecordsTrigger:
                 "CreateTags",
                 "DeleteTags",
                 "DescribeAddresses",
-                "DescribeInstances",
+                # DescribeInstances is deliberately collected: it is a key reconnaissance action
+                # performed with stolen EC2 credentials. See _forced_events below.
                 "DescribeInstanceStatus",
                 "DescribePublicIpv4Pools",
                 "DescribeSubnets",
@@ -50,6 +51,15 @@ class BaseAwsS3RecordsTrigger:
             ],
         },
         "default": {"unsupported": ["List", "Describe", "GetRecords"]},
+    }
+
+    # Reconnaissance actions that must always be collected, even though their name matches one of the
+    # unsupported prefixes above. Keyed by eventSource, matched on the exact event name so that noisier
+    # neighbours (ListUserPolicies, ListSecretVersionIds, ...) keep being filtered out.
+    _forced_events = {
+        "iam.amazonaws.com": {"ListAccessKeys", "ListRoles", "ListUsers"},
+        "secretsmanager.amazonaws.com": {"ListSecrets"},
+        "ssm.amazonaws.com": {"DescribeParameters"},
     }
 
     @classmethod
@@ -65,6 +75,10 @@ class BaseAwsS3RecordsTrigger:
         """
         event_source = payload.get("eventSource", "")
         event_name = payload.get("eventName", "")
+
+        if event_name in cls._forced_events.get(event_source, set()):
+            return True
+
         if event_source not in cls._events_prefixes.keys():
             event_source = "default"
 

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -30,7 +30,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "categories": ["Cloud Providers"],
   "supports_validation": true
 }

--- a/AWS/tests/connectors/s3/test_trigger_s3_records.py
+++ b/AWS/tests/connectors/s3/test_trigger_s3_records.py
@@ -113,10 +113,59 @@ def test_check_if_payload_is_valid_1(connector: AwsS3RecordsTrigger, session_fak
     assert connector.is_valid_payload({"eventSource": "random.amazonaws.com", "eventName": "Random"}) is True
     assert connector.is_valid_payload({"eventSource": "random.amazonaws.com", "eventName": "GetRecords"}) is False
 
-    assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "DescribeInstances"}) is False
+    assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "DescribeInstances"}) is True
     assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "CreateImage"}) is True
     assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "DescribeTags"}) is False
     assert connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "CreateTags"}) is False
+    assert (
+        connector.is_valid_payload({"eventSource": "ec2.amazonaws.com", "eventName": "DescribeInstanceStatus"})
+        is False
+    )
+
+
+def test_check_if_payload_is_valid_reconnaissance_events(connector: AwsS3RecordsTrigger):
+    """
+    Reconnaissance events performed with stolen EC2 credentials must be collected,
+    even though their name matches an unsupported prefix.
+
+    Args:
+        connector: AwsS3RecordsTrigger
+    """
+    forced_events = [
+        ("iam.amazonaws.com", "ListRoles"),
+        ("iam.amazonaws.com", "ListUsers"),
+        ("iam.amazonaws.com", "ListAccessKeys"),
+        ("secretsmanager.amazonaws.com", "ListSecrets"),
+        ("ssm.amazonaws.com", "DescribeParameters"),
+        ("ec2.amazonaws.com", "DescribeInstances"),
+    ]
+
+    for event_source, event_name in forced_events:
+        assert connector.is_valid_payload({"eventSource": event_source, "eventName": event_name}) is True
+
+    # Neighbouring event names are matched exactly, so they keep being filtered out
+    still_filtered = [
+        ("iam.amazonaws.com", "ListUserPolicies"),
+        ("iam.amazonaws.com", "ListRoleTags"),
+        ("secretsmanager.amazonaws.com", "ListSecretVersionIds"),
+        ("ssm.amazonaws.com", "DescribeInstanceInformation"),
+        # The exception is scoped to its event source
+        ("random.amazonaws.com", "ListRoles"),
+    ]
+
+    for event_source, event_name in still_filtered:
+        assert connector.is_valid_payload({"eventSource": event_source, "eventName": event_name}) is False
+
+    # Non read-only events of those sources are still collected
+    not_filtered = [
+        ("iam.amazonaws.com", "CreateUser"),
+        ("iam.amazonaws.com", "AttachRolePolicy"),
+        ("secretsmanager.amazonaws.com", "GetSecretValue"),
+        ("ssm.amazonaws.com", "SendCommand"),
+    ]
+
+    for event_source, event_name in not_filtered:
+        assert connector.is_valid_payload({"eventSource": event_source, "eventName": event_name}) is True
 
 
 def test_check_if_payload_is_valid_2(connector: AwsS3RecordsTrigger, session_faker: Faker):


### PR DESCRIPTION
Relates to [1844](https://github.com/SekoiaLab/integration/issues/1844)

## Summary by Sourcery

Adjust AWS S3 CloudTrail records trigger to always collect specific reconnaissance events that were previously filtered out and bump the AWS integration version.

New Features:
- Collect key reconnaissance CloudTrail events such as EC2 DescribeInstances and IAM/Secrets Manager/SSM listing and describing actions that were previously excluded by prefix filters.

Enhancements:
- Introduce a forced-events mechanism in the AWS S3 records trigger to override generic unsupported prefix rules for selected event sources and names.

Build:
- Update the AWS integration manifest to version 1.38.0.

Documentation:
- Update the AWS changelog to document collection of additional reconnaissance events and the new 1.38.0 release.

Tests:
- Extend AWS S3 records trigger tests to cover forced reconnaissance events, neighbouring events that remain filtered, and non read-only events that are still collected.