### PR TITLE
Fix: EntraId Asset Connector Missing Users (1657)

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-13 - 2.12.0
+
+### Added
+
+- Add a `full_resync_frequency` argument (default 7 days, 0 to disable) to the user asset connector: the checkpoint is dropped once the window has elapsed so the whole tenant is collected again. The checkpoint only moves forward on `createdDateTime`, so a user missed by one cycle was previously never collected again
+
+### Fixed
+
+- Skip a user whose enrichment calls fail (typically a 403 on a restricted account) instead of aborting the whole collection cycle. The connector used to stop on that user on every run and never reach the users behind it. Skipped users are logged and collected again on the next full resync
+
 ## 2026-07-28 - 2.11.1
 
 ### Added

--- a/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
+++ b/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 
@@ -12,8 +13,10 @@ from msgraph.generated.models.microsoft_authenticator_authentication_method impo
 from msgraph.generated.models.phone_authentication_method import PhoneAuthenticationMethod
 from msgraph.generated.models.software_oath_authentication_method import SoftwareOathAuthenticationMethod
 from msgraph.generated.models.user import User
+from msgraph.generated.models.user_collection_response import UserCollectionResponse
 from msgraph.generated.users.users_request_builder import UsersRequestBuilder
 from sekoia_automation.asset_connector import AsyncAssetConnector
