### PR TITLE
fix(sekoia): fix sol query

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2026-07-22 - 2.74.4
+## 2026-07-31 - 2.74.5
+
+### Fixed
+
+- `Execute a Query` action now handles the case where a query run returns no results.
 
 ### Fixed
 

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.74.4",
+  "version": "2.74.5",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/execute_a_query.py
+++ b/Sekoia.io/sekoiaio/operation_center/execute_a_query.py
@@ -203,18 +203,29 @@ class ExecuteAQuery(BaseSolAction):
         stop=stop_after_attempt(10),
         retry=retry_if_exception_type(Timeout) | retry_if_exception_type(Urllib3TimeoutError),
     )
-    def download_query_result(self, run_uuid: str, result_format: str) -> str:
+    def download_query_result(self, run_uuid: str, result_format: str) -> str | None:
         """Download the result of a completed query run.
 
         :param run_uuid: UUID of the query run whose result should be downloaded
         :param result_format: Desired output format, either "jsonl" or "csv"
-        :return: Raw result content as a string
+        :return: Raw result content as a string, or None if the query returned no results
         """
         response_download_result = self.http_session.get(
             url=urljoin(self.query_runs_api_path, f"{run_uuid}/download"),
             timeout=60,
             params={"download_format": result_format},
         )
+        if response_download_result.status_code == 404:
+            try:
+                error_code = response_download_result.json().get("detail", {}).get("code")
+            except Exception:
+                error_code = None
+            if error_code == "NO_RESULTS":
+                self.log(
+                    f"Query run '{run_uuid}' returned no results.",
+                    level="info",
+                )
+                return None
         try:
             response_download_result.raise_for_status()
         except HTTPError as e:
@@ -353,6 +364,8 @@ class ExecuteAQuery(BaseSolAction):
             query_uuid=query["uuid"],
             run_uuid=run_uuid,
         )
+        if result is None:
+            return ExecuteAQueryResults(query_result=None, output_path=None)
         if arguments.to_file:
             filepath = self.save_to_file(result, arguments.result_format)
             return ExecuteAQueryResults(query_result=None, output_path=filepath)

--- a/Sekoia.io/tests/operation_center_action/test_action_execute_a_query.py
+++ b/Sekoia.io/tests/operation_center_action/test_action_execute_a_query.py
@@ -400,6 +400,68 @@ def test_download_query_result_http_error(requests_mock):
     assert "Gone: result expired" in action._logs[0]["message"]
 
 
+
+def test_download_query_result_no_results_returns_none(requests_mock):
+    """A 404 with NO_RESULTS code should return None instead of raising."""
+    action = make_action()
+    action.configure_http_session()
+    action.configure_urls()
+
+    requests_mock.get(
+        f"{QUERY_RUNS_URL}/{SAMPLE_QUERY_RUN['uuid']}/download",
+        status_code=404,
+        json={"detail": {"message": "There is no results to download", "code": "NO_RESULTS"}},
+    )
+
+    result = action.download_query_result(SAMPLE_QUERY_RUN["uuid"], "jsonl")
+
+    assert result is None
+    assert len(action._logs) == 1
+    assert action._logs[0]["level"] == "info"
+    assert "no results" in action._logs[0]["message"].lower()
+
+
+def test_download_query_result_404_non_no_results_raises(requests_mock):
+    """A 404 without NO_RESULTS code should still raise an HTTPError."""
+    action = make_action()
+    action.configure_http_session()
+    action.configure_urls()
+
+    requests_mock.get(
+        f"{QUERY_RUNS_URL}/{SAMPLE_QUERY_RUN['uuid']}/download",
+        status_code=404,
+        json={"detail": {"message": "Run not found", "code": "NOT_FOUND"}},
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        action.download_query_result(SAMPLE_QUERY_RUN["uuid"], "jsonl")
+
+    assert len(action._logs) == 1
+    assert action._logs[0]["level"] == "error"
+    assert "HTTP error when downloading query result" in action._logs[0]["message"]
+
+
+def test_run_no_results_returns_gracefully(requests_mock):
+    """When the query run has no results the action should finish without error."""
+    action = make_action()
+    action.configure_http_session()
+    action.configure_urls()
+
+    requests_mock.get(f"{QUERIES_URL}/{SAMPLE_QUERY['uuid']}", json=SAMPLE_QUERY)
+    requests_mock.post(QUERY_RUNS_URL, json=SAMPLE_QUERY_RUN)
+    requests_mock.get(f"{QUERY_RUNS_URL}/{SAMPLE_QUERY_RUN['uuid']}", json={"status": "done"})
+    requests_mock.get(
+        f"{QUERY_RUNS_URL}/{SAMPLE_QUERY_RUN['uuid']}/download",
+        status_code=404,
+        json={"detail": {"message": "There is no results to download", "code": "NO_RESULTS"}},
+    )
+
+    result = action.run({"query_uuid": SAMPLE_QUERY["uuid"], "result_format": "jsonl"})
+
+    assert result["query_result"] is None
+    assert result["output_path"] is None
+
+
 # ---------------------------------------------------------------------------
 # run() — full polling cycle (pending → running → done)
 # ---------------------------------------------------------------------------

--- a/Sekoia.io/tests/operation_center_action/test_action_execute_a_query.py
+++ b/Sekoia.io/tests/operation_center_action/test_action_execute_a_query.py
@@ -400,7 +400,6 @@ def test_download_query_result_http_error(requests_mock):
     assert "Gone: result expired" in action._logs[0]["message"]
 
 
-
 def test_download_query_result_no_results_returns_none(requests_mock):
     """A 404 with NO_RESULTS code should return None instead of raising."""
     action = make_action()


### PR DESCRIPTION
Main issue : [issue](https://github.com/SekoiaLab/integration/issues/1842)

## Summary by Sourcery

Handle Sekoia.io "Execute a Query" runs that complete without results without raising errors.

Bug Fixes:
- Treat 404 responses with NO_RESULTS code from the query result download endpoint as an empty result instead of an error.
- Ensure the execute-a-query action returns a successful result with null payloads when a query run has no downloadable results, avoiding failures in downstream usage.

Enhancements:
- Log informative messages when query runs return no results or when HTTP errors occur while downloading results.

Build:
- Bump Sekoia.io integration version from 2.74.4 to 2.74.5.

Documentation:
- Update changelog to document the improved handling of no-result query runs in the "Execute a Query" action.

Tests:
- Add tests covering 404 NO_RESULTS responses, non-NO_RESULTS 404 errors, and end-to-end execution when query runs have no results.