### PR TITLE
Fix: Okta Account Validation (1848)

### DIFF
--- a/Okta/CHANGELOG.md
+++ b/Okta/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-21 - 2.10.5
+
+### Fixed
+
+- Account validation now reports the real error to the platform instead of "Unknown error": the validator calls `self.error()` so the message reaches the UI, and falls back to `str(err)`/`repr(err)` when the Okta SDK error carries an empty `message`.
+
 ## 2026-06-16 - 2.10.4
 
 ### Fixed

--- a/Okta/manifest.json
+++ b/Okta/manifest.json
@@ -26,7 +26,7 @@
   "name": "Okta",
   "uuid": "4ef895d1-3f21-4678-8d0a-5c39c37210fe",
   "slug": "okta",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "categories": [
     "IAM"
   ],

--- a/Okta/okta_modules/account_validator.py
+++ b/Okta/okta_modules/account_validator.py
@@ -28,14 +28,18 @@ class OktaAccountValidator(AccountValidator):
         try:
             loop = asyncio.get_event_loop()
             _, _, err = loop.run_until_complete(self.client.list_users())
-            if err:
-                message = getattr(err, "message", str(err))
-                self.log(f"Error while validating account. Authentication failed: {message}", level="error")
+            if not err:
+                return True
 
-                return False
+            # Okta errors expose `.message`, but it is empty on the base `Error` class.
+            # Network failures are returned as raw exceptions, some of which stringify to "".
+            message = getattr(err, "message", "") or str(err) or repr(err)
         except Exception as e:
-            self.log(f"Error while validating account. Authentication failed: {e}", level="error")
+            message = str(e) or repr(e)
 
-            return False
+        error_message = f"Error while validating account. Authentication failed: {message}"
+        self.log(error_message, level="error")
+        # Without this the platform has no error to display and falls back to "Unknown error"
+        self.error(error_message)
 
-        return True
+        return False

--- a/Okta/tests/test_account_validator.py
+++ b/Okta/tests/test_account_validator.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import Mock, PropertyMock, patch
 
 from okta_modules.account_validator import OktaAccountValidator
@@ -189,3 +190,93 @@ class TestOktaAccountValidator:
                 mock_log.assert_called_once_with(
                     f"Error while validating account. Authentication failed: {error_message}", level="error"
                 )
+
+    def test_validate_error_with_empty_message_falls_back_to_str(self):
+        """Okta errors carrying an empty `.message` must not produce a blank log/error."""
+        mock_client = Mock()
+
+        class FakeOktaError:
+            message = ""
+
+            def __str__(self):
+                return "Your Okta domain should not contain -admin."
+
+        okta_error = FakeOktaError()
+
+        async def mock_list_users():
+            return None, Mock(), okta_error
+
+        mock_client.list_users = mock_list_users
+
+        with patch.object(type(self.validator), "client", new_callable=PropertyMock, return_value=mock_client):
+            with patch.object(self.validator, "log") as mock_log:
+                with patch.object(self.validator, "error") as mock_error:
+                    result = self.validator.validate()
+
+                    assert result is False
+                    expected = (
+                        "Error while validating account. Authentication failed: "
+                        "Your Okta domain should not contain -admin."
+                    )
+                    mock_log.assert_called_once_with(expected, level="error")
+                    mock_error.assert_called_once_with(expected)
+
+    def test_validate_error_with_empty_message_and_empty_str_falls_back_to_repr(self):
+        """Errors that stringify to an empty string (e.g. TimeoutError) still yield a message."""
+        mock_client = Mock()
+        okta_error = asyncio.TimeoutError()
+
+        async def mock_list_users():
+            return None, Mock(), okta_error
+
+        mock_client.list_users = mock_list_users
+
+        with patch.object(type(self.validator), "client", new_callable=PropertyMock, return_value=mock_client):
+            with patch.object(self.validator, "log") as mock_log:
+                with patch.object(self.validator, "error") as mock_error:
+                    result = self.validator.validate()
+
+                    assert result is False
+                    expected = "Error while validating account. Authentication failed: TimeoutError()"
+                    mock_log.assert_called_once_with(expected, level="error")
+                    mock_error.assert_called_once_with(expected)
+
+    def test_validate_reports_error_to_platform_on_sdk_error(self):
+        """`error()` must be called so the platform shows the real message, not "Unknown error"."""
+        mock_client = Mock()
+        okta_error = Mock()
+        okta_error.message = "Okta HTTP 401 E0000011 Invalid token provided"
+
+        async def mock_list_users():
+            return None, Mock(), okta_error
+
+        mock_client.list_users = mock_list_users
+
+        with patch.object(type(self.validator), "client", new_callable=PropertyMock, return_value=mock_client):
+            with patch.object(self.validator, "error") as mock_error:
+                result = self.validator.validate()
+
+                assert result is False
+                mock_error.assert_called_once_with(
+                    f"Error while validating account. Authentication failed: {okta_error.message}"
+                )
+
+    def test_validate_reports_error_to_platform_on_exception(self):
+        """Client construction failures (e.g. a `-admin` org URL) must reach the platform too."""
+        with patch.object(
+            type(self.validator),
+            "client",
+            new_callable=PropertyMock,
+            side_effect=ValueError("Your Okta domain should not contain -admin."),
+        ):
+            with patch.object(self.validator, "log") as mock_log:
+                with patch.object(self.validator, "error") as mock_error:
+                    result = self.validator.validate()
+
+                    assert result is False
+                    expected = (
+                        "Error while validating account. Authentication failed: "
+                        "Your Okta domain should not contain -admin."
+                    )
+                    mock_log.assert_called_once_with(expected, level="error")
+                    mock_error.assert_called_once_with(expected)


### PR DESCRIPTION
Relates to [1848](https://github.com/SekoiaLab/integration/issues/1848)

## Summary by Sourcery

Fix Okta account validation to surface meaningful authentication errors and consistently fail validation when account checks encounter problems.

Bug Fixes:
- Ensure Okta account validation reports the actual authentication or connection error to the platform instead of falling back to "Unknown error".
- Provide reliable error messages when Okta SDK or network exceptions have empty message strings.

Tests:
- Add coverage for SDK errors, empty error messages, empty-string exceptions, and client construction failures.