+from sekoia_automation.asset_connector.models.connector import DefaultAssetConnectorConfiguration
 from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product
 from sekoia_automation.asset_connector.models.ocsf.organization import Organization
 from sekoia_automation.asset_connector.models.ocsf.user import (
@@ -38,6 +41,18 @@ from sekoia_automation.storage import PersistentJSON
 from azure_ad.base import AzureADModule
 
 
+class EntraIDAssetConnectorConfiguration(DefaultAssetConnectorConfiguration):
+    """Configuration of the Entra ID user asset connector.
+
+    Attributes:
+        full_resync_frequency (int): Seconds between two full re-collections of the
+            tenant. 0 disables periodic resync and keeps the connector purely
+            incremental.
+    """
+
+    full_resync_frequency: int = 604800  # 7 days
+
+
 class EntraIDAssetConnector(AsyncAssetConnector):
     """Asset connector for Microsoft Entra ID user inventory.
 
@@ -46,6 +61,7 @@ class EntraIDAssetConnector(AsyncAssetConnector):
     """
 
     module: AzureADModule
+    configuration: EntraIDAssetConnectorConfiguration
 
     PRODUCT_NAME = "Microsoft Entra ID"
     PRODUCT_VERSION = "1.0"
@@ -105,6 +121,41 @@ class EntraIDAssetConnector(AsyncAssetConnector):
         with self.context as cache:
             cache.pop("most_recent_date_seen", None)
         self._latest_time = None
+
+    async def maybe_full_resync(self) -> None:
+        """Drop the checkpoint periodically so the next cycle re-collects the whole tenant.
+
+        The checkpoint only ever moves forward on `createdDateTime`, so a user missed once
+        - a failed batch, an aborted cycle, an enrichment error - would never be collected
+        again. Re-collecting everything every `full_resync_frequency` seconds bounds how
+        long such a gap can last.
+        """
+        full_resync_frequency = self.configuration.full_resync_frequency
+        if full_resync_frequency <= 0:
+            return
+
+        now = time.time()
+        with self.context as cache:
+            last_full_resync: float | None = cache.get("last_full_resync")
+
+        # First run: the cycle about to start is already a full collection.
+        if last_full_resync is None:
+            with self.context as cache:
+                cache["last_full_resync"] = now
+
+            return
+
+        if now - last_full_resync < full_resync_frequency:
+            return
+
+        self.log(
+            message=f"Last full resync was {int(now - last_full_resync)} seconds ago, "
+            f"resetting the checkpoint to re-collect all users",
+            level="info",
+        )
+        await self.reset_checkpoint()
+        with self.context as cache:
+            cache["last_full_resync"] = now
 
     def get_mapped_fields(self) -> dict[str, str]:
         """Return the Entra ID → OCSF field mapping used for schema-change fingerprinting.
@@ -371,12 +422,8 @@ class EntraIDAssetConnector(AsyncAssetConnector):
         try:
             users = await self.client.users.get(request_configuration=request_configuration)
 
-            if users and users.value:
-                for user in users.value:
-                    # Fetch user details including MFA status
-                    new_user = await self.fetch_user(user)
-                    yield new_user
-                    self._latest_time = new_user.time
+            async for new_user in self.fetch_users_page(users):
+                yield new_user
 
             # Handle pagination for multiple pages of results
             while users is not None and users.odata_next_link is not None:
@@ -386,13 +433,35 @@ class EntraIDAssetConnector(AsyncAssetConnector):
                 users = await self.client.users.with_url(users.odata_next_link).get(
                     request_configuration=pagination_config
                 )
-                if users and users.value:
-                    for user in users.value:
-                        new_user = await self.fetch_user(user)
-                        yield new_user
-                        self._latest_time = new_user.time
+                async for new_user in self.fetch_users_page(users):
+                    yield new_user
         except Exception as e:
             raise ValueError(f"Error fetching users: {e}") from e
+
+    async def fetch_users_page(self, users: UserCollectionResponse | None) -> AsyncGenerator[UserOCSFModel, None]:
+        """Enrich and yield every user of a single page of results.
+
+        A user whose enrichment calls fail - typically a 403 on a restricted account - is
+        logged and skipped instead of aborting the cycle: otherwise the connector stops on
+        that user on every run and never reaches the users behind it. The skipped user is
+        collected again on the next full resync (see :meth:`maybe_full_resync`).
+        """
+        if not users or not users.value:
+            return
+
+        for user in users.value:
+            try:
+                # Fetch user details including MFA status
+                new_user = await self.fetch_user(user)
+            except Exception as e:
+                self.log(
+                    message=f"Skipping user {user.id} - it will be collected again " f"on the next full resync: {e}",
+                    level="error",
+                )
+                continue
+
+            yield new_user
+            self._latest_time = new_user.time
 
     async def get_assets(self) -> AsyncGenerator[UserOCSFModel, None]:
         """Fetch user assets from Microsoft Graph API.
@@ -400,6 +469,9 @@ class EntraIDAssetConnector(AsyncAssetConnector):
         Yields:
             UserOCSFModel: OCSF-formatted user inventory data.
         """
+        # Periodically drop the checkpoint so users missed by a previous cycle come back
+        await self.maybe_full_resync()
+
         # Fetch users from Microsoft Graph API
         last_run_date: str | None = self.most_recent_date_seen
         try:

--- a/MicrosoftEntraID/connector_entra_id_user_assets.json
+++ b/MicrosoftEntraID/connector_entra_id_user_assets.json
@@ -28,10 +28,16 @@
           "description": "Batch size",
           "minimum": 1,
           "default": 100
+      },
+      "full_resync_frequency": {
+          "type": "integer",
+          "description": "Seconds between two full re-collections of the tenant. 0 disables the periodic resync",
+          "minimum": 0,
+          "default": 604800
       }
     },
     "required": ["sekoia_api_key"],
     "secrets": ["sekoia_api_key"],
-    "internal": ["sekoia_base_url", "sekoia_api_key", "frequency", "batch_size"]
+    "internal": ["sekoia_base_url", "sekoia_api_key", "frequency", "batch_size", "full_resync_frequency"]
   }
 }

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftEntraID/tests/asset_connector/test_users_assets.py
+++ b/MicrosoftEntraID/tests/asset_connector/test_users_assets.py
@@ -1,10 +1,12 @@
 import datetime
 import hashlib
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 import requests_mock
+from msgraph.generated.models.user import User
 from sekoia_automation.module import Module
 
 from azure_ad.asset_connector.user_assets import EntraIDAssetConnector
@@ -1165,3 +1167,157 @@ async def test_unchanged_schema_keeps_checkpoint(test_entra_id_asset_connector):
 
     # Assert
     assert test_entra_id_asset_connector.most_recent_date_seen == "2022-01-01T00:00:01+00:00"
+
+
+def set_checkpoint(connector, timestamp=1640995200.0):
+    """Give the connector a checkpoint, as if a previous cycle had collected users."""
+    connector._latest_time = timestamp
+    with connector.context as cache:
+        cache["most_recent_date_seen"] = (
+            datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).replace(microsecond=0).isoformat()
+        )
+
+
+def set_last_full_resync(connector, seconds_ago):
+    with connector.context as cache:
+        cache["last_full_resync"] = time.time() - seconds_ago
+
+
+def get_last_full_resync(connector):
+    with connector.context as cache:
+        return cache.get("last_full_resync")
+
+
+def test_full_resync_frequency_defaults_to_seven_days(test_entra_id_asset_connector):
+    """The connector must resync at least weekly without any explicit configuration."""
+    assert test_entra_id_asset_connector.configuration.full_resync_frequency == 604800
+
+
+@pytest.mark.asyncio
+async def test_maybe_full_resync_first_run_stamps_without_resetting(test_entra_id_asset_connector):
+    """A first run is already a full scan, so it must be stamped but must not drop the checkpoint."""
+    # Arrange
+    set_checkpoint(test_entra_id_asset_connector)
+    assert get_last_full_resync(test_entra_id_asset_connector) is None
+
+    # Act
+    await test_entra_id_asset_connector.maybe_full_resync()
+
+    # Assert
+    assert test_entra_id_asset_connector.most_recent_date_seen is not None
+    assert get_last_full_resync(test_entra_id_asset_connector) is not None
+
+
+@pytest.mark.asyncio
+async def test_maybe_full_resync_resets_checkpoint_once_window_elapsed(test_entra_id_asset_connector):
+    """Past the resync window the checkpoint is dropped, so skipped users get collected again."""
+    # Arrange
+    set_checkpoint(test_entra_id_asset_connector)
+    set_last_full_resync(test_entra_id_asset_connector, seconds_ago=604801)
+    previous_stamp = get_last_full_resync(test_entra_id_asset_connector)
+
+    # Act
+    await test_entra_id_asset_connector.maybe_full_resync()
+
+    # Assert
+    assert test_entra_id_asset_connector.most_recent_date_seen is None
+    assert test_entra_id_asset_connector._latest_time is None
+    assert get_last_full_resync(test_entra_id_asset_connector) > previous_stamp
+
+
+@pytest.mark.asyncio
+async def test_maybe_full_resync_keeps_checkpoint_inside_window(test_entra_id_asset_connector):
+    """Inside the window the connector stays incremental."""
+    # Arrange
+    set_checkpoint(test_entra_id_asset_connector)
+    set_last_full_resync(test_entra_id_asset_connector, seconds_ago=3600)
+    previous_stamp = get_last_full_resync(test_entra_id_asset_connector)
+
+    # Act
+    await test_entra_id_asset_connector.maybe_full_resync()
+
+    # Assert
+    assert test_entra_id_asset_connector.most_recent_date_seen == "2022-01-01T00:00:00+00:00"
+    assert get_last_full_resync(test_entra_id_asset_connector) == previous_stamp
+
+
+@pytest.mark.asyncio
+async def test_maybe_full_resync_disabled_by_zero_frequency(test_entra_id_asset_connector):
+    """A frequency of 0 opts out of periodic resync entirely."""
+    # Arrange
+    test_entra_id_asset_connector.configuration.full_resync_frequency = 0
+    set_checkpoint(test_entra_id_asset_connector)
+    set_last_full_resync(test_entra_id_asset_connector, seconds_ago=100 * 86400)
+
+    # Act
+    await test_entra_id_asset_connector.maybe_full_resync()
+
+    # Assert
+    assert test_entra_id_asset_connector.most_recent_date_seen == "2022-01-01T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_get_assets_fetches_unfiltered_after_resync(test_entra_id_asset_connector):
+    """After a resync is due, get_assets must query without the createdDateTime filter."""
+    # Arrange
+    set_checkpoint(test_entra_id_asset_connector)
+    set_last_full_resync(test_entra_id_asset_connector, seconds_ago=604801)
+
+    seen_dates = []
+
+    async def record_last_run_date(last_run_date=None):
+        seen_dates.append(last_run_date)
+        return
+        yield  # make it an async generator
+
+    test_entra_id_asset_connector.fetch_new_users = record_last_run_date
+    test_entra_id_asset_connector.close_client = AsyncMock()
+
+    # Act
+    _ = [user async for user in test_entra_id_asset_connector.get_assets()]
+
+    # Assert
+    assert seen_dates == [None]
+
+
+@pytest.mark.asyncio
+async def test_fetch_new_users_skips_user_whose_enrichment_fails(test_entra_id_asset_connector):
+    """One user failing enrichment must not abort the cycle for the users behind it."""
+    # Arrange
+    mock_users = [
+        User(id="user1", user_principal_name="user1@example.com"),
+        User(id="broken", user_principal_name="broken@example.com"),
+        User(id="user3", user_principal_name="user3@example.com"),
+    ]
+    mock_users_response = MagicMock()
+    mock_users_response.value = mock_users
+    mock_users_response.odata_next_link = None
+    test_entra_id_asset_connector.client = mock_graph_service_client()
+    test_entra_id_asset_connector.client.users.get = AsyncMock(return_value=mock_users_response)
+
+    first, third = MagicMock(time=1.0), MagicMock(time=3.0)
+    test_entra_id_asset_connector.fetch_user = AsyncMock(
+        side_effect=[first, ValueError("Error fetching user MFA: 403"), third]
+    )
+
+    # Act
+    result = [user async for user in test_entra_id_asset_connector.fetch_new_users()]
+
+    # Assert
+    assert result == [first, third]
+    logged = [call.kwargs for call in test_entra_id_asset_connector.log.call_args_list]
+    assert any(entry.get("level") == "error" and "broken" in entry.get("message", "") for entry in logged)
+
+
+@pytest.mark.asyncio
+async def test_fetch_new_users_still_raises_when_listing_fails(test_entra_id_asset_connector):
+    """Tolerating per-user failures must not swallow a failure of the users listing itself."""
+    # Arrange
+    mock_client = mock_graph_service_client()
+    mock_client.users.get = AsyncMock(side_effect=Exception("API Error"))
+    test_entra_id_asset_connector._client = mock_client
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Error fetching users"):
+        async for _ in test_entra_id_asset_connector.fetch_new_users():
+            pass


### PR DESCRIPTION
Relates to [1657](https://github.com/SekoiaLab/integration/issues/1657)

## Summary by Sourcery

Introduce periodic full-resync behavior and resilience to per-user enrichment failures in the Entra ID user asset connector, ensuring missed or problematic users do not prevent subsequent users from being collected.

New Features:
- Add a configurable `full_resync_frequency` option to the Entra ID user asset connector that controls how often the checkpoint is dropped to re-collect the full tenant.

Bug Fixes:
- Skip and log users whose enrichment fails instead of aborting the entire user collection cycle, allowing subsequent users to be collected.

Enhancements:
- Trigger a possible full resync at the start of asset collection so previously missed users can be re-collected.
- Refactor user page processing into a dedicated helper that updates the checkpoint per enriched user and supports error handling for enrichment failures.

Documentation:
- Document the new full-resync behavior and failure handling in the Microsoft Entra ID changelog.

Tests:
- Add tests covering full-resync scheduling, checkpoint reset behavior, and unfiltered asset fetching after a resync window elapses.
- Add tests verifying that per-user enrichment failures are logged and skipped while global user listing failures still surface as errors.

Chores:
- Bump the Microsoft Entra ID connector version to 2.12.0 in the manifest.