### PR TITLE
Fix: Aws bump sdk version

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-26 - 1.39.0
+
+### Changed
+
+- Upgrade `sekoia-automation-sdk` to 1.24.0
+
 ## 2026-07-31 - 1.38.0
 
 ### Added

--- a/AWS/asset_connector/aws_assets.py
+++ b/AWS/asset_connector/aws_assets.py
@@ -94,6 +94,19 @@ class AwsAssetsConnector(OidcAwsMixin, AssetConnector):
             self.log_exception(e)
             return None
 
+    def reset_checkpoint(self) -> None:
+        """Clear the checkpoint so every asset is collected again on the next cycle."""
+        try:
+            with self.context as cache:
+                cache.pop("most_recent_date_seen", None)
+        except Exception as e:
+            self.log(f"Failed to reset checkpoint: {str(e)}", level="error")
+            self.log_exception(e)
+            return
+
+        self.new_most_recent_date = None
+        self.log("Checkpoint reset - a full re-collection will occur on the next cycle", level="info")
+
     def update_checkpoint(self) -> None:
         """Update checkpoint with the most recent processed date."""
         if self.new_most_recent_date is None:

--- a/AWS/asset_connector/device_assets.py
+++ b/AWS/asset_connector/device_assets.py
@@ -61,6 +61,41 @@ class AwsDeviceAssetConnector(AwsAssetsConnector):
     OCSF_VERSION: str = "1.6.0"
     PRODUCT_VERSION: str = "N/A"
 
