### PR TITLE
fix/sekoiaio_debug_case_timeout

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2026-08-04 - 2.75.1
 
-### Changed
+### Fixed
 
-- Debug large/empty `description` field errors in `Edit case` (`update_case`) playbook action:
-  - Raise `timeout` default value to `120` in `UpdateCase` class
+- Fix large/empty `description` field timeout errors in `Edit case` (`update_case`) playbook action:
+  - Raise `timeout` default value from `5` to `60` seconds in `UpdateCase` class
 
 ## 2026-08-04 - 2.75.0
 

--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-04 - 2.75.1
+
+### Changed
+
+- Debug large/empty `description` field errors in `Edit case` (`update_case`) playbook action:
+  - Raise `timeout` default value to `120` in `UpdateCase` class
+
 ## 2026-08-04 - 2.75.0
 
 ### Fixed
 
 - Update Sekoia Automation SDK to 1.24.0
+
 ## 2026-07-31 - 2.74.5
 
 ### Fixed

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.75.0",
+  "version": "2.75.1",
   "categories": [
     "Generic"
   ]

--- a/Sekoia.io/sekoiaio/operation_center/__init__.py
+++ b/Sekoia.io/sekoiaio/operation_center/__init__.py
@@ -227,7 +227,7 @@ UpdateCase = type(
         "verb": "patch",
         "endpoint": base_url + "cases/{uuid}",
         "query_parameters": [],
-        "timeout": 120,
+        "timeout": 60,
     },
 )
 

--- a/Sekoia.io/sekoiaio/operation_center/__init__.py
+++ b/Sekoia.io/sekoiaio/operation_center/__init__.py
@@ -227,6 +227,7 @@ UpdateCase = type(
         "verb": "patch",
         "endpoint": base_url + "cases/{uuid}",
         "query_parameters": [],
+        "timeout": 120,
     },
 )
 


### PR DESCRIPTION
## Description

Relates to https://github.com/SekoiaLab/platform/issues/89963

### Fixed

- Fix large/empty `description` field timeout errors in `Edit case` (`update_case`) playbook action:
  - Raise `timeout` default value from `5` to `60` seconds in `UpdateCase` class

## Summary by Sourcery

Increase the timeout for the Sekoia.io case update operation and release a new patch version.

Enhancements:
- Raise the default timeout for the `UpdateCase` playbook action to better handle large or empty case descriptions.

Build:
- Bump the Sekoia.io integration version from 2.75.0 to 2.75.1 in the manifest.

Documentation:
- Document the timeout change and new patch release in the changelog.