### PR TITLE
fix sekoia module

### DIFF
--- a/Sekoia.io/CHANGELOG.md
+++ b/Sekoia.io/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-08-27 - 2.76.2
+
+### Fixed
+
+- Apply gevent monkey-patching before any import pulls in `ssl` (via `requests`/`urllib3`), and restrict it to trigger executions. Patching an already-loaded `ssl` module caused `RecursionError` on HTTPS calls.
+
 ## 2026-08-27 - 2.76.1
 
 ### Fixed

--- a/Sekoia.io/main.py
+++ b/Sekoia.io/main.py
@@ -1,7 +1,9 @@
 # flake8: noqa: E402
-from sekoiaio.utils import should_patch
+import sys
 
-if should_patch():
+# Patch before any import pulls in ssl (via requests/urllib3), otherwise
+# gevent patches an already-loaded ssl module and HTTPS calls hit RecursionError.
+if len(sys.argv) >= 2 and sys.argv[1].endswith("_trigger"):
     from gevent import monkey
 
     monkey.patch_all()

--- a/Sekoia.io/manifest.json
+++ b/Sekoia.io/manifest.json
@@ -12,7 +12,7 @@
   "name": "Sekoia.io",
   "uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
   "slug": "sekoia.io",
-  "version": "2.76.1",
+  "version": "2.76.2",
   "categories": [
     "Generic"
   ]


### PR DESCRIPTION
## Summary by Sourcery

Prevent SSL recursion errors by limiting early gevent patching to trigger executions.

Bug Fixes:
- Fix HTTPS trigger executions by applying gevent monkey-patching before SSL-related modules are loaded.

Chores:
- Bump the Sekoia.io module version to 2.76.2.