### PR TITLE
Fix: MicrosoftActiveDirectory bump sdk version

### DIFF
--- a/MicrosoftActiveDirectory/CHANGELOG.md
+++ b/MicrosoftActiveDirectory/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-26 - 1.6.0
+
+### Added
+
+- User asset connector now declares its LDAP -> OCSF field mapping and resets its
+  checkpoint automatically when that mapping changes, so all users are re-collected with
+  the new mapping
+
+### Changed
+
+- Upgrade `sekoia-automation-sdk` to 1.24.0
+- Migrate the configuration and action models from `pydantic.v1` to Pydantic v2, required
+  by the SDK
+
 ## 2026-07-13 - 1.5.8
 
 ### Fixed

--- a/MicrosoftActiveDirectory/manifest.json
+++ b/MicrosoftActiveDirectory/manifest.json
@@ -32,7 +32,7 @@
   "name": "Microsoft Active Directory",
   "uuid": "b2d96259-af89-4f7a-ae6e-a0af2d2400f3",
   "slug": "microsoft-ad",
-  "version": "1.5.8",
+  "version": "1.6.0",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -66,6 +66,40 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
             return "(&(objectCategory=person)(objectClass=user))"
         return f"(&(objectCategory=person)(objectClass=user)(whenCreated>={self.most_recent_datetime}))"
 
+    def get_mapped_fields(self) -> dict[str, str]:
+        """
+        Return the LDAP -> OCSF field mapping used for schema-change fingerprinting.
+
+        Static OCSF constants are excluded: they never depend on the LDAP payload, so they
+        cannot invalidate a checkpoint.
+        """
+        return {
+            "objectSid": "user.uid",
+            "objectGUID": "user.uid_alt",
+            "userPrincipalName": "user.account.name",
+            "givenName": "user.name",
+            "sn": "user.name",
+            "displayName": "user.full_name",
+            "mail": "user.email_addr",
+            "distinguishedName": "user.domain",
+            "memberOf": "user.groups.name",
+            "sAMAccountName": "user.type",
+            "userAccountControl": "enrichments.data.is_enabled",
+            "lastLogon": "enrichments.data.last_logon",
+            "badPwdCount": "enrichments.data.bad_password_count",
+            "logonCount": "enrichments.data.number_of_logons",
+            "whenCreated": "time",
+        }
+
+    def reset_checkpoint(self) -> None:
+        """Clear the checkpoint so every user is collected again on the next cycle."""
+        with self.context as cache:
+            cache.pop("most_recent_datetime", None)
+            cache.pop("seen_sids_at_checkpoint", None)
+        self._latest_time = None
+        self._seen_sids = set()
+        self.log("Checkpoint reset - a full user re-collection will occur on the next cycle", level="info")
+
     def update_checkpoint(self) -> None:
         if self._latest_time is None:
             return

--- a/MicrosoftActiveDirectory/microsoft_ad/models/action_models.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/models/action_models.py
@@ -1,4 +1,4 @@
-from pydantic.v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 
 
 class UserAccountArguments(BaseModel):

--- a/MicrosoftActiveDirectory/microsoft_ad/models/common_models.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/models/common_models.py
@@ -1,6 +1,6 @@
 import datetime
 
-from pydantic.v1 import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sekoia_automation.asset_connector.models.connector import DefaultAssetConnectorConfiguration
 from sekoia_automation.module import Module
 
@@ -8,7 +8,7 @@ from sekoia_automation.module import Module
 class MicrosoftADConfiguration(BaseModel):
     servername: str = Field(..., description="Remote machine IP or Name")
     admin_username: str = Field(..., description="Admin username")
-    admin_password: str = Field(..., secret=True, description="Admin password")  # type: ignore
+    admin_password: str = Field(..., description="Admin password", json_schema_extra={"secret": True})
 
 
 class MicrosoftADModule(Module):
@@ -55,7 +55,5 @@ class LDAPUserAttributes(BaseModel):
     mail: str | None = None
     member_of: list[str] | None = Field(None, alias="memberOf")
 
-    class Config:
-        # Accept datetime objects with any tzinfo (e.g. ldap3's OffsetTzInfo)
-        arbitrary_types_allowed = True
-        allow_population_by_field_name = True
+    # Accept datetime objects with any tzinfo (e.g. ldap3's OffsetTzInfo)
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)

--- a/MicrosoftActiveDirectory/microsoft_ad/search_actions.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/search_actions.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import orjson
 from ldap3 import ALL_ATTRIBUTES
 from ldap3.core.timezone import OffsetTzInfo
-from pydantic.v1 import BaseModel
+from pydantic import BaseModel
 
 from .actions_base import MicrosoftADAction
 
@@ -14,7 +14,7 @@ from .actions_base import MicrosoftADAction
 class SearchArguments(BaseModel):
     search_filter: str
     basedn: str
-    attributes: List[str] | None
+    attributes: List[str] | None = None
     to_file: bool = False
 
 

--- a/MicrosoftActiveDirectory/poetry.lock
+++ b/MicrosoftActiveDirectory/poetry.lock
@@ -2411,15 +2411,30 @@ botocore = ">=1.37.4,<2.0a0"
 crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
