### PR TITLE
feat(asset_connector): add field again to activate the reset checkpoint

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-25 - 2.10.28
+
+### Changed
+
+- Add again `created_date_time` → `time` field mapping from `EntraIDAssetConnector.get_mapped_fields` to activate the reset checkpoint feature for this asset connector.
+
 ## 2026-08-25 - 2.10.27
 
 ### Changed

--- a/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
+++ b/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
@@ -117,7 +117,7 @@ class EntraIDAssetConnector(AsyncAssetConnector):
             "job_title": "enrichments.employment.value",
             "sign_in_activity.last_sign_in_date_time": "enrichments.account.data.last_logon",
             "last_password_change_date_time": "enrichments.account.data.last_time_password_change",
-            "created_date_time": "time"
+            "created_date_time": "time",
         }
 
     def map_fields(self, user: User, has_mfa: bool, groups: list[UserOCSFGroup], is_admin: bool) -> UserOCSFModel:

--- a/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
+++ b/MicrosoftEntraID/azure_ad/asset_connector/user_assets.py
@@ -117,6 +117,7 @@ class EntraIDAssetConnector(AsyncAssetConnector):
             "job_title": "enrichments.employment.value",
             "sign_in_activity.last_sign_in_date_time": "enrichments.account.data.last_logon",
             "last_password_change_date_time": "enrichments.account.data.last_time_password_change",
+            "created_date_time": "time"
         }
 
     def map_fields(self, user: User, has_mfa: bool, groups: list[UserOCSFGroup], is_admin: bool) -> UserOCSFModel:

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.10.27",
+  "version": "2.10.28",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftEntraID/tests/asset_connector/test_users_assets.py
+++ b/MicrosoftEntraID/tests/asset_connector/test_users_assets.py
@@ -1043,6 +1043,7 @@ def test_get_mapped_fields(test_entra_id_asset_connector):
         "job_title": "enrichments.employment.value",
         "sign_in_activity.last_sign_in_date_time": "enrichments.account.data.last_logon",
         "last_password_change_date_time": "enrichments.account.data.last_time_password_change",
+        "created_date_time": "time"
     }
 
     assert test_entra_id_asset_connector.get_mapped_fields() == expected

--- a/MicrosoftEntraID/tests/asset_connector/test_users_assets.py
+++ b/MicrosoftEntraID/tests/asset_connector/test_users_assets.py
@@ -1043,7 +1043,7 @@ def test_get_mapped_fields(test_entra_id_asset_connector):
         "job_title": "enrichments.employment.value",
         "sign_in_activity.last_sign_in_date_time": "enrichments.account.data.last_logon",
         "last_password_change_date_time": "enrichments.account.data.last_time_password_change",
-        "created_date_time": "time"
+        "created_date_time": "time",
     }
 
     assert test_entra_id_asset_connector.get_mapped_fields() == expected


### PR DESCRIPTION
## Summary by Sourcery

Restore the Microsoft Entra ID asset field mapping required to activate reset checkpoints.

Bug Fixes:
- Restore the `created_date_time` to `time` asset field mapping so the Microsoft Entra ID reset checkpoint feature is activated.

Tests:
- Update asset connector mapping coverage to include the restored checkpoint field.

Chores:
- Bump the Microsoft Entra ID connector version to 2.10.28 and document the change in the changelog.