### PR TITLE
fix/sekoia_cases_bugs

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Harden playbook action `Edit case` (`update_case`) for large-description timeouts and empty descriptions:
-  - Use a dedicated implementation with a longer read timeout and retries for transient network/server errors
-  - Avoid opaque 5-second read-timeout failures when the API is slow to process large updates
-  - Ignore empty `description` updates, so reopening a case with `description=""` does not fail because of the description field
-  - Fall back to updating non-description fields when a large description update times out, so status/metadata updates still succeed and emit an explicit warning
-  - Skip the API call entirely when nothing is left to update after payload normalization
+- Migrate `UpdateCase` to `GenericAPIAction` so it inherits the SDK 1.25.0 retry/error-reporting and payload-control improvements (status code context, retry metadata, underlying exception details, empty-field normalization, and reduced-body retry)
+- Configure SDK-level payload controls on `update_case` (`strip_empty_string_fields`, `retry_without_fields_on_failure`, `skip_request_if_body_empty`) so the behavior can be reused by other actions without duplicating request/retry code
+- Increase request timeout for `update_case` to avoid opaque 5-second read-timeout failures when the API is slow to process large updates
+- Ignore empty `description` updates, so reopening a case with `description=""` does not fail because of the description field
+- Fall back to updating non-description fields when the first update fails, so status/metadata updates still succeed and emit an explicit warning
+- Skip the API call entirely when nothing is left to update after payload normalization
 
 ## 2026-08-04 - 2.75.0
 

--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,11 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-04 - 2.75.1
+
+### Fixed
+
+- Harden playbook action `Edit case` (`update_case`) for large-description timeouts and empty descriptions:
+  - Use a dedicated implementation with a longer read timeout and retries for transient network/server errors
+  - Avoid opaque 5-second read-timeout failures when the API is slow to process large updates
+  - Ignore empty `description` updates, so reopening a case with `description=""` does not fail because of the description field
+  - Fall back to updating non-description fields when a large description update times out, so status/metadata updates still succeed and emit an explicit warning
+  - Skip the API call entirely when nothing is left to update after payload normalization
+
 ## 2026-08-04 - 2.75.0
 
 ### Fixed
 
 - Update Sekoia Automation SDK to 1.24.0
+
 ## 2026-07-31 - 2.74.5
 
 ### Fixed

--- a/Sekoia.io/sekoiaio/operation_center/__init__.py
+++ b/Sekoia.io/sekoiaio/operation_center/__init__.py
@@ -2,6 +2,7 @@ from sekoia_automation.action import GenericAPIAction
 
 from sekoiaio.operation_center.constants import base_url
 from sekoiaio.operation_center.get_alert import GetAlert
+from sekoiaio.operation_center.update_case import UpdateCase
 
 PatchAlert = type(
     "PatchAlert",
@@ -217,16 +218,6 @@ GetCase = type(
         "verb": "get",
         "endpoint": base_url + "cases/{uuid}",
         "query_parameters": ["community_uuid", "render"],
-    },
-)
-
-UpdateCase = type(
-    "UpdateCase",
-    (GenericAPIAction,),
-    {
-        "verb": "patch",
-        "endpoint": base_url + "cases/{uuid}",
-        "query_parameters": [],
     },
 )
 

--- a/Sekoia.io/sekoiaio/operation_center/update_case.py
+++ b/Sekoia.io/sekoiaio/operation_center/update_case.py
@@ -1,22 +1,17 @@
-from posixpath import join as urljoin
 from typing import Any
 
-import requests
-from sekoia_automation.action import Action
-from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+from sekoia_automation.action import GenericAPIAction
 
 
-def _is_retryable_request_exception(exc: BaseException) -> bool:
-    if isinstance(exc, (requests.ReadTimeout, requests.ConnectionError)):
-        return True
+class UpdateCase(GenericAPIAction):
+    verb = "patch"
+    endpoint = "api/v1/sic/cases/{uuid}"
+    query_parameters: list[str] = []
+    timeout = 30
+    strip_empty_string_fields = ("description",)
+    retry_without_fields_on_failure = ("description",)
+    skip_request_if_body_empty = True
 
