### PR TITLE
fix(entraid): fix frequency

### DIFF
--- a/MicrosoftEntraID/CHANGELOG.md
+++ b/MicrosoftEntraID/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-25 - 2.10.29
+
+### Changed
+
+- Set default frequency to 86400s (1 day) and minimum to 10800s (3 hours) in user asset connector
+
 ## 2026-08-25 - 2.10.28
 
 ### Changed

--- a/MicrosoftEntraID/connector_entra_id_user_assets.json
+++ b/MicrosoftEntraID/connector_entra_id_user_assets.json
@@ -16,8 +16,8 @@
       "frequency": {
           "type": "integer",
           "description": "Batch frequency in seconds",
-          "minimum": 1,
-          "default": 1200
+          "minimum": 10800,
+          "default": 86400
       },
       "sekoia_api_key": {
           "description": "API key to use from sekoia.io",

--- a/MicrosoftEntraID/manifest.json
+++ b/MicrosoftEntraID/manifest.json
@@ -41,7 +41,7 @@
   "name": "Microsoft Entra ID",
   "uuid": "3abf7928-65ef-4a5f-ba3e-5fbe56123d0c",
   "slug": "azure-ad",
-  "version": "2.10.28",
+  "version": "2.10.29",
   "categories": [
     "IAM"
   ],


### PR DESCRIPTION
## Summary by Sourcery

Correct the Microsoft Entra ID user asset connector frequency settings.

Bug Fixes:
- Set the Microsoft Entra ID user asset connector’s default polling frequency to one day and minimum frequency to three hours.

Chores:
- Bump the Microsoft Entra ID integration version to 2.10.29 and update its changelog.