### PR TITLE
fix(harfanglab): typo on FF

### DIFF
--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-27 - 1.31.10
+
+### Fixed
+
+- Fix typo in software asset connector feature flag key (`feature-flags` → `feature_flags`)
+
 ## 2026-08-27 - 1.31.9
 
 ### Changed

--- a/HarfangLab/connector_harfanglab_software_assets.json
+++ b/HarfangLab/connector_harfanglab_software_assets.json
@@ -34,5 +34,5 @@
     "secrets": ["sekoia_api_key"],
     "internal": ["sekoia_base_url", "sekoia_api_key", "frequency", "batch_size"]
   },
-  "feature-flags": ["reveal-application-discovery"]
+  "feature_flags": ["reveal-application-discovery"]
 }

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.31.9",
+  "version": "1.31.10",
   "categories": [
     "Endpoint"
   ],


### PR DESCRIPTION
## Summary by Sourcery

Correct the HarfangLab software asset connector feature flag key and release version 1.31.10.

Bug Fixes:
- Correct the HarfangLab software asset connector feature flag key from `feature-flags` to `feature_flags`.],
- enhancements|||| []
- build
- ci
- deployment
- docs
- tests
- chores
- overview