### PR TITLE
fix after testing

### DIFF
--- a/Upwind/CHANGELOG.md
+++ b/Upwind/CHANGELOG.md
@@ -2,19 +2,33 @@
 
 ## [0.4.1] - 2026-08-18
 
+### Changed
+
 - Store the boundary checkpoint in a dedicated `boundary_context.json` file to avoid overwriting the SDK checkpoint that owns `context.json`.
+
+### Fixed
+
 - Strip the timezone from the checkpoint datetime yielded to the SDK so lag metrics are computed correctly.
 
 ## [0.4.0] - 2026-08-18
+
+### Fixed
 
 - Fix Upwind category in manifest.json to be "Network" instead of "Cloud".
 
 ## [0.3.0] - 2026-08-17
 
+### Changed
+
 - Refactored the detections connector onto the SDK `iterate()` loop to restore forwarded/lag/duration metrics.
+
+### Removed
+
 - Removed the redundant `batch_size` connector setting (the SDK chunks events by size).
 
 ## [0.2.0] - 2026-08-14
+
+### Added
 
 - Initial version of the Upwind automation module.
 - Added the Upwind detections connector to collect detections and forward events to Sekoia.io intake.

--- a/Upwind/CHANGELOG.md
+++ b/Upwind/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.1] - 2026-08-18
+
+- Store the boundary checkpoint in a dedicated `boundary_context.json` file to avoid overwriting the SDK checkpoint that owns `context.json`.
+- Strip the timezone from the checkpoint datetime yielded to the SDK so lag metrics are computed correctly.
+
 ## [0.4.0] - 2026-08-18
 
 - Fix Upwind category in manifest.json to be "Network" instead of "Cloud".

--- a/Upwind/manifest.json
+++ b/Upwind/manifest.json
@@ -43,7 +43,7 @@
   "name": "Upwind",
   "uuid": "2f9602ef-bf5f-4a2a-b401-c8e3549ff34f",
   "slug": "upwind",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "categories": [
     "Network"
   ]

--- a/Upwind/tests/test_upwind_connector_core.py
+++ b/Upwind/tests/test_upwind_connector_core.py
@@ -67,7 +67,8 @@ def test_iterate_yields_new_detections_and_updates_checkpoint() -> None:
     assert len(batches) == 1
     outgoing, most_recent = batches[0]
     assert len(outgoing) == 3
-    assert most_recent == datetime(2026, 7, 3, 10, 5, tzinfo=UTC)
+    # iterate yields a naive UTC watermark for the SDK lag computation.
+    assert most_recent == datetime(2026, 7, 3, 10, 5)
     assert connector.last_detection_date.offset == datetime(2026, 7, 3, 10, 5, tzinfo=UTC)
     # Only the detection at the new watermark is retained for boundary dedup.
     assert connector._context.data["boundary_detection_ids"] == ["evt-3"]
@@ -109,6 +110,7 @@ def test_iterate_forwards_new_detection_at_checkpoint_boundary() -> None:
     assert len(batches) == 1
     outgoing, most_recent = batches[0]
     assert len(outgoing) == 1
-    assert most_recent == since
+    # iterate yields a naive UTC watermark for the SDK lag computation.
+    assert most_recent == since.replace(tzinfo=None)
     assert connector.last_detection_date.offset == since
     assert connector._context.data["boundary_detection_ids"] == ["evt-1", "evt-2"]

--- a/Upwind/upwind/upwind_detections_connector.py
+++ b/Upwind/upwind/upwind_detections_connector.py
@@ -82,7 +82,9 @@ class UpwindDetectionsConnector(Connector):
             start_at=timedelta(days=7),
             ignore_older_than=timedelta(days=30),
         )
-        self._context = PersistentJSON("context.json", self.data_path)
+        # Use a dedicated file: CheckpointDatetime already owns context.json, and two
+        # PersistentJSON instances on the same file overwrite each other on dump.
+        self._context = PersistentJSON("boundary_context.json", self.data_path)
         self.request_timeout = int(os.environ.get("UPWIND_CLIENT_TIMEOUT", "60"))
         self._oauth_provider = OAuthTokenProvider()
 
@@ -193,7 +195,8 @@ class UpwindDetectionsConnector(Connector):
             return
 
         # Yield before advancing the checkpoint so events are pushed first.
-        yield outgoing, most_recent
+        # The SDK computes lag against a naive UTC ``now``, so strip the tzinfo here.
+        yield outgoing, most_recent.astimezone(UTC).replace(tzinfo=None)
 
         self.last_detection_date.offset = most_recent
         self._save_boundary_ids(boundary_ids)


### PR DESCRIPTION
## Summary by Sourcery

Fix Upwind checkpoint handling and timestamp reporting to preserve SDK state and calculate lag metrics correctly.

Bug Fixes:
- Correct checkpoint persistence and lag metric timestamps for the Upwind detections connector.
- Update the manifest version to 0.4.1.

Enhancements:
- Separate boundary checkpoint state from the SDK-owned checkpoint file.

Tests:
- Update connector tests to validate naive UTC watermarks returned for SDK lag calculations.