### PR TITLE
Fix: Harfanglab bump sdk version

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-27 - 1.32.0
+
+### Added
+
+- Device and software asset connectors now declare their Harfanglab -> OCSF field mappings
+  and reset their checkpoint automatically when a mapping changes, so all assets are
+  re-collected with the new mapping
+
+### Changed
+
+- Upgrade `sekoia-automation-sdk` to 1.24.0
+- Migrate the remaining `pydantic.v1` models to Pydantic v2
+
 ## 2026-07-30 - 1.31.8
 
 ### Changed

--- a/HarfangLab/harfanglab/asset_connector/device_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/device_assets.py
@@ -4,7 +4,7 @@ from functools import cached_property
 from urllib.parse import urljoin
 
 from dateutil.parser import isoparse
-from pydantic.v1 import ValidationError
+from pydantic import ValidationError
 from requests.exceptions import RequestException
 from sekoia_automation.asset_connector import AssetConnector
 from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product
@@ -52,6 +52,7 @@ class HarfanglabAssetConnector(AssetConnector):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("context.json", self._data_path)
+        self._latest_time: str | None = None
 
     @property
     def most_recent_date_seen(self) -> str | None:
@@ -408,6 +409,45 @@ class HarfanglabAssetConnector(AssetConnector):
         except Exception as e:
             self.log(f"Device iteration failed - Error: {e!s}, Devices processed: {device_count}", level="error")
             raise
+
+    def get_mapped_fields(self) -> dict[str, str]:
+        """
+        Return the Harfanglab -> OCSF field mapping used for schema-change fingerprinting.
+
+        Static OCSF constants are excluded: they never depend on the Harfanglab payload, so
+        they cannot invalidate a checkpoint.
+        """
+        return {
+            "id": "device.uid",
+            "hostname": "device.hostname",
+            "domainname": "device.domain",
+            "ipaddress": "device.ip",
+            "ipmask": "device.subnet",
+            "osproducttype": "device.os.name",
+            "ostype": "device.os.type",
+            "producttype": "device.model",
+            "description": "device.desc",
+            "policy": "device.is_managed",
+            "has_valid_password": "device.is_trusted",
+            "firstseen": "device.first_seen_time",
+            "lastseen": "device.last_seen_time",
+            "machine_boottime": "device.boot_time",
+            "installdate": "device.created_time",
+            "subnet.name": "device.network_interfaces.name",
+            "subnet.id": "device.network_interfaces.uid",
+            "subnet.gateway_macaddress": "device.network_interfaces.mac",
+            "policy.windows_self_protection_feature_firewall": "enrichments.data.Firewall_status",
+            "encrypted_disk_count": "enrichments.data.Storage_encryption",
+            "disk_count": "enrichments.data.Storage_encryption",
+            "dnsdomainname": "enrichments.data.Full_qualified_domain_name",
+        }
+
+    def reset_checkpoint(self) -> None:
+        """Clear the checkpoint so every device is collected again on the next cycle."""
+        with self.context as cache:
+            cache.pop("most_recent_date_seen", None)
+        self._latest_time = None
+        self.log("Checkpoint reset - a full device re-collection will occur on the next cycle", level="info")
 
     def update_checkpoint(self) -> None:
         if self._latest_time:

--- a/HarfangLab/harfanglab/asset_connector/models.py
+++ b/HarfangLab/harfanglab/asset_connector/models.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic.v1 import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class HarfanglabAdditionalInfo(BaseModel):
@@ -9,16 +9,14 @@ class HarfanglabAdditionalInfo(BaseModel):
     additional_info3: str | None = None
     additional_info4: str | None = None
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class HarfanglabGroup(BaseModel):
     id: str | None = None
     name: str | None = None
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class HarfanglabSubnet(BaseModel):
@@ -28,8 +26,7 @@ class HarfanglabSubnet(BaseModel):
     id: str | None = None
     name: str | None = None
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class HarfanglabOriginStack(BaseModel):
@@ -39,8 +36,7 @@ class HarfanglabOriginStack(BaseModel):
     is_tenant: bool | None = None
     name: str | None = None
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class HarfanglabPolicy(BaseModel):
@@ -229,8 +225,7 @@ class HarfanglabPolicy(BaseModel):
     yara_skip_signed_ms: bool | None = None
     yara_skip_signed_others: bool | None = None
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class HarfanglabAgent(BaseModel):
@@ -314,8 +309,7 @@ class HarfanglabAgent(BaseModel):
     windows_groups_last_update: str | None = None
     windows_users_last_update: str | None = None
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class HarfanglabAgentPage(BaseModel):
@@ -324,8 +318,7 @@ class HarfanglabAgentPage(BaseModel):
     previous: str | None = None
     results: list[HarfanglabAgent] = []
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class HarfanglabApplication(BaseModel):
@@ -344,8 +337,7 @@ class HarfanglabApplication(BaseModel):
     app_type: str | None = None
     description: str | None = None
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class HarfanglabApplicationPage(BaseModel):
@@ -354,5 +346,4 @@ class HarfanglabApplicationPage(BaseModel):
     previous: str | None = None
     results: list[HarfanglabApplication] = []
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")