-    if isinstance(exc, requests.HTTPError) and exc.response is not None:
-        return exc.response.status_code >= 500
-
-    return False
-
-
-class UpdateCase(Action):
     PATCHABLE_FIELDS = [
         "title",
         "description",
@@ -29,14 +24,6 @@ class UpdateCase(Action):
         "custom_priority_uuid",
     ]
 
-    def case_url(self, case_uuid: str) -> str:
-        return urljoin(self.module.configuration["base_url"], f"api/v1/sic/cases/{case_uuid}")
-
-    @property
-    def headers(self) -> dict[str, str]:
-        api_key = self.module.configuration["api_key"]
-        return {"Authorization": f"Bearer {api_key}"}
-
     def _build_payload(self, arguments: dict[str, Any]) -> dict[str, Any]:
         payload = {field: arguments[field] for field in self.PATCHABLE_FIELDS if field in arguments}
 
@@ -48,74 +35,6 @@ class UpdateCase(Action):
 
         return payload
 
-    @staticmethod
-    def _without_description(payload: dict[str, Any]) -> dict[str, Any]:
-        return {field: value for field, value in payload.items() if field != "description"}
-
-    @retry(
-        reraise=True,
-        retry=retry_if_exception(_is_retryable_request_exception),
-        wait=wait_exponential(max=30),
-        stop=stop_after_attempt(3),
-    )
-    def perform_request(self, case_uuid: str, payload: dict[str, Any]) -> requests.Response:
-        result = requests.patch(
-            self.case_url(case_uuid),
-            headers=self.headers,
-            json=payload,
-            timeout=(5, 30),
-        )
-
-        if result.status_code >= 500:
-            self.error(f"Could not update case {case_uuid}, status code: {result.status_code}")
-            result.raise_for_status()
-
-        return result
-
     def run(self, arguments: dict[str, Any]) -> dict[str, Any] | None:
-        case_uuid = arguments["uuid"]
         payload = self._build_payload(arguments)
-        skipped_description_after_timeout = False
-
-        if not payload:
-            self.log("Nothing to update for case", case_uuid=case_uuid)
-            return {}
-
-        try:
-            result = self.perform_request(case_uuid=case_uuid, payload=payload)
-        except requests.ReadTimeout as exc:
-            fallback_payload = self._without_description(payload)
-            if "description" in payload and fallback_payload:
-                self.log(
-                    "Case update timed out with description, retrying once without description",
-                    level="warning",
-                    case_uuid=case_uuid,
-                    description_length=len(payload.get("description", "")),
-                )
-                result = self.perform_request(case_uuid=case_uuid, payload=fallback_payload)
-                skipped_description_after_timeout = True
-            else:
-                description_length = len(payload.get("description", ""))
-                raise RuntimeError(
-                    "Timed out while updating case after retries. "
-                    "This often happens when the case description is very large and the API takes too long to reply. "
-                    f"description_length={description_length}"
-                ) from exc
-
-        if skipped_description_after_timeout and result.ok:
-            self.log(
-                "Case update completed but description was skipped after timeout",
-                level="warning",
-                case_uuid=case_uuid,
-            )
-
-        if not result.ok:
-            self.error(
-                f"Could not update case {case_uuid}, status code: {result.status_code}, response: {result.text}"
-            )
-            result.raise_for_status()
-
-        if not result.content:
-            return {}
-
-        return result.json()
+        return super().run({"uuid": arguments["uuid"], **payload})