+    def get_mapped_fields(self) -> dict[str, str]:
+        """Return the EC2 -> OCSF field mapping used for schema-change fingerprinting.
+
+        Static OCSF constants are excluded: they never depend on the EC2 payload, so they
+        cannot invalidate a checkpoint.
+        """
+        return {
+            "Reservations.OwnerId": "device.org.uid",
+            "Instances.InstanceId": "device.uid",
+            "Instances.PublicDnsName": "device.hostname",
+            "Instances.PrivateDnsName": "device.hostname",
+            "Instances.Tags.Name": "device.name",
+            "Instances.Tags.aws:autoscaling:groupName": "device.autoscale_uid",
+            "Instances.PlatformDetails": "device.os.name",
+            "Instances.PublicIpAddress": "device.ip",
+            "Instances.PrivateIpAddress": "device.ip",
+            "Instances.Placement.AvailabilityZone": "device.region",
+            "Instances.SubnetId": "device.subnet",
+            "Instances.VpcId": "device.domain",
+            "Instances.Hypervisor": "device.hypervisor",
+            "Instances.InstanceType": "device.model",
+            "Instances.ImageId": "device.desc",
+            "Instances.State.Name": "device.desc",
+            "Instances.IamInstanceProfile": "device.is_managed",
+            "Instances.LaunchTime": "device.boot_time",
+            "Instances.BlockDeviceMappings.Ebs.AttachTime": "device.created_time",
+            "Instances.NetworkInterfaces.NetworkInterfaceId": "device.network_interfaces.uid",
+            "Instances.NetworkInterfaces.Description": "device.network_interfaces.name",
+            "Instances.NetworkInterfaces.MacAddress": "device.network_interfaces.mac",
+            "Instances.NetworkInterfaces.PrivateIpAddress": "device.network_interfaces.ip",
+            "Instances.NetworkInterfaces.PrivateDnsName": "device.network_interfaces.hostname",
+            "Instances.SecurityGroups.GroupId": "device.groups.uid",
+            "Instances.SecurityGroups.GroupName": "device.groups.name",
+        }
+
     def client(self) -> boto3.client:
         """Create and return a configured AWS EC2 client.
 

--- a/AWS/asset_connector/users_assets.py
+++ b/AWS/asset_connector/users_assets.py
@@ -248,6 +248,26 @@ class AwsUsersAssetConnector(AwsAssetsConnector):
 
         self.log(f"Successfully collected {user_count} AWS users", level="info")
 
+    def get_mapped_fields(self) -> dict[str, str]:
+        """Return the IAM -> OCSF field mapping used for schema-change fingerprinting.
+
+        Sources prefixed with ``Groups.`` come from ``list_groups_for_user``,
+        ``AttachedPolicies.`` from ``list_attached_group_policies`` and ``MFADevices``
+        from ``list_mfa_devices``. Static OCSF constants are excluded: they never depend
+        on the IAM payload, so they cannot invalidate a checkpoint.
+        """
+        return {
+            "UserName": "user.name",
+            "Arn": "user.uid",
+            "UserId": "user.uid_alt",
+            "CreateDate": "time",
+            "PasswordLastUsed": "enrichments.data.last_logon",
+            "Groups.GroupName": "user.groups.name",
+            "Groups.Arn": "user.groups.uid",
+            "AttachedPolicies.PolicyName": "user.groups.privileges",
+            "MFADevices": "user.has_mfa",
+        }
+
     def user_has_admin_policy(self, user_groups: List[Group]) -> bool:
         """Check if a user has admin policies."""
         admin_patterns = ["admin", "administrator", "poweruser"]

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -30,7 +30,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "categories": ["Cloud Providers"],
   "supports_validation": true
 }

--- a/AWS/poetry.lock
+++ b/AWS/poetry.lock
@@ -3755,14 +3755,28 @@ cryptography = ">=2.0"
 jeepney = ">=0.6"
 
 [[package]]
+name = "sekoia-automation-models"
+version = "1.2.0"
+description = "Standalone Pydantic models (OCSF asset-connector) shared across Sekoia services and the `sekoia-automation-sdk`"
+optional = false
+python-versions = "<4,>=3.11"
+files = [
+    {file = "sekoia_automation_models-1.2.0-py3-none-any.whl", hash = "sha256:028afe35160fcfba1b25361f414e4f19dbb427a75b9830831f55d6b93e559c32"},
+    {file = "sekoia_automation_models-1.2.0.tar.gz", hash = "sha256:085d843fe0148a103927fbb6520ec865964b7552cd4c3c37f10d6196ac8a13ce"},
+]
+
+[package.dependencies]
+pydantic = ">=2.10,<3.0.0"
+
+[[package]]
 name = "sekoia-automation-sdk"
-version = "1.23.1"
+version = "1.24.0"
 description = "SDK to create Sekoia.io playbook modules"
 optional = false
 python-versions = "<4,>=3.11"
 files = [
-    {file = "sekoia_automation_sdk-1.23.1-py3-none-any.whl", hash = "sha256:b13a143b8794c188bb900b3e2c3ecbf3b4eeb38b476790f3bdefe6ed52075ebc"},
-    {file = "sekoia_automation_sdk-1.23.1.tar.gz", hash = "sha256:500d2b27ba836411387cf9f339539bfdb4f976d709b9847e10c64d9724ad3e05"},
+    {file = "sekoia_automation_sdk-1.24.0-py3-none-any.whl", hash = "sha256:52b4545cb3bce9a5d14cd1bb1e104b889ab0ae98288f85099b02e9404b39e50f"},
+    {file = "sekoia_automation_sdk-1.24.0.tar.gz", hash = "sha256:09d7a08263354d7494bf94300fadf640d970d0585b9a0e7fdaeab13380ce7fd2"},
 ]
 
 [package.dependencies]
@@ -3786,6 +3800,7 @@ pyyaml = ">=6.0,<7"
 requests = ">=2.25,<3"
 requests-ratelimiter = ">=0.7.0,<0.8"
 s3path = ">=0.6.4,<0.7"
+sekoia-automation-models = ">=1.2.0,<2"
 sentry-sdk = "*"
 tenacity = "*"
 typer = ">=0.20"
@@ -4480,4 +4495,4 @@ type = ["pytest-mypy (>=1.0.1)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.15"
-content-hash = "b77367ef76196ac9890443ef84ac509ecd5e25096506f3becd6c6723e66975f3"
+content-hash = "dcf6e7c6a5b808bf7dd69e982df6c962f8ab651edacaaa95bf460a8580591a3d"

--- a/AWS/pyproject.toml
+++ b/AWS/pyproject.toml
@@ -37,7 +37,7 @@ exclude = ["tests/*"]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.15"
-sekoia-automation-sdk = "^1.23.1"
+sekoia-automation-sdk = "^1.24.0"
 boto3 = ">=1.43.0"
 botocore = ">=1.43.0"
 aiobotocore = "^3.7.0"

--- a/AWS/tests/asset_connector/test_device_assets.py
+++ b/AWS/tests/asset_connector/test_device_assets.py
@@ -1112,3 +1112,23 @@ def test_update_checkpoint_integration(test_aws_device_asset_connector):
 
     # Verify logging was called
     test_aws_device_asset_connector.log.assert_called_with(f"Checkpoint updated with date: {test_date}", level="info")
+
+
+def test_get_mapped_fields(test_aws_device_asset_connector):
+    fields = test_aws_device_asset_connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["Instances.InstanceId"] == "device.uid"
+
+
+def test_reset_checkpoint(test_aws_device_asset_connector):
+    test_aws_device_asset_connector.new_most_recent_date = "2025-01-01T00:00:00+00:00"
+    test_aws_device_asset_connector.update_checkpoint()
+    assert test_aws_device_asset_connector.most_recent_date_seen == "2025-01-01T00:00:00+00:00"
+
+    test_aws_device_asset_connector.reset_checkpoint()
+
+    assert test_aws_device_asset_connector.new_most_recent_date is None
+    assert test_aws_device_asset_connector.most_recent_date_seen is None

--- a/AWS/tests/asset_connector/test_users_assets.py
+++ b/AWS/tests/asset_connector/test_users_assets.py
@@ -1073,3 +1073,23 @@ def test_get_assets_with_exception(test_aws_users_asset_connector):
         # Verify that the method handled the error gracefully and continued processing
         test_aws_users_asset_connector.get_groups_for_user.assert_called_once_with("testuser")
         test_aws_users_asset_connector.get_mfa_status_for_user.assert_called_once_with("testuser")
+
+
+def test_get_mapped_fields(test_aws_users_asset_connector):
+    fields = test_aws_users_asset_connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["Arn"] == "user.uid"
+
+
+def test_reset_checkpoint(test_aws_users_asset_connector):
+    test_aws_users_asset_connector.new_most_recent_date = "2025-01-01T00:00:00+00:00"
+    test_aws_users_asset_connector.update_checkpoint()
+    assert test_aws_users_asset_connector.most_recent_date_seen == "2025-01-01T00:00:00+00:00"
+
+    test_aws_users_asset_connector.reset_checkpoint()
+
+    assert test_aws_users_asset_connector.new_most_recent_date is None
+    assert test_aws_users_asset_connector.most_recent_date_seen is None


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the AWS integration and add schema-aware checkpoint management for reliable asset recollection.

New Features:
- Add AWS asset field mappings for EC2 devices and IAM users to support schema-change fingerprinting.
- Support resetting asset collection checkpoints to trigger a full re-collection.

Enhancements:
- Upgrade the AWS integration to sekoia-automation-sdk 1.24.0.

Build:
- Update the AWS dependency lockfile for the SDK upgrade.

Tests:
- Add coverage for asset field mappings and checkpoint reset behavior.

Chores:
- Bump the AWS integration version to 1.39.0 and document the release.