### PR TITLE
Imp/darktrace cloud onpremise flow

### DIFF
--- a/Darktrace/CHANGELOG.md
+++ b/Darktrace/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-20 - 1.7.3
+
+### Fixed
+
+- Allow creating Darktrace integration without Cloud API credentials for On-Premise syslog setups.
+- Validate Cloud API credentials only when the Darktrace connector is started.
+
 ## 2026-08-20 - 1.7.2
 
 ### Changed

--- a/Darktrace/darktrace_modules/models.py
+++ b/Darktrace/darktrace_modules/models.py
@@ -2,10 +2,10 @@ from pydantic import BaseModel, Field
 
 
 class DarktraceModuleConfiguration(BaseModel):
-    api_url: str = Field(..., description="The url of the Darktrace appliance")
-    public_key: str = Field(..., description="The public key to the Darktrace API")
-    private_key: str = Field(
-        ...,
+    api_url: str | None = Field(default=None, description="The url of the Darktrace appliance")
+    public_key: str | None = Field(default=None, description="The public key to the Darktrace API")
+    private_key: str | None = Field(
+        default=None,
         description="The private key to the Darktrace API",
         json_schema_extra={"secret": True},
     )

--- a/Darktrace/darktrace_modules/threat_visualizer_log_trigger.py
+++ b/Darktrace/darktrace_modules/threat_visualizer_log_trigger.py
@@ -205,6 +205,24 @@ class ThreatVisualizerLogConnector(Connector):
     module: DarktraceModule
     configuration: ThreatVisualizerLogConnectorConfiguration
 
+    def validate_cloud_configuration(self):
+        """
+        Ensure Cloud API settings are present before starting collectors.
+        """
+        missing_fields = [
+            field_name
+            for field_name in ("api_url", "public_key", "private_key")
+            if not getattr(self.module.configuration, field_name, None)
+        ]
+
+        if missing_fields:
+            missing_fields_str = ", ".join(missing_fields)
+            raise ValueError(
+                "Missing required Darktrace Cloud configuration fields: "
+                f"{missing_fields_str}. "
+                "These fields are only required when running the Cloud API connector."
+            )
+
     def start_consumers(self):
         consumers = {}
         for endpoint in Endpoints:
@@ -232,6 +250,8 @@ class ThreatVisualizerLogConnector(Connector):
 
     def run(self):
         self.log(message="Start fetching Darktrace threat visualizer logs", level="info")  # pragma: no cover
+
+        self.validate_cloud_configuration()
 
         consumers = self.start_consumers()
         while self.running:

--- a/Darktrace/manifest.json
+++ b/Darktrace/manifest.json
@@ -5,24 +5,19 @@
     "type": "object",
     "properties": {
       "api_url": {
-        "description": "The url of the Darktrace appliance. (e.g. https://example.darktrace.com or https://192.168.0.1)",
+        "description": "The url of the Darktrace appliance, required only for Cloud API collection (e.g. https://example.darktrace.com or https://192.168.0.1)",
         "format": "uri",
         "type": "string"
       },
       "public_key": {
-        "description": "The public key to the Darktrace API",
+        "description": "The public key to the Darktrace API, required only for Cloud API collection",
         "type": "string"
       },
       "private_key": {
-        "description": "The private key to the Darktrace API",
+        "description": "The private key to the Darktrace API, required only for Cloud API collection",
         "type": "string"
       }
     },
-    "required": [
-      "api_url",
-      "public_key",
-      "private_key"
-    ],
     "secrets": [
       "private_key"
     ]
@@ -31,7 +26,7 @@
   "name": "Darktrace",
   "uuid": "0637f7c2-d68b-49cc-a1fc-ab7d0836e7ee",
   "slug": "darktrace",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "categories": [
     "Endpoint"
   ]

--- a/Darktrace/tests/test_threat_visualizer_log_trigger.py
+++ b/Darktrace/tests/test_threat_visualizer_log_trigger.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytest
 import requests_mock
@@ -143,3 +143,17 @@ def test_validate_cloud_configuration_missing_field(trigger):
         match="Missing required Darktrace Cloud configuration fields: private_key",
     ):
         trigger.validate_cloud_configuration()
+
+
+def test_run_validates_cloud_configuration(trigger):
+    with (
+        patch.object(ThreatVisualizerLogConnector, "validate_cloud_configuration") as mock_validate,
+        patch.object(ThreatVisualizerLogConnector, "start_consumers", return_value={}) as mock_start,
+        patch.object(ThreatVisualizerLogConnector, "stop_consumers") as mock_stop,
+        patch.object(ThreatVisualizerLogConnector, "running", new_callable=PropertyMock, return_value=False),
+    ):
+        trigger.run()
+
+    assert mock_validate.call_count == 1
+    assert mock_start.call_count == 1
+    assert mock_stop.call_count == 1

--- a/Darktrace/tests/test_threat_visualizer_log_trigger.py
+++ b/Darktrace/tests/test_threat_visualizer_log_trigger.py
@@ -126,3 +126,20 @@ def test_supervise_consumers(trigger):
 
         trigger.supervise_consumers(consumers)
         assert mock_start.call_count == 1
+
+
+def test_validate_cloud_configuration_ok(trigger):
+    trigger.validate_cloud_configuration()
+
+
+def test_validate_cloud_configuration_missing_field(trigger):
+    trigger.module.configuration = {
+        "api_url": "https://api_url",
+        "public_key": "public",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="Missing required Darktrace Cloud configuration fields: private_key",
+    ):
+        trigger.validate_cloud_configuration()


### PR DESCRIPTION
https://github.com/SekoiaLab/platform/issues/87608

## Summary by Sourcery

Support Darktrace On-Premise syslog setups while enforcing Cloud API configuration when Cloud collection is started.

Bug Fixes:
- Allow Darktrace integrations to be created without Cloud API credentials for On-Premise syslog collection.
- Validate required Cloud API credentials when the Cloud connector starts.

Enhancements:
- Clarify that Cloud API configuration fields are optional for non-Cloud collection.

Tests:
- Add coverage for valid, incomplete, and startup-time Cloud configuration validation.