### PR TITLE
fix upwind categorie

### DIFF
--- a/Upwind/CHANGELOG.md
+++ b/Upwind/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.0] - 2026-08-18
+
+- Fix Upwind category in manifest.json to be "Network" instead of "Cloud".
+
 ## [0.3.0] - 2026-08-17
 
 - Refactored the detections connector onto the SDK `iterate()` loop to restore forwarded/lag/duration metrics.

--- a/Upwind/manifest.json
+++ b/Upwind/manifest.json
@@ -43,8 +43,8 @@
   "name": "Upwind",
   "uuid": "2f9602ef-bf5f-4a2a-b401-c8e3549ff34f",
   "slug": "upwind",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "categories": [
-    "Cloud"
+    "Network"
   ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Correct the Upwind integration metadata and release version.

Bug Fixes:
- Correct the Upwind integration category from Cloud to Network.

Chores:
- Bump the Upwind manifest version to 0.4.0.