### PR TITLE
Fix: MicrosoftDefender bump sdk version

### DIFF
--- a/MicrosoftDefender/CHANGELOG.md
+++ b/MicrosoftDefender/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-08-26 - 1.4.0
+
+### Added
+
+- Device asset connector now declares its Defender -> OCSF field mapping and resets its
+  checkpoint automatically when that mapping changes, so all devices are re-collected with
+  the new mapping
+
+### Changed
+
+- Upgrade `sekoia-automation-sdk` to 1.24.0
+
 ## 2026-08-18 - 1.3.6
 
 ### Fixed

--- a/MicrosoftDefender/asset_connector/device_assets.py
+++ b/MicrosoftDefender/asset_connector/device_assets.py
@@ -414,6 +414,56 @@ class MicrosoftDefenderDeviceAssetConnector(AsyncAssetConnector):
 
         self._latest_time_raw = most_recent_raw
 
+    def get_mapped_fields(self) -> dict[str, str]:
+        """
+        Return the Defender -> OCSF field mapping used for schema-change fingerprinting.
+
+        Sources prefixed with ``managedDevice.`` come from the Graph
+        ``/deviceManagement/managedDevices`` enrichment call. Static OCSF constants are
+        excluded: they never depend on the Defender payload, so they cannot invalidate a
+        checkpoint.
+        """
+        return {
+            "id": "device.uid",
+            "aadDeviceId": "device.uid_alt",
+            "computerDnsName": "device.hostname",
+            "lastIpAddress": "device.ip",
+            "osPlatform": "device.os.type",
+            "osBuild": "device.os.name",
+            "riskScore": "device.risk_level",
+            "firstSeen": "device.first_seen_time",
+            "lastSeen": "device.last_seen_time",
+            "rbacGroupName": "device.groups.name",
+            "rbacGroupId": "device.groups.uid",
+            "ipAddresses": "device.network_interfaces",
+            "healthStatus": "enrichments.health_status",
+            "exposureLevel": "enrichments.exposure_level",
+            "managedDevice.ethernetMacAddress": "device.network_interfaces.mac",
+            "managedDevice.wiFiMacAddress": "device.network_interfaces.mac",
+            "managedDevice.imei": "device.imei_list",
+            "managedDevice.meid": "device.meid",
+            "managedDevice.iccid": "device.iccid",
+            "managedDevice.udid": "device.udid",
+            "managedDevice.model": "device.model",
+            "managedDevice.manufacturer": "device.vendor_name",
+            "managedDevice.osVersion": "device.os.name",
+            "managedDevice.complianceState": "device.is_compliant",
+            "managedDevice.managedDeviceOwnerType": "device.is_personal",
+            "managedDevice.isSupervised": "device.is_supervised",
+            "managedDevice.userPrincipalName": "enrichments.user_principal_name",
+            "managedDevice.managementAgent": "enrichments.management_agent",
+        }
+
+    async def reset_checkpoint(self) -> None:
+        """Clear the checkpoint so every device is collected again on the next cycle."""
+        with self.context as cache:
+            cache.pop("most_recent_date_seen", None)
+        self._latest_time_raw = None
+        self.log(
+            message="Checkpoint reset - a full device re-collection will occur on the next cycle",
+            level="info",
+        )
+
     async def update_checkpoint(self) -> None:
         if self._latest_time_raw:
             with self.context as cache:

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -50,6 +50,6 @@
   "categories": [
     "Endpoint"
   ],
-  "version": "1.3.6",
+  "version": "1.4.0",
   "supports_validation": true
 }

--- a/MicrosoftDefender/poetry.lock
+++ b/MicrosoftDefender/poetry.lock
@@ -2961,15 +2961,30 @@ botocore = ">=1.37.4,<2.0a0"
 crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