--- a/HarfangLab/harfanglab/asset_connector/software_assets.py
+++ b/HarfangLab/harfanglab/asset_connector/software_assets.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 from urllib.parse import urljoin
 
 from dateutil.parser import isoparse
-from pydantic.v1 import ValidationError
+from pydantic import ValidationError
 from requests.exceptions import RequestException
 from sekoia_automation.asset_connector import AssetConnector
 from sekoia_automation.asset_connector.models.ocsf.base import Metadata, Product
@@ -63,6 +63,7 @@ class HarfanglabSoftwareAssetConnector(AssetConnector):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("software_context.json", self._data_path)
+        self._latest_time: str | None = None
 
     @property
     def most_recent_date_seen(self) -> str | None:
@@ -325,6 +326,38 @@ class HarfanglabSoftwareAssetConnector(AssetConnector):
         except Exception as e:
             self.log(f"Device iteration failed - Error: {e!s}, Devices processed: {device_count}", level="error")
             raise
+
+    def get_mapped_fields(self) -> dict[str, str]:
+        """
+        Return the Harfanglab -> OCSF field mapping used for schema-change fingerprinting.
+
+        Sources prefixed with ``application.`` come from the per-agent application inventory.
+        Static OCSF constants are excluded: they never depend on the Harfanglab payload, so
+        they cannot invalidate a checkpoint.
+        """
+        return {
+            "id": "device.uid",
+            "hostname": "device.hostname",
+            "domainname": "device.domain",
+            "ipaddress": "device.ip",
+            "osproducttype": "device.os.name",
+            "ostype": "device.os.type",
+            "firstseen": "device.first_seen_time",
+            "lastseen": "device.last_seen_time",
+            "application.id": "sbom.package.uid",
+            "application.name": "sbom.package.name",
+            "application.last_version": "sbom.package.version",
+            "application.first_version": "sbom.package.version",
+            "application.cpe_prefix": "sbom.package.cpe_name",
+            "application.app_type": "sbom.package.type",
+        }
+
+    def reset_checkpoint(self) -> None:
+        """Clear the checkpoint so every software asset is collected again on the next cycle."""
+        with self.context as cache:
+            cache.pop("most_recent_date_seen", None)
+        self._latest_time = None
+        self.log("Checkpoint reset - a full software re-collection will occur on the next cycle", level="info")
 
     def update_checkpoint(self) -> None:
         if self._latest_time:

--- a/HarfangLab/harfanglab/models.py
+++ b/HarfangLab/harfanglab/models.py
@@ -6,7 +6,7 @@ Data models of the HarfangLab module
 from typing import Any
 
 # third parties
-from pydantic.v1 import BaseModel
+from pydantic import BaseModel
 
 
 class JobTarget(BaseModel):

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.31.8",
+  "version": "1.32.0",
   "categories": [
     "Endpoint"
   ],

