### PR TITLE
Fix: Tenable bump sdk version

### DIFF
--- a/Tenable/CHANGELOG.md
+++ b/Tenable/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-26 - 1.1.0
+
+### Added
+
+- Vulnerability asset connector now declares its Tenable -> OCSF field mapping and resets
+  its checkpoint automatically when that mapping changes, so all findings are re-collected
+  with the new mapping
+
+### Changed
+
+- Upgrade `sekoia-automation-sdk` to 1.24.0
+
 ## 2026-07-29 - 1.0.18
 
 ### Fixed

--- a/Tenable/manifest.json
+++ b/Tenable/manifest.json
@@ -30,7 +30,7 @@
   "description": "Tenable is a cybersecurity company specializing in vulnerability management and risk assessment solutions, known for its flagship product, Nessus. It helps organizations identify, assess, and prioritize security risks across their IT infrastructure.",
   "name": "Tenable Vulnerability Management",
   "uuid": "1214e603-6c86-4e86-896f-70198c9ade86",
-  "version": "1.0.18",
+  "version": "1.1.0",
   "slug": "tenable",
   "categories": [
     "Endpoint"

--- a/Tenable/poetry.lock
+++ b/Tenable/poetry.lock
@@ -2682,15 +2682,30 @@ botocore = ">=1.37.4,<2.0a.0"
 crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
+name = "sekoia-automation-models"
+version = "1.2.0"
+description = "Standalone Pydantic models (OCSF asset-connector) shared across Sekoia services and the `sekoia-automation-sdk`"
+optional = false
+python-versions = "<4,>=3.11"
+groups = ["main"]
+files = [
+    {file = "sekoia_automation_models-1.2.0-py3-none-any.whl", hash = "sha256:028afe35160fcfba1b25361f414e4f19dbb427a75b9830831f55d6b93e559c32"},
+    {file = "sekoia_automation_models-1.2.0.tar.gz", hash = "sha256:085d843fe0148a103927fbb6520ec865964b7552cd4c3c37f10d6196ac8a13ce"},
+]
+
+[package.dependencies]
+pydantic = ">=2.10,<3.0.0"
+
+[[package]]
 name = "sekoia-automation-sdk"
-version = "1.22.5"
+version = "1.24.0"
 description = "SDK to create Sekoia.io playbook modules"
 optional = false
 python-versions = "<4,>=3.11"
 groups = ["main"]
 files = [
-    {file = "sekoia_automation_sdk-1.22.5-py3-none-any.whl", hash = "sha256:468031fdff74a9b77153bed4df491f16fbc0ab70a732c248f61d41f3e0f12b9b"},
-    {file = "sekoia_automation_sdk-1.22.5.tar.gz", hash = "sha256:152384f82062b090317c945edc95323550ba6eee7b879e5fe2554cf72b74e4d2"},
+    {file = "sekoia_automation_sdk-1.24.0-py3-none-any.whl", hash = "sha256:52b4545cb3bce9a5d14cd1bb1e104b889ab0ae98288f85099b02e9404b39e50f"},
+    {file = "sekoia_automation_sdk-1.24.0.tar.gz", hash = "sha256:09d7a08263354d7494bf94300fadf640d970d0585b9a0e7fdaeab13380ce7fd2"},
 ]
 
 [package.dependencies]
@@ -2714,6 +2729,7 @@ pyyaml = ">=6.0,<7"
 requests = ">=2.25,<3"
 requests-ratelimiter = ">=0.7.0,<0.8"
 s3path = ">=0.6.4,<0.7"
+sekoia-automation-models = ">=1.2.0,<2"
 sentry-sdk = "*"
 tenacity = "*"
 typer = ">=0.20"
@@ -3261,4 +3277,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "ec36c582960bac0accf0b21bafcc43ae5f8ae2ded27966da6bfcd5a89c4062f0"
+content-hash = "0b80d1da7117f0f05b8e06f714684d9cd1a2e1b0364b953a613819aa138b82a2"

--- a/Tenable/pyproject.toml
+++ b/Tenable/pyproject.toml
@@ -23,7 +23,7 @@ line_length = 119
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
-sekoia-automation-sdk = "^1.22.5"
+sekoia-automation-sdk = "^1.24.0"
 pydantic = "^2.11.7"
 pytenable = "^1.8.2"
 aiolimiter = "^1.2.1"

--- a/Tenable/tenable_conn/asset_connector/vulnerability_asset.py
+++ b/Tenable/tenable_conn/asset_connector/vulnerability_asset.py
@@ -19,6 +19,7 @@ from tenable.io import TenableIO
 
 from sekoia_automation.asset_connector import AssetConnector
 from sekoia_automation.checkpoint import CheckpointTimestamp, TimeUnit
+from sekoia_automation.storage import PersistentJSON
 from sekoia_automation.asset_connector.models.ocsf.base import Product, Metadata
 from sekoia_automation.asset_connector.models.ocsf.vulnerability import (
     VulnerabilityOCSFModel,
@@ -550,6 +551,68 @@ class TenableAssetConnector(AssetConnector):
         if last_datetime > self._latest_time:
             self._latest_time = last_datetime
             self.log(f"Latest time updated to {last_datetime}", level="debug")
+
+    def get_mapped_fields(self) -> dict[str, str]:
+        """
+        Return the Tenable -> OCSF field mapping used for schema-change fingerprinting.
+
+        Sources prefixed with ``asset.`` come from the asset export (``exports.assets_v2``)
+        used to build the device attached to each finding. Static OCSF constants are excluded:
+        they never depend on the Tenable payload, so they cannot invalidate a checkpoint.
+        """
+        return {
+            "state": "activity_id",
+            "severity": "vulnerabilities.severity",
+            "first_found": "time",
+            "last_found": "finding_info.last_seen_time",
+            "finding_id": "finding_info.uid",
+            "source": "finding_info.data_sources",
+            "plugin.type": "finding_info.types",
+            "plugin.name": "finding_info.title",
+            "plugin.synopsis": "finding_info.desc",
+            "plugin.description": "vulnerabilities.desc",
+            "plugin.see_also": "vulnerabilities.references",
+            "plugin.publication_date": "finding_info.created_time",
+            "plugin.version": "metadata.product.version",
+            "plugin.cve": "vulnerabilities.cve.uid",
+            "plugin.cvss_base_score": "vulnerabilities.cve.cvss.base_score",
+            "plugin.cvss3_base_score": "vulnerabilities.cve.cvss.base_score",
+            "plugin.vpr_v2.score": "confidence_score",
+            "asset.id": "device.uid",
+            "asset.name": "device.name",
+            "asset.hostname": "device.hostname",
+            "asset.fqdn": "device.hostname",
+            "asset.system_type": "device.type",
+            "asset.operating_system": "device.os.name",
+            "asset.ipv4": "device.ip",
+            "asset.interfaces.ipv4": "device.network_interfaces.ip",
+            "asset.interfaces.mac_address": "device.network_interfaces.mac",
+            "asset.interfaces.fqdn": "device.network_interfaces.hostname",
+            "asset.interfaces.name": "device.network_interfaces.name",
+            "asset.aws_region": "device.location.city",
+            "asset.azure_location": "device.location.city",
+            "asset.gcp_zone": "device.location.city",
+            "asset.first_seen": "device.first_seen_time",
+            "asset.last_seen": "device.last_seen_time",
+            "asset.created_at": "device.created_time",
+            "asset.has_agent": "device.is_managed",
+        }
+
+    def reset_checkpoint(self) -> None:
+        """
+        Clear the checkpoint so every vulnerability is re-collected on the next cycle.
+        """
+        with PersistentJSON("context.json", self._data_path) as cache:
+            cache.pop("most_recent_date_seen", None)
+
+        self.cursor = CheckpointTimestamp(
+            path=self._data_path,
+            time_unit=TimeUnit.SECOND,
+            start_at=timedelta(days=200),
+        )
+        self._latest_time = self.cursor.offset
+        self._asset_map = None
+        self.log("Checkpoint reset - a full vulnerability re-collection will occur on the next cycle", level="info")
 
     def update_checkpoint(self) -> None:
         """

--- a/Tenable/tests/asset_connector/test_vulnerability_asset.py
+++ b/Tenable/tests/asset_connector/test_vulnerability_asset.py
@@ -1149,3 +1149,26 @@ def test_asset_info_with_tags_none_added_by():
     assert asset.aes_score_v3 == 704.0
     assert asset.acr_score_v3 == 5.0
     assert asset.tags[0].added_by is None
+
+
+def test_get_mapped_fields(tenable_asset_connector):
+    fields = tenable_asset_connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["plugin.cve"] == "vulnerabilities.cve.uid"
+    assert fields["asset.id"] == "device.uid"
+
+
+def test_reset_checkpoint(tenable_asset_connector):
+    tenable_asset_connector._latest_time = int(datetime.now().timestamp())
+    tenable_asset_connector.update_checkpoint()
+    tenable_asset_connector._asset_map = {"some-uuid": Mock()}
+
+    tenable_asset_connector.reset_checkpoint()
+
+    expected_offset = int((datetime.now() - timedelta(days=200)).timestamp())
+    assert tenable_asset_connector._asset_map is None
+    assert abs(tenable_asset_connector._latest_time - expected_offset) < 60
+    assert abs(tenable_asset_connector.cursor.offset - expected_offset) < 60


### PR DESCRIPTION
## Summary by Sourcery

Ensure vulnerability mapping changes trigger a complete re-collection while upgrading the Tenable SDK dependency.

New Features:
- Add vulnerability field mapping metadata and automatically invalidate the collection checkpoint when mappings change.
- Reset vulnerability collection state to trigger a full re-collection after mapping changes.

Build:
- Upgrade the Tenable integration to sekoia-automation-sdk 1.24.0 and refresh its locked dependencies.

Tests:
- Add coverage for vulnerability field mappings and checkpoint reset behavior.

Chores:
- Bump the Tenable integration version to 1.1.0.