### PR TITLE
Feat: Add source IP to the Beyond Trust connector

### DIFF
--- a/BeyondTrust/CHANGELOG.md
+++ b/BeyondTrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Include customer and representative IP addresses (public/private) in events from the PRA platform connector
+
 ## 2026-04-30 - 1.3.0
 
 ### Added

--- a/BeyondTrust/beyondtrust_modules/helpers.py
+++ b/BeyondTrust/beyondtrust_modules/helpers.py
@@ -1,6 +1,37 @@
+import re
 from typing import Any
 
 from lxml import etree
+
+# BeyondTrust reports IPs as "<ip>[:<port>]", with IPv6 addresses bracketed
+# (e.g. "4.231.237.19:61606" or "[2a01:e34:...]:56722"), or the string "Unknown".
+IP_PATTERN = re.compile(r"^\[(?P<ipv6>[0-9a-fA-F:]+)\](?::\d+)?$|^(?P<ipv4>\d{1,3}(?:\.\d{1,3}){3})(?::\d+)?$")
+
+
+def _extract_ip(raw: str | None) -> str | None:
+    """Extract the bare IP address from a BeyondTrust '<ip>[:<port>]' value."""
+    if not raw or raw.strip().lower() == "unknown":
+        return None
+
+    match = IP_PATTERN.match(raw.strip())
+    if not match:
+        return None
+
+    return match.group("ipv6") or match.group("ipv4")
+
+
+def _parse_endpoints(root: Any, xpath_expr: str, namespace: dict[str, str]) -> list[dict[str, str]]:
+    """Parse a list of customer/representative elements into username + IP dicts."""
+    result = []
+    for elem in root.xpath(xpath_expr, namespaces=namespace):
+        endpoint = {
+            "username": elem.findtext("ns:username", namespaces=namespace),
+            "public_ip": _extract_ip(elem.findtext("ns:public_ip", namespaces=namespace)),
+            "private_ip": _extract_ip(elem.findtext("ns:private_ip", namespaces=namespace)),
+        }
+        result.append({key: value for key, value in endpoint.items() if value})
+
+    return result
 
 
 def parse_session_list(raw: bytes) -> list[str]:
@@ -33,6 +64,14 @@ def parse_session(raw: bytes) -> list[dict[str, Any]]:
             "type": root.xpath("/ns:session_list/ns:session/ns:jump_group/@type", namespaces=namespace)[0],
         },
     }
+
+    customers = _parse_endpoints(root, "/ns:session_list/ns:session/ns:customer_list/ns:customer", namespace)
+    if customers:
+        events_header["customers"] = customers
+
+    representatives = _parse_endpoints(root, "/ns:session_list/ns:session/ns:rep_list/ns:representative", namespace)
+    if representatives:
+        events_header["representatives"] = representatives
 
     result = []
     events = root.xpath("/ns:session_list/ns:session/ns:session_details/ns:event", namespaces=namespace)

--- a/BeyondTrust/tests/test_helpers.py
+++ b/BeyondTrust/tests/test_helpers.py
@@ -1,6 +1,6 @@
 from pytest import fixture
 
-from beyondtrust_modules.helpers import parse_session, parse_session_end_time, parse_session_list
+from beyondtrust_modules.helpers import _extract_ip, parse_session, parse_session_end_time, parse_session_list
 
 
 def test_parse_session_list(sessions_list_xml):
@@ -10,12 +10,17 @@ def test_parse_session_list(sessions_list_xml):
 
 def test_parse_session(session_xml):
     items = parse_session(session_xml)
+    customers = [{"username": "Sekoia.io integration", "public_ip": "4.231.237.19", "private_ip": "10.0.0.4"}]
+    representatives = [{"username": "admin", "public_ip": "2a01:e34:ec57:b230:f188:56c5:7089:d987"}]
+
     assert items == [
         {
             "timestamp": "1733239565",
             "event_type": "Session Start",
             "session_id": "e9e99aeb9ad54fb381634498502c5a1b",
             "jump_group": {"name": "Sekoia.io integration", "type": "shared"},
+            "customers": customers,
+            "representatives": representatives,
         },
         {
             "timestamp": "1733239565",
@@ -24,6 +29,8 @@ def test_parse_session(session_xml):
             "destination": {"type": "system", "name": "Pre-start Conference"},
             "session_id": "e9e99aeb9ad54fb381634498502c5a1b",
             "jump_group": {"name": "Sekoia.io integration", "type": "shared"},
+            "customers": customers,
+            "representatives": representatives,
         },
     ]
 
@@ -31,3 +38,26 @@ def test_parse_session(session_xml):
 def test_parse_end_time(session_xml):
     end_time = parse_session_end_time(session_xml)
     assert end_time == 1733240467
+
+
+class TestExtractIp:
+    def test_ipv4_with_port(self):
+        assert _extract_ip("4.231.237.19:61606") == "4.231.237.19"
+
+    def test_ipv4_without_port(self):
+        assert _extract_ip("10.0.0.4") == "10.0.0.4"
+
+    def test_ipv6_with_port(self):
+        assert _extract_ip("[2a01:e34:ec57:b230:f188:56c5:7089:d987]:56722") == "2a01:e34:ec57:b230:f188:56c5:7089:d987"
+
+    def test_unknown(self):
+        assert _extract_ip("Unknown") is None
+
+    def test_none(self):
+        assert _extract_ip(None) is None
+
+    def test_empty(self):
+        assert _extract_ip("") is None
+
+    def test_unparsable(self):
+        assert _extract_ip("not-an-ip") is None


### PR DESCRIPTION
Hi! First of all, thanks for your product!

As opened on #2955, this is a PoC for an improvement that I think could benefit lot of clients.

In fact, currently if someone connects to BYT via a tor node or equivalent, no alert will be raised on the SIEM.

Thanks in advance.

## Summary by Sourcery

Add customer and representative source IP information to BeyondTrust PRA session events.

New Features:
- Include customer and representative public and private IP addresses in PRA session events.

Enhancements:
- Normalize reported IPv4 and IPv6 endpoint values by removing optional ports and ignoring unknown or invalid addresses.

Tests:
- Add coverage for IPv4 and IPv6 address parsing, missing values, unknown values, and invalid input.