### PR TITLE
register AWS S3 FlowLogs Parquet connector for intake v2

### DIFF
--- a/AWS/connector_s3_flowlogs_parquet.json
+++ b/AWS/connector_s3_flowlogs_parquet.json
@@ -1,6 +1,6 @@
 {
   "description": "Get FlowLogs records from new S3 Parquet objects based on notifications",
-  "docker_parameters": "aws_s3_flowlogs_parquet_records_trigger",
+  "docker_parameters": "aws_s3_flowlogs_parquet_records_connector",
   "name": "Fetch new FlowLogs Parquet records on S3",
   "arguments": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/AWS/main.py
+++ b/AWS/main.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
     module.register(FlowlogRecordsTrigger, "flowlog_records_trigger")
     module.register(AwsS3LogsTrigger, "aws_s3_logs_trigger")
     module.register(AwsS3RecordsTrigger, "aws_s3_cloudtrail_records_trigger")
+    module.register(AwsS3FlowLogsParquetRecordsTrigger, "aws_s3_flowlogs_parquet_records_connector")
     module.register(AwsS3FlowLogsParquetRecordsTrigger, "aws_s3_flowlogs_parquet_records_trigger")
     module.register(AwsSqsMessagesTrigger, "aws_sqs_messages_trigger")
     module.register(AwsS3FlowLogsTrigger, "aws_s3_flowlogs_trigger")


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1857

## Summary by Sourcery

New Features:
- Expose the AwsS3FlowLogsParquetRecordsTrigger via an additional connector name for intake v2 compatibility.