### PR TITLE
fix(asset_connector): delete just one field

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-25 - 2.10.27
+
+### Changed
+
+- Remove `created_date_time` → `time` field mapping from `EntraIDAssetConnector.get_mapped_fields`
+
 ## 2026-07-27 - 2.10.26
 
 ### Added

--- a/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
+++ b/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
@@ -117,7 +117,6 @@ class EntraIDAssetConnector(AsyncAssetConnector):
             "job_title": "enrichments.employment.value",
             "sign_in_activity.last_sign_in_date_time": "enrichments.account.data.last_logon",
             "last_password_change_date_time": "enrichments.account.data.last_time_password_change",
-            "created_date_time": "time",
         }
 
     def map_fields(self, user: User, has_mfa: bool, groups: list[UserOCSFGroup], is_admin: bool) -> UserOCSFModel:

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.10.26",
+  "version": "2.10.27",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftEntraID/tests/asset_connector/test_users_assets.py
+++ b/MicrosoftEntraID/tests/asset_connector/test_users_assets.py
@@ -1043,7 +1043,6 @@ def test_get_mapped_fields(test_entra_id_asset_connector):
         "job_title": "enrichments.employment.value",
         "sign_in_activity.last_sign_in_date_time": "enrichments.account.data.last_logon",
         "last_password_change_date_time": "enrichments.account.data.last_time_password_change",
-        "created_date_time": "time",
     }
 
     assert test_entra_id_asset_connector.get_mapped_fields() == expected


### PR DESCRIPTION
## Summary by Sourcery

Remove the Microsoft Entra ID user creation timestamp mapping from asset fields.

Bug Fixes:
- Stop mapping the Microsoft Entra ID user creation timestamp to the asset `time` field, ensuring only the intended field is removed.

Tests:
- Update asset connector mapping expectations to reflect removal of the creation timestamp mapping.

Chores:
- Bump the Microsoft Entra ID connector version to 2.10.27 and document the change in the changelog.