### PR TITLE
Github - fix loop

### DIFF
--- a/Github/CHANGELOG.md
+++ b/Github/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Accommodate for async loop behaviour in python 3.14
+- Adjust for async loop behaviour in Python 3.14
 
 ## 2026-08-18 - 1.12.0
 

--- a/Github/CHANGELOG.md
+++ b/Github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-19 - 1.12.1
+
+### Fixed
+
+- Accommodate for async loop behaviour in python 3.14
+
 ## 2026-08-18 - 1.12.0
 
 ### Changed

--- a/Github/github_modules/audit_log_trigger.py
+++ b/Github/github_modules/audit_log_trigger.py
@@ -215,6 +215,12 @@ class AuditLogConnector(AsyncConnector):
             try:
                 loop = asyncio.get_event_loop()
 
+            except RuntimeError:
+                # Fallback
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+            try:
                 while self.running:
                     loop.run_until_complete(self.next_batch())
 

--- a/Github/manifest.json
+++ b/Github/manifest.json
@@ -38,7 +38,7 @@
   "name": "Github",
   "uuid": "7a951812-28a2-445a-a257-f26deae34d44",
   "slug": "github",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "categories": [
     "Collaboration Tools"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Handle missing default asyncio event loops in the GitHub audit log trigger.

Bug Fixes:
- Ensure the GitHub audit log trigger continues to operate when Python 3.14 does not provide a default asynchronous event loop.

Chores:
- Bump the GitHub integration version to 1.12.1 and document the fix in the changelog.