### PR TITLE
Fix: CrowdStrikeFalcon bump sdk version

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-26 - 1.26.0
+
+### Changed
+
+- Upgrade `sekoia-automation-sdk` to 1.24.0
+- Migrate the module configuration from `pydantic.v1` to Pydantic v2, required by the SDK
+
 ## 2026-07-02 - 1.25.18
 
 ### Fixed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
@@ -380,6 +380,55 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
 
         return device_ocsf
 
+    def get_mapped_fields(self) -> dict[str, str]:
+        """
+        Return the CrowdStrike -> OCSF field mapping used for schema-change fingerprinting.
+
+        Sources prefixed with ``host_groups.`` come from the host-groups lookup used to
+        resolve group names. Static OCSF constants are excluded: they never depend on the
+        CrowdStrike payload, so they cannot invalidate a checkpoint.
+        """
+        return {
+            "device_id": "device.uid",
+            "hostname": "device.hostname",
+            "serial_number": "device.uid_alt",
+            "machine_domain": "device.domain",
+            "platform_name": "device.os.type",
+            "os_version": "device.os.name",
+            "product_type_desc": "device.type",
+            "external_ip": "device.ip",
+            "local_ip": "device.network_interfaces.ip",
+            "mac_address": "device.network_interfaces.mac",
+            "connection_ip": "device.network_interfaces.ip",
+            "connection_mac_address": "device.network_interfaces.mac",
+            "default_gateway_ip": "device.subnet",
+            "system_product_name": "device.model",
+            "system_manufacturer": "device.vendor_name",
+            "bios_manufacturer": "device.hypervisor",
+            "zone_group": "device.region",
+            "cid": "device.org.uid",
+            "service_provider": "device.org.name",
+            "groups": "device.groups.uid",
+            "host_groups.name": "device.groups.name",
+            "host_groups.description": "device.groups.desc",
+            "first_seen": "device.first_seen_time",
+            "last_seen": "device.last_seen_time",
+            "agent_local_time": "device.boot_time",
+            "modified_timestamp": "time",
+            "status": "device.is_compliant",
+            "reduced_functionality_mode": "device.is_compliant",
+            "filesystem_containment_status": "device.is_compliant",
+            "device_policies.firewall.applied": "enrichments.data.Firewall_status",
+            "last_login_user": "enrichments.data.Users",
+        }
+
+    def reset_checkpoint(self) -> None:
+        """Clear the checkpoint so every device is collected again on the next cycle."""
+        with self.context as cache:
+            cache.pop("most_recent_device_id", None)
+        self._latest_id = None
+        self.log("Checkpoint reset - a full device re-collection will occur on the next cycle", level="info")
+
     def update_checkpoint(self) -> None:
         """Update the checkpoint with the latest device ID."""
         self.log("Updating the device id !!", level="info")

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/user_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/user_assets.py
@@ -73,11 +73,44 @@ class CrowdstrikeUserAssetConnector(AssetConnector):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("context.json", self._data_path)
+        self._latest_time: str | None = None
 
     @property
     def most_recent_user_date(self) -> str | None:
         with self.context as cache:
             return cache.get(self.CHECKPOINT_KEY, None)
