### PR TITLE
Fix: Holm Devices And Vulnerabilities (1902)

### DIFF
--- a/HolmSecurity/CHANGELOG.md
+++ b/HolmSecurity/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.1] - 2026-08-28
+## [1.3.1] - 2026-09-03
 
 ### Fixed
 
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reports a field as `null` instead of omitting it. A pydantic default only applies to
   an absent key, so a single `"risk_score": null` or `"open_ports": null` on one network
   asset failed the validation of the entire page and no asset was ever pushed
+- `emails` of a device is a list of `{email, username}` objects, not a list of addresses
+
+### Changed
+
+- Every optional field of the Holm API models is now nullable, following the published
+  API schema: a `null` is kept as `null` instead of being replaced by a fabricated
+  default. An absent `risk_score` is no longer reported as a score of `0`, and a real
+  score of `0` is now reported instead of being dropped
 
 ## [1.3.0] - 2026-08-20
 

--- a/HolmSecurity/CHANGELOG.md
+++ b/HolmSecurity/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-08-28
+
+### Fixed
+
+- Both asset connectors no longer abort a whole collection cycle when the Holm API
+  reports a field as `null` instead of omitting it. A pydantic default only applies to
+  an absent key, so a single `"risk_score": null` or `"open_ports": null` on one network
+  asset failed the validation of the entire page and no asset was ever pushed
+
 ## [1.3.0] - 2026-08-20
 
 ### Added

--- a/HolmSecurity/holm_security/asset_connector/device_assets.py
+++ b/HolmSecurity/holm_security/asset_connector/device_assets.py
@@ -151,7 +151,7 @@ class HolmSecurityDeviceAssetConnector(AssetConnector):
             created_time=self._to_epoch(device.created),
             last_seen_time=self._to_epoch(device.last_sync),
             is_managed=True,
-            risk_score=device.risk_score if device.risk_score else None,
+            risk_score=device.risk_score,
             risk_level=risk_level,
             risk_level_id=risk_level_id,
         )
@@ -178,7 +178,7 @@ class HolmSecurityDeviceAssetConnector(AssetConnector):
             last_seen_time=self._to_epoch(asset.last_detected),
             is_managed=False,
             vendor_name=self.PRODUCT_NAME,
-            risk_score=asset.risk_score if asset.risk_score else None,
+            risk_score=asset.risk_score,
             risk_level=risk_level,
             risk_level_id=risk_level_id,
         )

--- a/HolmSecurity/holm_security/asset_connector/device_mapping.yml
+++ b/HolmSecurity/holm_security/asset_connector/device_mapping.yml
@@ -248,7 +248,7 @@ mapping:
     - source: "risk_score"
       target: "device.risk_score"
       type: "integer"
-      logic: "Direct mapping; omitted when 0"
+      logic: "Direct mapping; null when the API reports no score"
       description: "Device risk score"
 
     # NETWORK ASSET ATTRIBUTES (GET /v2/net-assets)
@@ -328,7 +328,7 @@ mapping:
     - source: "net_assets.risk_score"
       target: "device.risk_score"
       type: "integer"
-      logic: "Direct mapping; omitted when 0"
+      logic: "Direct mapping; null when the API reports no score"
       description: "Network asset risk score"
 
     - source: "static: false"

--- a/HolmSecurity/holm_security/asset_connector/models.py
+++ b/HolmSecurity/holm_security/asset_connector/models.py
@@ -8,9 +8,13 @@ class HolmBaseModel(BaseModel):
     """Base model tolerating the explicit ``null`` values of the Holm Security API.
 
     Holm reports a field it has no value for as ``null`` instead of omitting it, and a
-    pydantic default only applies to an absent key. Those nulls are dropped so the
-    declared default applies: without this, a single ``"risk_score": null`` aborts the
-    validation of the whole page and the connector collects nothing.
+    pydantic default only applies to an absent key: a single ``"risk_score": null`` or
+    ``"open_ports": null`` on one network asset aborted the validation of the whole page
+    and the connector collected nothing.
+
+    Those nulls are dropped so the declared default applies. Every optional scalar
+    defaults to ``None`` so a null is never turned into a fabricated value: only a
+    collection falls back to an empty one, where ``null`` and ``[]`` mean the same thing.
 
     Nulls on required fields are kept so a genuinely malformed record still fails.
     """
@@ -41,28 +45,39 @@ class HolmNetwork(HolmBaseModel):
     mac_address: str | None = None
 
 
-class HolmTag(HolmBaseModel):
-    """A tag attached to a Holm Security device."""
+class HolmDeviceEmail(HolmBaseModel):
+    """A notification recipient attached to a Holm Security device."""
 
