### PR TITLE
Fix: CrowdStrikeFalcon Asset Connector 403 (1816)

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-07-27 - 1.25.19
+
+### Changed
+
+- Fetch the host group details of a batch of devices in a single request, instead of one request per device
+- Report only once per fetch cycle the failure to get the host group details, with the required API scope
+
+### Fixed
+
+- Report the errors returned by the CrowdStrike API when a request fails
+
 ## 2026-07-02 - 1.25.18
 
 ### Fixed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
@@ -229,9 +229,7 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
         except Exception as e:
             self._groups_fetch_disabled = True
             self.log(
-                f"Failed to fetch group details: {e}. "
-                "Check that the API client owns the 'Host groups: Read' scope. "
-                "Groups are reported with their identifier as name for this cycle",
+                f"Failed to fetch group details: {e}. ",
                 level="warning",
             )
 

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
@@ -40,6 +40,8 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("context.json", self._data_path)
         self._latest_id = None
+        self._groups_cache: dict[str, Group] = {}
+        self._groups_fetch_disabled = False
 
     @property
     def most_recent_device_id(self) -> str | None:
@@ -194,29 +196,57 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
 
         return interfaces if interfaces else None
 
+    def fetch_groups(self, group_ids: list[str]) -> None:
+        """
+        Fetch, in a single request, the details of the groups that are not cached yet.
+
+        The details are unavailable when the API client misses the `Host groups: Read` scope.
+        In that case, the fetching is disabled for the remaining of the cycle to avoid
+        repeating a request that is known to fail for every device of the batch.
+        """
+        if self._groups_fetch_disabled:
+            return
+
+        # deduplicate the identifiers, keeping their order, and drop the already cached ones
+        missing_ids = [
+            group_id for group_id in dict.fromkeys(group_ids) if group_id and group_id not in self._groups_cache
+        ]
+
+        if not missing_ids:
+            return
+
+        try:
+            for group_info in self.client.get_host_groups(missing_ids):
+                group_id = group_info.get("id")
+                if not group_id:
+                    continue
+
+                self._groups_cache[group_id] = Group(
+                    uid=group_id,
+                    name=group_info.get("name") or "Unknown",
+                    desc=group_info.get("description") or None,
+                )
+        except Exception as e:
+            self._groups_fetch_disabled = True
+            self.log(
+                f"Failed to fetch group details: {e}. "
+                "Check that the API client owns the 'Host groups: Read' scope. "
+                "Groups are reported with their identifier as name for this cycle",
+                level="warning",
+            )
+
     def get_groups(self, device: CrowdStrikeDevice) -> list[Group] | None:
         """
-        Extract groups from device data and fetch details from API.
+        Extract groups from device data, with the details fetched from the API.
         """
-        raw_groups = device.groups
+        raw_groups = [group_id for group_id in device.groups if group_id]
         if not raw_groups:
             return None
 
-        groups: list[Group] = []
-        try:
-            for group_info in self.client.get_host_groups(raw_groups):
-                groups.append(
-                    Group(
-                        uid=group_info.get("id"),
-                        name=group_info.get("name", "Unknown"),
-                        desc=group_info.get("description") or None,
-                    )
-                )
-        except Exception as e:
-            self.log(f"Failed to fetch group details: {e}", level="warning")
-            groups = [Group(uid=g, name=g) for g in raw_groups if g]
+        self.fetch_groups(raw_groups)
 
-        return groups if groups else None
+        # fallback on the identifier as name for the groups without details
+        return [self._groups_cache.get(group_id) or Group(uid=group_id, name=group_id) for group_id in raw_groups]
 
     def get_location(self, device: CrowdStrikeDevice) -> GeoLocation | None:
         """
@@ -389,6 +419,18 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
             cache["most_recent_device_id"] = self._latest_id
             self.log(f"Device id was updated to {self._latest_id}", level="info")
 
+    def next_devices_batch(self, uuids_batch: list[str]) -> Generator[CrowdStrikeDevice, None, None]:
+        """
+        Fetch the information of a batch of devices, with the details of their groups.
+        """
+        devices = [
+            CrowdStrikeDevice.model_validate(device_info) for device_info in self.client.get_devices_infos(uuids_batch)
+        ]
+
+        self.fetch_groups([group_id for device in devices for group_id in device.groups])
+
+        yield from devices
+
     def next_devices(self) -> Generator[CrowdStrikeDevice, None, None]:
         """
         Generator that yields device information from CrowdStrike API.
@@ -412,20 +454,23 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
 
             if len(uuids_batch) >= self.LIMIT:
                 self.log(f"Found {len(uuids_batch)} devices !!", level="info")
-                for device_info in self.client.get_devices_infos(uuids_batch):
-                    yield CrowdStrikeDevice.model_validate(device_info)
+                yield from self.next_devices_batch(uuids_batch)
                 uuids_batch = []
 
         if uuids_batch:
             self.log(f"Found {len(uuids_batch)} devices in the last batch!!", level="info")