+
+    def get_mapped_fields(self) -> dict[str, str]:
+        """
+        Return the Identity Protection -> OCSF field mapping used for schema-change
+        fingerprinting.
+
+        Static OCSF constants are excluded: they never depend on the CrowdStrike payload,
+        so they cannot invalidate a checkpoint.
+        """
+        return {
+            "entityId": "user.uid",
+            "primaryDisplayName": "user.name",
+            "secondaryDisplayName": "user.full_name",
+            "emailAddresses": "user.email_addr",
+            "creationTime": "time",
+            "riskScore": "user.risk_score",
+            "riskScoreSeverity": "user.risk_level",
+            "roles.type": "user.type",
+            "accounts.dataSource": "user.account.type",
+            "accounts.domain": "user.domain",
+            "accounts.samAccountName": "user.account.name",
+            "accounts.objectSid": "user.account.uid",
+            "accounts.objectGuid": "user.account.uid",
+            "accounts.enabled": "enrichments.data.is_enabled",
+        }
+
+    def reset_checkpoint(self) -> None:
+        """Clear the checkpoint so every user is collected again on the next cycle."""
+        with self.context as cache:
+            cache.pop(self.CHECKPOINT_KEY, None)
+        self._latest_time = None
+        self.log("Checkpoint reset - a full user re-collection will occur on the next cycle", level="info")
 
     def update_checkpoint(self) -> None:
         """

--- a/CrowdStrikeFalcon/crowdstrike_falcon/models.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/models.py
@@ -1,7 +1,11 @@
-from pydantic.v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 
 
 class CrowdStrikeFalconModuleConfiguration(BaseModel):
     client_id: str = Field(..., description="OAuth2 Client Identifier as provided by CrowdStrike Falcon")
-    client_secret: str = Field(secret=True, description="OAuth2 Client Secret as provided by CrowdStrike Falcon")
+    client_secret: str = Field(
+        ...,
+        description="OAuth2 Client Secret as provided by CrowdStrike Falcon",
+        json_schema_extra={"secret": True},
+    )
     base_url: str = Field(..., description="Base URL of the CrowdStrike Falcon platform")

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "CrowdStrike Falcon is a cloud-native cybersecurity platform known for its advanced threat detection, endpoint protection, and real-time response capabilities. It leverages AI and machine learning to protect against malware and sophisticated cyberattacks.",
-  "version": "1.25.18",
+  "version": "1.26.0",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/CrowdStrikeFalcon/poetry.lock
+++ b/CrowdStrikeFalcon/poetry.lock
@@ -2336,15 +2336,30 @@ botocore = ">=1.37.4,<2.0a.0"
 crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
+name = "sekoia-automation-models"
+version = "1.2.0"
+description = "Standalone Pydantic models (OCSF asset-connector) shared across Sekoia services and the `sekoia-automation-sdk`"
+optional = false
+python-versions = "<4,>=3.11"
+groups = ["main"]
+files = [
+    {file = "sekoia_automation_models-1.2.0-py3-none-any.whl", hash = "sha256:028afe35160fcfba1b25361f414e4f19dbb427a75b9830831f55d6b93e559c32"},
+    {file = "sekoia_automation_models-1.2.0.tar.gz", hash = "sha256:085d843fe0148a103927fbb6520ec865964b7552cd4c3c37f10d6196ac8a13ce"},
+]
+
+[package.dependencies]
+pydantic = ">=2.10,<3.0.0"
+
+[[package]]
 name = "sekoia-automation-sdk"
-version = "1.22.5"
+version = "1.24.0"
 description = "SDK to create Sekoia.io playbook modules"
 optional = false
 python-versions = "<4,>=3.11"
 groups = ["main"]
 files = [
-    {file = "sekoia_automation_sdk-1.22.5-py3-none-any.whl", hash = "sha256:468031fdff74a9b77153bed4df491f16fbc0ab70a732c248f61d41f3e0f12b9b"},
-    {file = "sekoia_automation_sdk-1.22.5.tar.gz", hash = "sha256:152384f82062b090317c945edc95323550ba6eee7b879e5fe2554cf72b74e4d2"},
+    {file = "sekoia_automation_sdk-1.24.0-py3-none-any.whl", hash = "sha256:52b4545cb3bce9a5d14cd1bb1e104b889ab0ae98288f85099b02e9404b39e50f"},
+    {file = "sekoia_automation_sdk-1.24.0.tar.gz", hash = "sha256:09d7a08263354d7494bf94300fadf640d970d0585b9a0e7fdaeab13380ce7fd2"},
 ]
 
 [package.dependencies]
@@ -2368,6 +2383,7 @@ pyyaml = ">=6.0,<7"
 requests = ">=2.25,<3"
 requests-ratelimiter = ">=0.7.0,<0.8"
 s3path = ">=0.6.4,<0.7"
+sekoia-automation-models = ">=1.2.0,<2"
 sentry-sdk = "*"
 tenacity = "*"
 typer = ">=0.20"
@@ -2940,4 +2956,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "942701abebb6e8106e931f12641f2507ef227bb5c6322ec500797d09e3e0d89b"
+content-hash = "0cfbfa24d9543ed1640a967037a67c0ab640d116a86641270ef4d42446c2de96"

--- a/CrowdStrikeFalcon/pyproject.toml
+++ b/CrowdStrikeFalcon/pyproject.toml
@@ -20,7 +20,7 @@ line_length = 119
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
-sekoia-automation-sdk = "^1.22.5"
+sekoia-automation-sdk = "^1.24.0"
 crowdstrike-falconpy = "^1.1.4"
 requests-ratelimiter = "^0.7.0"
 stix2-patterns = "^2.0.0"

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
@@ -352,3 +352,23 @@ def test_is_device_compliant(connector):
     assert connector.is_device_compliant(compliant) is True
     assert connector.is_device_compliant(non_compliant) is False
     assert connector.is_device_compliant(CrowdStrikeDevice()) is None
+
+
+def test_get_mapped_fields(connector):
+    fields = connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["device_id"] == "device.uid"
+
+
+def test_reset_checkpoint(connector):
+    connector._latest_id = "device-1"
+    connector.update_checkpoint()
+    assert connector.most_recent_device_id == "device-1"
+
+    connector.reset_checkpoint()
+
+    assert connector._latest_id is None
+    assert connector.most_recent_device_id is None

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_user_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_user_asset_connector.py
@@ -445,3 +445,23 @@ class TestListIdentityEntities:
             query="query { test }",
             data_path=["entities", "nodes"],
         )
+
+
+def test_get_mapped_fields(connector):
+    fields = connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["entityId"] == "user.uid"
+
+
+def test_reset_checkpoint(connector):
+    connector._latest_time = "2025-01-01T00:00:00Z"
+    connector.update_checkpoint()
+    assert connector.most_recent_user_date == "2025-01-01T00:00:00Z"
+
+    connector.reset_checkpoint()
+
+    assert connector._latest_time is None
+    assert connector.most_recent_user_date is None


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the CrowdStrike Falcon integration for SDK 1.24.0 while adding schema-aware asset checkpoint handling and Pydantic v2 compatibility.

Bug Fixes:
- Add checkpoint reset support so device and user asset collections can be fully re-collected when mappings change.

Enhancements:
- Expose CrowdStrike device and user field mappings for schema-change fingerprinting.
- Migrate module configuration models to Pydantic v2 compatibility.

Build:
- Upgrade the sekoia-automation-sdk dependency to 1.24.0 and release CrowdStrike Falcon version 1.26.0.

Tests:
- Add coverage for field mappings and checkpoint reset behavior for device and user asset connectors.