-    uuid: str
-    name: str
+    email: str | None = None
+    username: str | None = None
+
+
+class HolmTag(HolmBaseModel):
+    """A tag attached to a Holm Security device or network asset.
+
+    Devices carry a full tag object, network assets a minimal one holding only a name
+    and a uuid, so every field is optional.
+    """
+
+    uuid: str | None = None
+    name: str | None = None
     color: str | None = None
-    is_dynamic: bool = False
-    host_assets_cnt: int = 0
-    da_assets_cnt: int = 0
-    web_assets_cnt: int = 0
-    cloud_assets_cnt: int = 0
-    recipient_assets_cnt: int = 0
+    is_dynamic: bool | None = None
+    host_assets_cnt: int | None = None
+    da_assets_cnt: int | None = None
+    web_assets_cnt: int | None = None
+    cloud_assets_cnt: int | None = None
+    recipient_assets_cnt: int | None = None
 
 
 class HolmSeverityBreakdown(HolmBaseModel):
     """Per-severity vulnerability counts for a device."""
 
-    info: int = 0
-    low: int = 0
-    medium: int = 0
-    high: int = 0
-    critical: int = 0
+    info: int | None = None
+    low: int | None = None
+    medium: int | None = None
+    high: int | None = None
+    critical: int | None = None
 
 
 class HolmDevice(HolmBaseModel):
@@ -80,19 +95,19 @@ class HolmDevice(HolmBaseModel):
     os_version: str | None = None
     os_build: str | None = None
     network: HolmNetwork | None = None
-    internet_facing: bool = False
-    internet_facing_user_override: bool = False
+    internet_facing: bool | None = None
+    internet_facing_user_override: bool | None = None
     debug_level: str | None = None
     error_interval: str | None = None
     update_interval: str | None = None
     user_account: str | None = None
-    emails: list[str] = []
+    emails: list[HolmDeviceEmail] = []
     tags: list[HolmTag] = []
-    vuln_count: int = 0
+    vuln_count: int | None = None
     max_severity: int | str | None = None
     severity: HolmSeverityBreakdown | None = None
     current_version: str | None = None
-    risk_score: int = 0
+    risk_score: int | None = None
 
 
 class HolmDevicePage(HolmBaseModel):
@@ -128,10 +143,10 @@ class HolmNetAsset(HolmBaseModel):
     created: str | None = None
     last_detected: str | None = None
     business_impact: str | None = None
-    hosts_personal_data: bool = False
+    hosts_personal_data: bool | None = None
     auth_status: str | None = None
-    vulnerabilities_count: int = 0
-    risk_score: int = 0
+    vulnerabilities_count: int | None = None
+    risk_score: int | None = None
     severity: HolmSeverityBreakdown | None = None
     tags: list[HolmTag] = []
     open_ports: list[HolmOpenPort] = []