--- a/HarfangLab/pyproject.toml
+++ b/HarfangLab/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 requires-python = ">=3.14,<4"
 dependencies = [
-    "sekoia-automation-sdk>=1.23.1,<2",
+    "sekoia-automation-sdk>=1.24.0,<2",
     "pydantic>=2.10,<3",
     "requests",
     "requests-ratelimiter>=0.7.0,<1",

--- a/HarfangLab/tests/asset_connector/test_device_assets.py
+++ b/HarfangLab/tests/asset_connector/test_device_assets.py
@@ -1203,3 +1203,25 @@ def test_get_assets_skips_on_map_error(test_harfanglab_asset_connector, agent_en
             with patch.object(test_harfanglab_asset_connector, "map_fields", side_effect=ValueError("mapping error")):
                 assets = list(test_harfanglab_asset_connector.get_assets())
                 assert len(assets) == 0
+
+
+def test_get_mapped_fields(test_harfanglab_asset_connector):
+    fields = test_harfanglab_asset_connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["id"] == "device.uid"
+
+
+def test_reset_checkpoint(test_harfanglab_asset_connector):
+    connector = test_harfanglab_asset_connector
+
+    connector._latest_time = "2025-01-01T00:00:00+00:00"
+    connector.update_checkpoint()
+    assert connector.most_recent_date_seen == "2025-01-01T00:00:00+00:00"
+
+    connector.reset_checkpoint()
+
+    assert connector._latest_time is None
+    assert connector.most_recent_date_seen is None

--- a/HarfangLab/tests/asset_connector/test_software_assets.py
+++ b/HarfangLab/tests/asset_connector/test_software_assets.py
@@ -499,3 +499,25 @@ def test_get_assets_no_applications(test_software_connector):
             assets = list(test_software_connector.get_assets())
 
     assert len(assets) == 0
+
+
+def test_get_mapped_fields(test_software_connector):
+    fields = test_software_connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["application.name"] == "sbom.package.name"
+
+
+def test_reset_checkpoint(test_software_connector):
+    connector = test_software_connector
+
+    connector._latest_time = "2025-01-01T00:00:00+00:00"
+    connector.update_checkpoint()
+    assert connector.most_recent_date_seen == "2025-01-01T00:00:00+00:00"
+
+    connector.reset_checkpoint()
+
+    assert connector._latest_time is None
+    assert connector.most_recent_date_seen is None

--- a/HarfangLab/uv.lock
+++ b/HarfangLab/uv.lock
@@ -254,7 +254,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10,<3" },
     { name = "requests" },
     { name = "requests-ratelimiter", specifier = ">=0.7.0,<1" },
-    { name = "sekoia-automation-sdk", specifier = ">=1.23.1,<2" },
+    { name = "sekoia-automation-sdk", specifier = ">=1.24.0,<2" },
     { name = "stix2-patterns", specifier = ">=2.0.0,<3" },
     { name = "structlog", specifier = ">=24.4.0,<25" },
 ]
@@ -1273,8 +1273,20 @@ wheels = [
 ]
 
 [[package]]
+name = "sekoia-automation-models"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/b9/7cb7a8e200e2487a3b4b9efd5c6445eba02afbecb3421ecec5717ae9e5a5/sekoia_automation_models-1.2.0.tar.gz", hash = "sha256:085d843fe0148a103927fbb6520ec865964b7552cd4c3c37f10d6196ac8a13ce", size = 8417, upload-time = "2026-07-21T13:24:21.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/a2/cf9977065c43ffbf24075d5004bd232cd45621d536b9bc658faca2536645/sekoia_automation_models-1.2.0-py3-none-any.whl", hash = "sha256:028afe35160fcfba1b25361f414e4f19dbb427a75b9830831f55d6b93e559c32", size = 12708, upload-time = "2026-07-21T13:24:20.01Z" },
+]
+
+[[package]]
 name = "sekoia-automation-sdk"
-version = "1.23.1"
+version = "1.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiocsv" },
@@ -1297,14 +1309,15 @@ dependencies = [
     { name = "requests" },
     { name = "requests-ratelimiter" },
     { name = "s3path" },
+    { name = "sekoia-automation-models" },
     { name = "sentry-sdk" },
     { name = "tenacity" },
     { name = "typer" },
     { name = "uv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/ec/469ab1751f1375075d6c488e475be0c2f90b8643b6bc21be12a5a02fd3ac/sekoia_automation_sdk-1.23.1.tar.gz", hash = "sha256:500d2b27ba836411387cf9f339539bfdb4f976d709b9847e10c64d9724ad3e05", size = 65281, upload-time = "2026-06-08T07:32:57.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/6c/d15bd717255fe493747b24bc8e63a5929231c011ca2f28608bef5a53d9a4/sekoia_automation_sdk-1.24.0.tar.gz", hash = "sha256:09d7a08263354d7494bf94300fadf640d970d0585b9a0e7fdaeab13380ce7fd2", size = 62692, upload-time = "2026-07-30T10:44:42.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/cd/ba6fe6bb924d0969986ee0d74c852bf64a1375383652c9a197600c06fb30/sekoia_automation_sdk-1.23.1-py3-none-any.whl", hash = "sha256:b13a143b8794c188bb900b3e2c3ecbf3b4eeb38b476790f3bdefe6ed52075ebc", size = 96485, upload-time = "2026-06-08T07:32:56.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b0/c218b5a9dc1545b12e9814c6377adc6b7fa5930e04437116ca41d824e330/sekoia_automation_sdk-1.24.0-py3-none-any.whl", hash = "sha256:52b4545cb3bce9a5d14cd1bb1e104b889ab0ae98288f85099b02e9404b39e50f", size = 94507, upload-time = "2026-07-30T10:44:40.955Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the HarfangLab integration to the current SDK and add mapping-aware asset checkpoint management.

New Features:
- Add field mapping declarations for device and software asset connectors, with automatic full re-collection when mappings change.

Enhancements:
- Migrate HarfangLab models and validation errors from Pydantic v1 compatibility APIs to Pydantic v2.
- Upgrade the HarfangLab integration to version 1.32.0 and the automation SDK dependency to 1.24.0.

Tests:
- Add coverage for asset field mappings and checkpoint resets.