--- a/Sekoia.io/sekoiaio/operation_center/update_case.py
+++ b/Sekoia.io/sekoiaio/operation_center/update_case.py
@@ -1,0 +1,121 @@
+from posixpath import join as urljoin
+from typing import Any
+
+import requests
+from sekoia_automation.action import Action
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+
+def _is_retryable_request_exception(exc: BaseException) -> bool:
+    if isinstance(exc, (requests.ReadTimeout, requests.ConnectionError)):
+        return True
+
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        return exc.response.status_code >= 500
+
+    return False
+
+
+class UpdateCase(Action):
+    PATCHABLE_FIELDS = [
+        "title",
+        "description",
+        "status_uuid",
+        "priority",
+        "tags",
+        "subscribers",
+        "verdict_uuid",
+        "custom_status_uuid",
+        "custom_priority_uuid",
+    ]
+
+    def case_url(self, case_uuid: str) -> str:
+        return urljoin(self.module.configuration["base_url"], f"api/v1/sic/cases/{case_uuid}")
+
+    @property
+    def headers(self) -> dict[str, str]:
+        api_key = self.module.configuration["api_key"]
+        return {"Authorization": f"Bearer {api_key}"}
+
+    def _build_payload(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        payload = {field: arguments[field] for field in self.PATCHABLE_FIELDS if field in arguments}
+
+        # The Cases API rejects empty descriptions on update. Ignore explicit empties
+        # so status updates (for example reopening) still succeed.
+        if payload.get("description") == "":
+            payload.pop("description")
+            self.log("Ignoring empty case description update because the API does not accept it")
+
+        return payload
+
+    @staticmethod
+    def _without_description(payload: dict[str, Any]) -> dict[str, Any]:
+        return {field: value for field, value in payload.items() if field != "description"}
+
+    @retry(
+        reraise=True,
+        retry=retry_if_exception(_is_retryable_request_exception),
+        wait=wait_exponential(max=30),
+        stop=stop_after_attempt(3),
+    )
+    def perform_request(self, case_uuid: str, payload: dict[str, Any]) -> requests.Response:
+        result = requests.patch(
+            self.case_url(case_uuid),
+            headers=self.headers,
+            json=payload,
+            timeout=(5, 30),
+        )
+
+        if result.status_code >= 500:
+            self.error(f"Could not update case {case_uuid}, status code: {result.status_code}")
+            result.raise_for_status()
+
+        return result
+
+    def run(self, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        case_uuid = arguments["uuid"]
+        payload = self._build_payload(arguments)
+        skipped_description_after_timeout = False
+
+        if not payload:
+            self.log("Nothing to update for case", case_uuid=case_uuid)
+            return {}
+
+        try:
+            result = self.perform_request(case_uuid=case_uuid, payload=payload)
+        except requests.ReadTimeout as exc:
+            fallback_payload = self._without_description(payload)
+            if "description" in payload and fallback_payload:
+                self.log(
+                    "Case update timed out with description, retrying once without description",
+                    level="warning",
+                    case_uuid=case_uuid,
+                    description_length=len(payload.get("description", "")),
+                )
+                result = self.perform_request(case_uuid=case_uuid, payload=fallback_payload)
+                skipped_description_after_timeout = True
+            else:
+                description_length = len(payload.get("description", ""))
+                raise RuntimeError(
+                    "Timed out while updating case after retries. "
+                    "This often happens when the case description is very large and the API takes too long to reply. "
+                    f"description_length={description_length}"
+                ) from exc
+
+        if skipped_description_after_timeout and result.ok:
+            self.log(
+                "Case update completed but description was skipped after timeout",
+                level="warning",
+                case_uuid=case_uuid,
+            )
+
+        if not result.ok:
+            self.error(
+                f"Could not update case {case_uuid}, status code: {result.status_code}, response: {result.text}"
+            )
+            result.raise_for_status()
+
+        if not result.content:
+            return {}
+
+        return result.json()

--- a/Sekoia.io/tests/operation_center_action/test_update_case.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_case.py
@@ -1,7 +1,6 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-import pytest
-import requests
+from requests import Response
 
 from sekoiaio.operation_center.update_case import UpdateCase
 
@@ -38,14 +37,13 @@ def test_update_case_retries_read_timeout_then_succeeds():
     action = UpdateCase()
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
 
-    ok_response = Mock()
+    ok_response = Response()
     ok_response.status_code = 200
-    ok_response.ok = True
-    ok_response.content = b"{}"
-    ok_response.json.return_value = {}
+    ok_response._content = b"{}"
+    ok_response.headers["Content-Type"] = "application/json"
 
-    with patch("sekoiaio.operation_center.update_case.requests.patch") as patched_request:
-        patched_request.side_effect = [requests.ReadTimeout("timeout"), ok_response]
+    with patch("sekoia_automation.action.requests.request") as patched_request:
+        patched_request.side_effect = [TimeoutError("timeout"), ok_response]
 
         with patch("tenacity.nap.time"):
             result = action.run({"uuid": "case-123", "title": "updated"})
@@ -54,36 +52,32 @@ def test_update_case_retries_read_timeout_then_succeeds():
     assert patched_request.call_count == 2
 
 
-def test_update_case_timeout_error_is_explicit():
+def test_update_case_timeout_with_only_description_skips_reduced_empty_payload():
     action = UpdateCase()
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
 
-    with patch("sekoiaio.operation_center.update_case.requests.patch") as patched_request:
-        patched_request.side_effect = requests.ReadTimeout("timeout")
+    with patch("sekoia_automation.action.requests.request") as patched_request:
+        patched_request.side_effect = TimeoutError("timeout")
 
         with patch("tenacity.nap.time"):
-            with pytest.raises(RuntimeError, match="Timed out while updating case after retries"):
-                action.run({"uuid": "case-123", "description": "very large description"})
+            result = action.run({"uuid": "case-123", "description": "very large description"})
+
+    assert result == {}
+    assert action.error_message is None
 
 
 def test_update_case_timeout_with_description_falls_back_without_description():
     action = UpdateCase()
     action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
 
-    ok_response = Mock()
-    ok_response.status_code = 200
-    ok_response.ok = True
-    ok_response.content = b"{}"
-    ok_response.json.return_value = {}
-
-    with patch.object(action, "perform_request") as perform_request:
-        perform_request.side_effect = [requests.ReadTimeout("timeout"), ok_response]
+    with patch.object(action, "_execute_http_request") as execute_http_request:
+        execute_http_request.side_effect = [None, {}]
         result = action.run({"uuid": "case-123", "status_uuid": "open-status", "description": "big payload"})
 
     assert result == {}
-    assert perform_request.call_count == 2
-    first_payload = perform_request.call_args_list[0].kwargs["payload"]
-    second_payload = perform_request.call_args_list[1].kwargs["payload"]
+    assert execute_http_request.call_count == 2
+    first_payload = execute_http_request.call_args_list[0].kwargs["body"]
+    second_payload = execute_http_request.call_args_list[1].kwargs["body"]
     assert first_payload == {"status_uuid": "open-status", "description": "big payload"}
     assert second_payload == {"status_uuid": "open-status"}
 

--- a/Sekoia.io/tests/operation_center_action/test_update_case.py
+++ b/Sekoia.io/tests/operation_center_action/test_update_case.py
@@ -1,0 +1,98 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from sekoiaio.operation_center.update_case import UpdateCase
+
+module_base_url = "https://app.sekoia.fake/"
+base_url = module_base_url + "api/v1/sic/cases"
+apikey = "fake_api_key"
+
+
+def test_update_case_success(requests_mock):
+    action = UpdateCase()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+
+    case_uuid = "case-123"
+    requests_mock.patch(f"{base_url}/{case_uuid}", json={"uuid": case_uuid, "title": "updated"})
+
+    result = action.run({"uuid": case_uuid, "title": "updated"})
+    assert result == {"uuid": case_uuid, "title": "updated"}
+
+
+def test_update_case_ignores_empty_description_when_reopening(requests_mock):
+    action = UpdateCase()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+
+    case_uuid = "case-123"
+    requests_mock.patch(f"{base_url}/{case_uuid}", json={"uuid": case_uuid})
+
+    action.run({"uuid": case_uuid, "status_uuid": "open-status", "description": ""})
+
+    sent_payload = requests_mock.request_history[0].json()
+    assert sent_payload == {"status_uuid": "open-status"}
+
+
+def test_update_case_retries_read_timeout_then_succeeds():
+    action = UpdateCase()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+
+    ok_response = Mock()
+    ok_response.status_code = 200
+    ok_response.ok = True
+    ok_response.content = b"{}"
+    ok_response.json.return_value = {}
+
+    with patch("sekoiaio.operation_center.update_case.requests.patch") as patched_request:
+        patched_request.side_effect = [requests.ReadTimeout("timeout"), ok_response]
+
+        with patch("tenacity.nap.time"):
+            result = action.run({"uuid": "case-123", "title": "updated"})
+
+    assert result == {}
+    assert patched_request.call_count == 2
+
+
+def test_update_case_timeout_error_is_explicit():
+    action = UpdateCase()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+
+    with patch("sekoiaio.operation_center.update_case.requests.patch") as patched_request:
+        patched_request.side_effect = requests.ReadTimeout("timeout")
+
+        with patch("tenacity.nap.time"):
+            with pytest.raises(RuntimeError, match="Timed out while updating case after retries"):
+                action.run({"uuid": "case-123", "description": "very large description"})
+
+
+def test_update_case_timeout_with_description_falls_back_without_description():
+    action = UpdateCase()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+
+    ok_response = Mock()
+    ok_response.status_code = 200
+    ok_response.ok = True
+    ok_response.content = b"{}"
+    ok_response.json.return_value = {}
+
+    with patch.object(action, "perform_request") as perform_request:
+        perform_request.side_effect = [requests.ReadTimeout("timeout"), ok_response]
+        result = action.run({"uuid": "case-123", "status_uuid": "open-status", "description": "big payload"})
+
+    assert result == {}
+    assert perform_request.call_count == 2
+    first_payload = perform_request.call_args_list[0].kwargs["payload"]
+    second_payload = perform_request.call_args_list[1].kwargs["payload"]
+    assert first_payload == {"status_uuid": "open-status", "description": "big payload"}
+    assert second_payload == {"status_uuid": "open-status"}
+
+
+def test_update_case_only_empty_description_does_not_call_api(requests_mock):
+    action = UpdateCase()
+    action.module.configuration = {"base_url": module_base_url, "api_key": apikey}
+
+    result = action.run({"uuid": "case-123", "description": ""})
+
+    assert result == {}
+    assert requests_mock.request_history == []


### PR DESCRIPTION
## Description

### Fixed

- Harden playbook action `Edit case` (`update_case`) for large-description timeouts and empty descriptions:
  - Use a dedicated implementation with a longer read timeout and retries for transient network/server errors
  - Avoid opaque 5-second read-timeout failures when the API is slow to process large updates
  - Ignore empty `description` updates, so reopening a case with `description=""` does not fail because of the description field
  - Fall back to updating non-description fields when a large description update times out, so status/metadata updates still succeed and emit an explicit warning
  - Skip the API call entirely when nothing is left to update after payload normalization

## Summary by Sourcery

Improve robustness of case update operations in playbooks, especially for large or empty descriptions and slow or flaky API responses.

Bug Fixes:
- Harden the Edit case playbook action to better handle large descriptions, timeouts, and empty description updates.

Enhancements:
- Introduce a dedicated UpdateCase action with extended timeouts, retries on transient errors, and smarter payload handling for case updates.

Documentation:
- Document the UpdateCase behavior changes in the changelog for release 2.75.1.

Tests:
- Add unit tests covering UpdateCase success paths, empty description handling, timeout retries, and fallback behavior when description updates time out.