### PR TITLE
Ubika - change events age limit

### DIFF
--- a/Ubika/CHANGELOG.md
+++ b/Ubika/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-21 - 1.1.3
+
+### Changed
+
+- Reduce events age limit from one month to a week
+
 ## 2026-05-15 - 1.1.2
 
 ### Added

--- a/Ubika/CHANGELOG.md
+++ b/Ubika/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reduce events age limit from one month to a week
+- Reduce the maximum event lookback period to one week.
 
 ## 2026-05-15 - 1.1.2
 

--- a/Ubika/manifest.json
+++ b/Ubika/manifest.json
@@ -11,7 +11,7 @@
   "name": "Ubika",
   "uuid": "0c82ee9b-f645-47f9-8e16-a689cfc246c4",
   "slug": "ubika",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "categories": [
     "Network"
   ]

--- a/Ubika/tests/test_ubika_cloud_protector_next_gen_alerts.py
+++ b/Ubika/tests/test_ubika_cloud_protector_next_gen_alerts.py
@@ -315,7 +315,7 @@ def test_stepper_initializes_with_backfill(monkeypatch, trigger):
     )
 
 
-def test_stepper_clamps_dates_older_than_one_month(monkeypatch, trigger):
+def test_stepper_clamps_dates_older_than_one_week(monkeypatch, trigger):
     # Override some configuration parameters for the test
     trigger.configuration.frequency = 42
     old_dt = datetime.now(timezone.utc) - timedelta(days=60)
@@ -338,12 +338,12 @@ def test_stepper_clamps_dates_older_than_one_month(monkeypatch, trigger):
     # It must have returned our sentinel
     assert stepper is sentinel
 
-    # And the date passed in was clamped to one_month_ago
+    # And the date passed in was clamped to one_week_ago
     now = datetime.now(timezone.utc)
-    one_month_ago = now - timedelta(days=30)
+    one_week_ago = now - timedelta(days=7)
     passed = called["date"]
     # allow 2s slack for test timing
-    assert abs((passed - one_month_ago).total_seconds()) < 2
+    assert abs((passed - one_week_ago).total_seconds()) < 2
 
     # And create_from_time got the right config args
     assert called["freq"] == trigger.configuration.frequency

--- a/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen_base.py
+++ b/Ubika/ubika_modules/connector_ubika_cloud_protector_next_gen_base.py
@@ -127,12 +127,12 @@ class UbikaCloudProtectorNextGenBaseConnector(Connector):
             # Parse the most recent requested date
             most_recent_date = isoparse(most_recent_date_str)
 
-            # Ensure we do not go back more than one month
+            # Ensure we do not go back more than one week
             now = datetime.now(UTC)
-            one_month_ago = now - timedelta(days=30)
-            # If the most recent date is older than one month, set it to one month ago
-            if most_recent_date < one_month_ago:
-                most_recent_date = one_month_ago
+            one_week_ago = now - timedelta(days=7)
+            # If the most recent date is older than one week, set it to one week ago
+            if most_recent_date < one_week_ago:
+                most_recent_date = one_week_ago
 
             # Create a time stepper from the most recent date seen
             return TimeStepper.create_from_time(


### PR DESCRIPTION
https://github.com/SekoiaLab/platform/issues/93314

## Summary by Sourcery

Reduce the maximum Ubika event lookback period to one week.

Enhancements:
- Limit Ubika event lookback periods to a maximum of one week instead of one month.

Tests:
- Update alert stepper tests to verify the one-week event lookback limit.

Chores:
- Bump Ubika to version 1.1.3 and document the reduced event lookback period.