+name = "sekoia-automation-models"
+version = "1.2.0"
+description = "Standalone Pydantic models (OCSF asset-connector) shared across Sekoia services and the `sekoia-automation-sdk`"
+optional = false
+python-versions = "<4,>=3.11"
+groups = ["main"]
+files = [
+    {file = "sekoia_automation_models-1.2.0-py3-none-any.whl", hash = "sha256:028afe35160fcfba1b25361f414e4f19dbb427a75b9830831f55d6b93e559c32"},
+    {file = "sekoia_automation_models-1.2.0.tar.gz", hash = "sha256:085d843fe0148a103927fbb6520ec865964b7552cd4c3c37f10d6196ac8a13ce"},
+]
+
+[package.dependencies]
+pydantic = ">=2.10,<3.0.0"
+
+[[package]]
 name = "sekoia-automation-sdk"
-version = "1.22.5"
+version = "1.24.0"
 description = "SDK to create Sekoia.io playbook modules"
 optional = false
 python-versions = "<4,>=3.11"
 groups = ["main"]
 files = [
-    {file = "sekoia_automation_sdk-1.22.5-py3-none-any.whl", hash = "sha256:468031fdff74a9b77153bed4df491f16fbc0ab70a732c248f61d41f3e0f12b9b"},
-    {file = "sekoia_automation_sdk-1.22.5.tar.gz", hash = "sha256:152384f82062b090317c945edc95323550ba6eee7b879e5fe2554cf72b74e4d2"},
+    {file = "sekoia_automation_sdk-1.24.0-py3-none-any.whl", hash = "sha256:52b4545cb3bce9a5d14cd1bb1e104b889ab0ae98288f85099b02e9404b39e50f"},
+    {file = "sekoia_automation_sdk-1.24.0.tar.gz", hash = "sha256:09d7a08263354d7494bf94300fadf640d970d0585b9a0e7fdaeab13380ce7fd2"},
 ]
 
 [package.dependencies]
@@ -2443,6 +2458,7 @@ pyyaml = ">=6.0,<7"
 requests = ">=2.25,<3"
 requests-ratelimiter = ">=0.7.0,<0.8"
 s3path = ">=0.6.4,<0.7"
+sekoia-automation-models = ">=1.2.0,<2"
 sentry-sdk = "*"
 tenacity = "*"
 typer = ">=0.20"
@@ -2977,4 +2993,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "4df3a7eecdfb3d28e1545c5733313c02dec7800df8bd1f9dfb4204a9993e53a5"
+content-hash = "83cb5ec14cf4b85d712d4beb61884428bdd565031fb5cfed8804f06cb842566e"

--- a/MicrosoftActiveDirectory/pyproject.toml
+++ b/MicrosoftActiveDirectory/pyproject.toml
@@ -21,7 +21,7 @@ line_length = 119
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
 ldap3 = "^2.9.1"
-sekoia-automation-sdk = "^1.22.5"
+sekoia-automation-sdk = "^1.24.0"
 pytest = "^7.4.3"
 aiolimiter = "^1.2.1"
 

--- a/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
+++ b/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
@@ -5,6 +5,7 @@ import pytest
 from ldap3.core.exceptions import LDAPException, LDAPSessionTerminatedByServerError
 from ldap3.core.timezone import OffsetTzInfo
 from sekoia_automation.asset_connector.models.ocsf.user import AccountTypeId, UserOCSFModel, UserTypeId, UserTypeStr
+from sekoia_automation.storage import PersistentJSON
 
 from microsoft_ad.asset_connectors.user_assets import MicrosoftADUserAssetConnector
 from microsoft_ad.models.common_models import LDAPUserAttributes
@@ -350,3 +351,29 @@ def test_entries_deduplicates_by_dn(connector):
     entries = list(connector._entries())
 
     assert len(entries) == 1
+
+
+def test_get_mapped_fields(connector):
+    fields = connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["objectSid"] == "user.uid"
+
+
+def test_reset_checkpoint(connector, tmp_path):
+    connector.context = PersistentJSON("context.json", tmp_path)
+    connector._latest_time = "20250101000000.0Z"
+    connector._seen_sids = {"S-1-5-21-1"}
+    connector.update_checkpoint()
+
+    assert connector.most_recent_datetime == "20250101000000.0Z"
+    assert connector.seen_sids_at_checkpoint == {"S-1-5-21-1"}
+
+    connector.reset_checkpoint()
+
+    assert connector._latest_time is None
+    assert connector._seen_sids == set()
+    assert connector.most_recent_datetime is None
+    assert connector.seen_sids_at_checkpoint == set()


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the Microsoft Active Directory connector for SDK 1.24.0 while ensuring mapping changes trigger complete user synchronization.

New Features:
- Declare the LDAP-to-OCSF user field mapping and automatically reset checkpoints when mappings change to trigger full user re-collection.

Enhancements:
- Migrate configuration, action, and search models to Pydantic v2 compatibility.

Build:
- Upgrade the Microsoft Active Directory connector to sekoia-automation-sdk 1.24.0 and release version 1.6.0.

Tests:
- Add coverage for field mappings and checkpoint reset behavior.