+name = "sekoia-automation-models"
+version = "1.2.0"
+description = "Standalone Pydantic models (OCSF asset-connector) shared across Sekoia services and the `sekoia-automation-sdk`"
+optional = false
+python-versions = "<4,>=3.11"
+groups = ["main"]
+files = [
+    {file = "sekoia_automation_models-1.2.0-py3-none-any.whl", hash = "sha256:028afe35160fcfba1b25361f414e4f19dbb427a75b9830831f55d6b93e559c32"},
+    {file = "sekoia_automation_models-1.2.0.tar.gz", hash = "sha256:085d843fe0148a103927fbb6520ec865964b7552cd4c3c37f10d6196ac8a13ce"},
+]
+
+[package.dependencies]
+pydantic = ">=2.10,<3.0.0"
+
+[[package]]
 name = "sekoia-automation-sdk"
-version = "1.23.0"
+version = "1.24.0"
 description = "SDK to create Sekoia.io playbook modules"
 optional = false
 python-versions = "<4,>=3.11"
 groups = ["main"]
 files = [
-    {file = "sekoia_automation_sdk-1.23.0-py3-none-any.whl", hash = "sha256:2d94f8eb2a79e0943529f0f0c5685bc52aa8dff21eef31ae5e706945f2e2f5a5"},
-    {file = "sekoia_automation_sdk-1.23.0.tar.gz", hash = "sha256:bd9becf3b7b579c1a184ec903d5c14b8b70927b618f674da6662e3f62a2c650b"},
+    {file = "sekoia_automation_sdk-1.24.0-py3-none-any.whl", hash = "sha256:52b4545cb3bce9a5d14cd1bb1e104b889ab0ae98288f85099b02e9404b39e50f"},
+    {file = "sekoia_automation_sdk-1.24.0.tar.gz", hash = "sha256:09d7a08263354d7494bf94300fadf640d970d0585b9a0e7fdaeab13380ce7fd2"},
 ]
 
 [package.dependencies]
@@ -2993,6 +3008,7 @@ pyyaml = ">=6.0,<7"
 requests = ">=2.25,<3"
 requests-ratelimiter = ">=0.7.0,<0.8"
 s3path = ">=0.6.4,<0.7"
+sekoia-automation-models = ">=1.2.0,<2"
 sentry-sdk = "*"
 tenacity = "*"
 typer = ">=0.20"
@@ -3591,4 +3607,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "16690cbf3e3868c6ee492f250d1249f028a86297de8aeb03eaf690af63c9e00b"
+content-hash = "598f1608565bb80fd6767fc983671bad128efeb03edaed51a8c02bf6030a58de"

--- a/MicrosoftDefender/pyproject.toml
+++ b/MicrosoftDefender/pyproject.toml
@@ -20,7 +20,7 @@ line_length = 119
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
-sekoia-automation-sdk = "^1.22.4"
+sekoia-automation-sdk = "^1.24.0"
 structlog = "^25.5.0"
 stix2-patterns = "^2.1.2"
 requests = "^2.32.5"

--- a/MicrosoftDefender/tests/asset_connector/test_device_assets.py
+++ b/MicrosoftDefender/tests/asset_connector/test_device_assets.py
@@ -578,3 +578,25 @@ class TestGetAssetsCheckpointTracking:
 
         with connector.context as cache:
             assert cache["most_recent_date_seen"] == raw
+
+
+def test_get_mapped_fields(connector):
+    fields = connector.get_mapped_fields()
+
+    assert isinstance(fields, dict)
+    assert fields
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in fields.items())
+    assert fields["id"] == "device.uid"
+    assert fields["managedDevice.imei"] == "device.imei_list"
+
+
+@pytest.mark.asyncio
+async def test_reset_checkpoint(connector):
+    connector._latest_time_raw = "2024-12-01T10:00:00Z"
+    await connector.update_checkpoint()
+    assert connector.most_recent_date_seen == "2024-12-01T10:00:00Z"
+
+    await connector.reset_checkpoint()
+
+    assert connector._latest_time_raw is None
+    assert connector.most_recent_date_seen is None


### PR DESCRIPTION
## Summary by Sourcery

Update the MicrosoftDefender device asset connector for schema-aware recollection and SDK 1.24.0.

New Features:
- Declare the Defender-to-OCSF device field mapping and support automatic checkpoint resets when the mapping changes, triggering a full device recollection.

Build:
- Upgrade the MicrosoftDefender connector to sekoia-automation-sdk 1.24.0.

Tests:
- Add coverage for device field mappings and checkpoint reset behavior.