--- a/HolmSecurity/holm_security/asset_connector/models.py
+++ b/HolmSecurity/holm_security/asset_connector/models.py
@@ -1,20 +1,48 @@
-from pydantic import BaseModel, ConfigDict
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic.fields import FieldInfo
 
 
-class HolmNetwork(BaseModel):
-    """Network block of a Holm Security device record."""
+class HolmBaseModel(BaseModel):
+    """Base model tolerating the explicit ``null`` values of the Holm Security API.
+
+    Holm reports a field it has no value for as ``null`` instead of omitting it, and a
+    pydantic default only applies to an absent key. Those nulls are dropped so the
+    declared default applies: without this, a single ``"risk_score": null`` aborts the
+    validation of the whole page and the connector collects nothing.
+
+    Nulls on required fields are kept so a genuinely malformed record still fails.
+    """
 
     model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _null_to_default(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        # `cls.model_fields` is typed as an instance property, hence the cast.
+        fields = cast(dict[str, FieldInfo], cls.model_fields)
+
+        return {
+            key: value
+            for key, value in data.items()
+            if value is not None or key not in fields or fields[key].is_required()
+        }
+
+
+class HolmNetwork(HolmBaseModel):
+    """Network block of a Holm Security device record."""
 
     ip_address: str | None = None
     ip_address_v6: str | None = None
     mac_address: str | None = None
 
 
-class HolmTag(BaseModel):
+class HolmTag(HolmBaseModel):
     """A tag attached to a Holm Security device."""
-
-    model_config = ConfigDict(extra="allow")
 
     uuid: str
     name: str
@@ -27,10 +55,8 @@ class HolmTag(BaseModel):
     recipient_assets_cnt: int = 0
 
 
-class HolmSeverityBreakdown(BaseModel):
+class HolmSeverityBreakdown(HolmBaseModel):
     """Per-severity vulnerability counts for a device."""
-
-    model_config = ConfigDict(extra="allow")
 
     info: int = 0
     low: int = 0
@@ -39,10 +65,8 @@ class HolmSeverityBreakdown(BaseModel):
     critical: int = 0
 
 
-class HolmDevice(BaseModel):
+class HolmDevice(HolmBaseModel):
     """A single agent-managed device returned by ``GET /v2/devices``."""
-
-    model_config = ConfigDict(extra="allow")
 
     uid: str
     device_name: str | None = None
@@ -71,10 +95,8 @@ class HolmDevice(BaseModel):
     risk_score: int = 0
 
 
-class HolmDevicePage(BaseModel):
+class HolmDevicePage(HolmBaseModel):
     """Paginated response envelope for the devices endpoint."""
-
-    model_config = ConfigDict(extra="allow")
 
     count: int = 0
     next: str | None = None
@@ -82,22 +104,18 @@ class HolmDevicePage(BaseModel):
     results: list[HolmDevice] = []
 
 
-class HolmOpenPort(BaseModel):
+class HolmOpenPort(HolmBaseModel):
     """An open port reported on a Holm Security network asset."""
-
-    model_config = ConfigDict(extra="allow")
 
     proto: str | None = None
     port: int | None = None
 
 
-class HolmNetAsset(BaseModel):
+class HolmNetAsset(HolmBaseModel):
     """A single scanned network asset returned by ``GET /v2/net-assets``.
 
     Network assets are hosts and IP ranges discovered by a scan, without an agent.
     """
-
-    model_config = ConfigDict(extra="allow")
 
     uuid: str
     name: str | None = None
@@ -119,10 +137,8 @@ class HolmNetAsset(BaseModel):
     open_ports: list[HolmOpenPort] = []
 
 
-class HolmNetAssetPage(BaseModel):
+class HolmNetAssetPage(HolmBaseModel):
     """Paginated response envelope for the network assets endpoint."""
-
-    model_config = ConfigDict(extra="allow")
 
     count: int = 0
     next: str | None = None

--- a/HolmSecurity/holm_security/asset_connector/vulnerability_models.py
+++ b/HolmSecurity/holm_security/asset_connector/vulnerability_models.py
@@ -1,19 +1,15 @@
-from pydantic import BaseModel, ConfigDict
+from holm_security.asset_connector.models import HolmBaseModel
 
 
-class HolmVulnHost(BaseModel):
+class HolmVulnHost(HolmBaseModel):
     """Host context attached to a vulnerability finding."""
-
-    model_config = ConfigDict(extra="allow")
 
     name: str | None = None
     ip: str | None = None
 
 
-class HolmVulnInner(BaseModel):
+class HolmVulnInner(HolmBaseModel):
     """CVSS / detection details nested under ``vuln.vuln``."""
-
-    model_config = ConfigDict(extra="allow")
 
     base_score_v2: float | None = None
     base_score_v3: float | None = None
@@ -27,17 +23,13 @@ class HolmVulnInner(BaseModel):
     software: str | None = None
 
 
-class HolmVulnCategory(BaseModel):
-    model_config = ConfigDict(extra="allow")
-
+class HolmVulnCategory(HolmBaseModel):
     id: int | None = None
     name: str | None = None
 
 
-class HolmVulnDefinition(BaseModel):
+class HolmVulnDefinition(HolmBaseModel):
     """Vulnerability definition nested under the finding's ``vuln`` field."""
-
-    model_config = ConfigDict(extra="allow")
 
     hid: str | None = None
     name: str | None = None
@@ -49,10 +41,8 @@ class HolmVulnDefinition(BaseModel):
     vuln_category: HolmVulnCategory | None = None
 
 
-class HolmVulnerabilityFinding(BaseModel):
+class HolmVulnerabilityFinding(HolmBaseModel):
     """A single vulnerability finding returned by the report endpoint."""
-
-    model_config = ConfigDict(extra="allow")
 
     asset: str | None = None
     created_timestamp: str | None = None
@@ -66,10 +56,8 @@ class HolmVulnerabilityFinding(BaseModel):
     vuln: HolmVulnDefinition | None = None
 
 
-class HolmVulnerabilityPage(BaseModel):
+class HolmVulnerabilityPage(HolmBaseModel):
     """Paginated response envelope for the vulnerabilities report endpoint."""
-
-    model_config = ConfigDict(extra="allow")
 
     count: int = 0
     next: str | None = None

--- a/HolmSecurity/manifest.json
+++ b/HolmSecurity/manifest.json
@@ -27,7 +27,7 @@
   "name": "Holm Security",
   "uuid": "23886dfe-89a9-4522-b1fb-6e2837e15390",
   "slug": "holm-security",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "categories": [
     "Network"
   ],

--- a/HolmSecurity/tests/asset_connector/test_device_assets.py
+++ b/HolmSecurity/tests/asset_connector/test_device_assets.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 from dateutil.parser import isoparse
+from pydantic import ValidationError
 from sekoia_automation.asset_connector.models.ocsf.device import (
     DeviceOCSFModel,
     DeviceTypeId,
@@ -12,7 +13,12 @@ from sekoia_automation.asset_connector.models.ocsf.device import (
 from sekoia_automation.module import Module
 
 from holm_security.asset_connector.device_assets import HolmSecurityDeviceAssetConnector
-from holm_security.asset_connector.models import HolmDevice, HolmNetAsset
+from holm_security.asset_connector.models import (
+    HolmDevice,
+    HolmDevicePage,
+    HolmNetAsset,
+    HolmNetAssetPage,
+)
 
 BASE_URL = "https://se-api.holmsecurity.com"
 DEVICES_URL = f"{BASE_URL}/v2/devices"
@@ -589,3 +595,101 @@ def test_net_asset_checkpoint_is_not_advanced_when_the_connector_stops(connector
 
     connector.update_checkpoint()
     assert connector.most_recent_net_asset_last_detected is None
+
+
+def test_net_asset_page_accepts_null_values():
+    """The Holm API reports an absent value as `null` instead of omitting the key."""
+    page = HolmNetAssetPage.model_validate(
+        {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [
+                make_net_asset(
+                    risk_score=None,
+                    vulnerabilities_count=None,
+                    open_ports=None,
+                    tags=None,
+                    severity=None,
+                    hosts_personal_data=None,
+                )
+            ],
+        }
+    )
+
+    asset = page.results[0]
+    # A null scalar stays null: an absent score is not a score of 0.
+    assert asset.risk_score is None
+    assert asset.vulnerabilities_count is None
+    assert asset.hosts_personal_data is None
+    # A null collection is an empty one.
+    assert asset.open_ports == []
+    assert asset.tags == []
+
+
+def test_device_page_accepts_null_values():
+    page = HolmDevicePage.model_validate(
+        {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [
+                make_device(
+                    risk_score=None,
+                    vuln_count=None,
+                    internet_facing=None,
+                    current_version=None,
+                    emails=None,
+                    tags=None,
+                )
+            ],
+        }
+    )
+
+    device = page.results[0]
+    assert device.risk_score is None
+    assert device.vuln_count is None
+    assert device.internet_facing is None
+    assert device.emails == []
+    assert device.tags == []
+
+
+def test_page_still_rejects_a_null_identifier():
+    """A record without an identifier cannot be published and must still fail."""
+    with pytest.raises(ValidationError):
+        HolmNetAssetPage.model_validate(
+            {"count": 1, "next": None, "previous": None, "results": [make_net_asset(uuid=None)]}
+        )
+
+
+def test_device_emails_are_objects():
+    """`emails` holds `{email, username}` objects, not plain addresses."""
+    device = HolmDevice.model_validate(make_device(emails=[{"email": "soc@example.com", "username": "soc"}]))
+
+    assert device.emails[0].email == "soc@example.com"
+    assert device.emails[0].username == "soc"
+
+
+def test_net_asset_tags_without_a_uuid():
+    """Network assets carry a minimal tag object, sometimes without a uuid."""
+    asset = HolmNetAsset.model_validate(make_net_asset(tags=[{"name": "Web servers"}]))
+
+    assert asset.tags[0].name == "Web servers"
+    assert asset.tags[0].uuid is None
+
+
+def test_risk_score_null_is_not_reported(connector):
+    device = connector.build_device(HolmDevice.model_validate(make_device(risk_score=None)))
+    net_asset = connector.build_net_asset_device(HolmNetAsset.model_validate(make_net_asset(risk_score=None)))
+
+    assert device.risk_score is None
+    assert net_asset.risk_score is None
+
+
+def test_risk_score_zero_is_reported(connector):
+    """A score of 0 is a real score and must be distinguished from an absent one."""
+    device = connector.build_device(HolmDevice.model_validate(make_device(risk_score=0)))
+    net_asset = connector.build_net_asset_device(HolmNetAsset.model_validate(make_net_asset(risk_score=0)))
+
+    assert device.risk_score == 0
+    assert net_asset.risk_score == 0


### PR DESCRIPTION
Relates to [1902](https://github.com/SekoiaLab/integration/issues/1902)

## Summary by Sourcery

Make Holm asset and vulnerability collection resilient to nullable API responses while preserving accurate asset data.

Bug Fixes:
- Prevent device and network asset collection from failing when Holm returns explicit null values for optional fields.
- Preserve null and zero risk scores correctly when mapping assets.
- Parse device email recipients as objects containing email and username.
- Accept the published Holm API shapes for nullable tags, vulnerability data, and asset fields.

Enhancements:
- Centralize nullable Holm API model handling while continuing to reject missing required identifiers.

Tests:
- Add coverage for nullable API responses, email object parsing, minimal tags, identifier validation, and risk-score mapping.

Chores:
- Bump the Holm Security integration version to 1.3.1 and update the changelog.