### PR TITLE
fix(harfanglab): typo on FF + frequency update

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-27 - 1.31.9
+
+### Changed
+
+- Update software asset connector default frequency to 1 day (86400s) and minimum frequency to 3 hours (10800s)
+
 ## 2026-07-30 - 1.31.8
 
 ### Changed

--- a/HarfangLab/connector_harfanglab_software_assets.json
+++ b/HarfangLab/connector_harfanglab_software_assets.json
@@ -16,8 +16,8 @@
       "frequency": {
           "type": "integer",
           "description": "Batch frequency in seconds",
-          "minimum": 1,
-          "default": 60
+          "minimum": 10800,
+          "default": 86400
       },
       "sekoia_api_key": {
           "description": "API key to use from sekoia.io",
@@ -34,5 +34,5 @@
     "secrets": ["sekoia_api_key"],
     "internal": ["sekoia_base_url", "sekoia_api_key", "frequency", "batch_size"]
   },
-  "feature-flag": ["reveal-application-discovery"]
+  "feature-flags": ["reveal-application-discovery"]
 }

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.31.8",
+  "version": "1.31.9",
   "categories": [
     "Endpoint"
   ],


### PR DESCRIPTION
## Summary by Sourcery

Correct the HarfangLab software asset connector configuration and update its synchronization frequency limits.

Bug Fixes:
- Correct the HarfangLab software asset connector configuration typo.

Enhancements:
- Update software asset synchronization defaults to a one-day frequency with a three-hour minimum interval.

Chores:
- Bump the HarfangLab integration version to 1.31.9.