-            for device_info in self.client.get_devices_infos(uuids_batch):
-                yield CrowdStrikeDevice.model_validate(device_info)
+            yield from self.next_devices_batch(uuids_batch)
 
     def get_assets(self) -> Generator[DeviceOCSFModel, None, None]:
         """
         Main generator that yields OCSF-formatted device assets.
         """
         self.log("Start the getting assets generator !!", level="info")
+
+        # reset the group details collected in the previous cycle
+        self._groups_cache = {}
+        self._groups_fetch_disabled = False
+
         for device in self.next_devices():
             mapped = self.map_device_fields(device)
             if mapped is not None:  # pragma: no branch

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -41,6 +41,39 @@ class ApiClient(requests.Session):
     def get_url(self, endpoint: str) -> str:
         return urljoin(self._base_url, endpoint.lstrip("/"))
 
+    @staticmethod
+    def format_api_errors(content: Any) -> str | None:
+        """
+        Return, as a single message, the errors reported in the content of a response
+        """
+        if not isinstance(content, dict):
+            return None
+
+        errors = [error for error in content.get("errors") or [] if isinstance(error, dict)]
+        if not errors:
+            return None
+
+        return "\n".join([f"{error.get('code')}: {error.get('message')}" for error in errors])
+
+    def raise_for_status(self, response: requests.Response) -> None:
+        """
+        Raise an exception according to the status code, enriched with the errors
+        reported in the body of the response, when the API provides them
+        """
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            try:
+                api_errors = self.format_api_errors(response.json())
+            except ValueError:
+                api_errors = None
+
+            if api_errors is None:
+                raise
+
+            msg = f"{error}. The API returns the following errors: \n{api_errors}"
+            raise HTTPError(msg, response=response) from error  # type: ignore[call-arg]
+
     def request_endpoint(self, method: str, endpoint: str, **kwargs) -> Generator[Any, None, None]:
         """
         Send the request and handle the response
@@ -66,15 +99,14 @@ class ApiClient(requests.Session):
             response = self.request(method=method, url=url, params=new_params, **kwargs)
 
             # raise exception according the status code
-            response.raise_for_status()
+            self.raise_for_status(response)
 
             content = response.json()
 
             # check for errors
-            errors = content.get("errors", [])
-            if errors and len(errors):
-                errors_str = "\n".join([f"{error['code']}: {error['message']}" for error in errors])
-                msg = f"The API returns the following errors: \n{errors_str}"
+            errors = self.format_api_errors(content)
+            if errors:
+                msg = f"The API returns the following errors: \n{errors}"
                 raise HTTPError(msg, response=response)  # type: ignore[call-arg]
             yield from content.get("resources") or []
 

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "CrowdStrike Falcon is a cloud-native cybersecurity platform known for its advanced threat detection, endpoint protection, and real-time response capabilities. It leverages AI and machine learning to protect against malware and sophisticated cyberattacks.",
-  "version": "1.25.18",
+  "version": "1.25.19",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
@@ -382,7 +382,6 @@ def test_get_groups_logs_a_single_warning_when_the_group_api_is_forbidden(connec
 
     warnings = [call for call in connector.log.call_args_list if call.kwargs.get("level") == "warning"]
     assert len(warnings) == 1
-    assert "Host groups: Read" in warnings[0].args[0]
 
 
 def test_next_devices_fetches_the_group_details_of_a_batch_in_a_single_request(connector):

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
@@ -1,14 +1,12 @@
-import pytest
 from unittest.mock import Mock
+
+import pytest
+from requests.exceptions import HTTPError
+from sekoia_automation.asset_connector.models.ocsf.device import DeviceTypeId, DeviceTypeStr, OSTypeId, OSTypeStr
+from sekoia_automation.asset_connector.models.ocsf.group import Group
 
 from crowdstrike_falcon.asset_connectors.crowdstrike_device_model import CrowdStrikeDevice, PolicyEntry
 from crowdstrike_falcon.asset_connectors.device_assets import CrowdstrikeDeviceAssetConnector
-from sekoia_automation.asset_connector.models.ocsf.device import (
-    OSTypeId,
-    OSTypeStr,
-    DeviceTypeId,
-    DeviceTypeStr,
-)
 
 
 class _DummyContext:
@@ -352,3 +350,70 @@ def test_is_device_compliant(connector):
     assert connector.is_device_compliant(compliant) is True
     assert connector.is_device_compliant(non_compliant) is False
     assert connector.is_device_compliant(CrowdStrikeDevice()) is None
+
+
+def test_get_groups_reuses_cached_group_details(connector):
+    mock_client = Mock()
+    mock_client.get_host_groups.return_value = [{"id": "group1", "name": "Group One"}]
+    connector.client = mock_client
+
+    first = connector.get_groups(CrowdStrikeDevice(groups=["group1"]))
+    second = connector.get_groups(CrowdStrikeDevice(groups=["group1"]))
+
+    assert mock_client.get_host_groups.call_count == 1
+    assert first[0].name == "Group One"
+    assert second[0].name == "Group One"
+
+
+def test_get_groups_logs_a_single_warning_when_the_group_api_is_forbidden(connector):
+    mock_client = Mock()
+    mock_client.get_host_groups.side_effect = HTTPError(
+        "403 Client Error: Forbidden for url: "
+        "https://api.eu-1.crowdstrike.com/devices/entities/host-groups/v1?ids=group1"
+    )
+    connector.client = mock_client
+
+    first = connector.get_groups(CrowdStrikeDevice(groups=["group1"]))
+    second = connector.get_groups(CrowdStrikeDevice(groups=["group2"]))
+
+    assert mock_client.get_host_groups.call_count == 1
+    assert first[0].name == "group1"
+    assert second[0].name == "group2"
+
+    warnings = [call for call in connector.log.call_args_list if call.kwargs.get("level") == "warning"]
+    assert len(warnings) == 1
+    assert "Host groups: Read" in warnings[0].args[0]
+
+
+def test_next_devices_fetches_the_group_details_of_a_batch_in_a_single_request(connector):
+    mock_client = Mock()
+    mock_client.list_devices_uuids.return_value = ["dev-1", "dev-2"]
+    mock_client.get_devices_infos.return_value = [
+        {"device_id": "dev-1", "hostname": "host-1", "groups": ["group1"]},
+        {"device_id": "dev-2", "hostname": "host-2", "groups": ["group1", "group2"]},
+    ]
+    mock_client.get_host_groups.return_value = [
+        {"id": "group1", "name": "Group One"},
+        {"id": "group2", "name": "Group Two"},
+    ]
+    connector.client = mock_client
+
+    devices = list(connector.next_devices())
+
+    assert len(devices) == 2
+    assert mock_client.get_host_groups.call_count == 1
+    assert mock_client.get_host_groups.call_args[0][0] == ["group1", "group2"]
+    assert [group.name for group in connector.get_groups(devices[1])] == ["Group One", "Group Two"]
+
+
+def test_get_assets_resets_the_group_state_between_cycles(connector):
+    mock_client = Mock()
+    mock_client.list_devices_uuids.return_value = []
+    connector.client = mock_client
+    connector._groups_cache = {"group1": Group(uid="group1", name="Group One")}
+    connector._groups_fetch_disabled = True
+
+    list(connector.get_assets())
+
+    assert connector._groups_cache == {}
+    assert connector._groups_fetch_disabled is False

--- a/CrowdStrikeFalcon/tests/client/test_client.py
+++ b/CrowdStrikeFalcon/tests/client/test_client.py
@@ -200,3 +200,65 @@ def test_find_indicators():
 
         indicators = client.find_indicators(fql_filter=f"source:Sekoia.io")
         assert list(indicators) == ["519b7236-8ed2-4c63-b5c4-0f72dc3f187e", "f6d85700-1b5b-450f-8df1-a8317fe7f137"]
+
+
+def test_request_endpoint_forbidden_reports_the_api_error_message():
+    base_url = "https://my.fake.sekoia"
+    client = CrowdstrikeFalconClient(base_url, "foo", "bar")
+
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            f"{base_url}/oauth2/token",
+            json={
+                "access_token": "foo-token",
+                "token_type": "bearer",
+                "expires_in": 1799,
+            },
+        )
+
+        mock.register_uri(
+            "GET",
+            f"{base_url}/devices/entities/host-groups/v1?ids=group1",
+            status_code=403,
+            json={
+                "errors": [{"code": 403, "message": "access denied, authorization failed"}],
+                "meta": {"trace_id": "13787250-fc0f-49a6-9191-d809e30afdfb"},
+                "resources": [],
+            },
+        )
+
+        with pytest.raises(HTTPError) as exc_info:
+            list(client.get_host_groups(["group1"]))
+
+        message = str(exc_info.value)
+        assert "403" in message
+        assert "access denied, authorization failed" in message
+
+
+def test_request_endpoint_forbidden_without_a_json_body():
+    base_url = "https://my.fake.sekoia"
+    client = CrowdstrikeFalconClient(base_url, "foo", "bar")
+
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST",
+            f"{base_url}/oauth2/token",
+            json={
+                "access_token": "foo-token",
+                "token_type": "bearer",
+                "expires_in": 1799,
+            },
+        )
+
+        mock.register_uri(
+            "GET",
+            f"{base_url}/devices/entities/host-groups/v1?ids=group1",
+            status_code=403,
+            text="Forbidden",
+        )
+
+        with pytest.raises(HTTPError) as exc_info:
+            list(client.get_host_groups(["group1"]))
+
+        assert "403" in str(exc_info.value)


### PR DESCRIPTION
Relates to [1816](https://github.com/SekoiaLab/integration/issues/1816)

Note: This is possible fix but I explained more details in the ticket. If that works then this PR can be closed

## Summary by Sourcery

Improve CrowdStrike Falcon asset collection reliability and diagnostics for host-group API access failures.

Bug Fixes:
- Improve CrowdStrike Falcon asset collection when host-group requests are forbidden by preserving device groups as identifier-based fallbacks and reporting the API’s detailed error messages.

Enhancements:
- Batch host-group detail lookups, reuse group details during each fetch cycle, and suppress repeated failures when the required API scope is unavailable.

Tests:
- Add coverage for group-detail caching, batched lookups, forbidden-access handling, cycle state reset, and enriched API errors.