### PR TITLE
Fix: Crowdstrike Device Lag on the connector (1846)

### DIFF
--- a/CrowdStrikeFalcon/CHANGELOG.md
+++ b/CrowdStrikeFalcon/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-09-01 - 1.25.19
+
+### Fixed
+
+- Crowdstrike Falcon Devices asset connector: an interrupted collection cycle no longer
+  strands the devices it had not reached. The checkpoint used to be advanced to the newest
+  device as soon as the first batch was pushed, so any restart, API error or refused batch
+  made every later cycle stop immediately and skip the rest of the inventory.
+- Crowdstrike Falcon Devices asset connector: list devices through
+  `/devices/queries/devices-scroll/v1`.
+
+### Changed
+
+- Crowdstrike Falcon Devices asset connector: host groups are resolved once per cycle
+  instead of once per device, removing up to one API call per device (and the repeated
+  403 warnings when the API client lacks the `Host groups: Read` scope).
+
 ## 2026-07-02 - 1.25.18
 
 ### Fixed

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
@@ -243,30 +243,14 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
         host groups but tens of thousands of devices, and looking them up per device
         turns the run into one extra API call per device.
         """
-        raw_groups = [group_id for group_id in device.groups or [] if group_id]
+        raw_groups = [group_id for group_id in device.groups if group_id]
         if not raw_groups:
             return None
 
-        unresolved = [group_id for group_id in raw_groups if group_id not in self._groups_cache]
-        if unresolved:
-            try:
-                for group_info in self.client.get_host_groups(unresolved):
-                    group_id = group_info.get("id")
-                    if group_id:
-                        self._groups_cache[group_id] = Group(
-                            uid=group_id,
-                            name=group_info.get("name", "Unknown"),
-                            desc=group_info.get("description") or None,
-                        )
-            except Exception as e:
-                self.log(f"Failed to fetch group details: {e}", level="warning")
+        self.fetch_groups(raw_groups)
 
-            # Fall back on the identifier for whatever the API did not return, and cache
-            # that too so a missing scope does not retry (and re-log) on every device.
-            for group_id in unresolved:
-                self._groups_cache.setdefault(group_id, Group(uid=group_id, name=group_id))
-
-        return [self._groups_cache[group_id] for group_id in raw_groups]
+        # fallback on the identifier as name for the groups without details
+        return [self._groups_cache.get(group_id) or Group(uid=group_id, name=group_id) for group_id in raw_groups]
 
     def get_location(self, device: CrowdStrikeDevice) -> GeoLocation | None:
         """

--- a/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/asset_connectors/device_assets.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from dateutil.parser import isoparse
 from sekoia_automation.asset_connector import AssetConnector
+from sekoia_automation.asset_connector.models.connector import AssetList
 from sekoia_automation.asset_connector.models.ocsf.base import (
     Metadata,
     Product,
@@ -40,6 +41,8 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
         super().__init__(*args, **kwargs)
         self.context = PersistentJSON("context.json", self._data_path)
         self._latest_id = None
+        self._push_failed = False
+        self._groups_cache: dict[str, Group] = {}
 
     @property
     def most_recent_device_id(self) -> str | None:
@@ -197,26 +200,35 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
     def get_groups(self, device: CrowdStrikeDevice) -> list[Group] | None:
         """
         Extract groups from device data and fetch details from API.
+
+        Resolved groups are cached for the whole fetch cycle: a tenant has a handful of
+        host groups but tens of thousands of devices, and looking them up per device
+        turns the run into one extra API call per device.
         """
-        raw_groups = device.groups
+        raw_groups = [group_id for group_id in device.groups or [] if group_id]
         if not raw_groups:
             return None
 
-        groups: list[Group] = []
-        try:
-            for group_info in self.client.get_host_groups(raw_groups):
-                groups.append(
-                    Group(
-                        uid=group_info.get("id"),
-                        name=group_info.get("name", "Unknown"),
-                        desc=group_info.get("description") or None,
-                    )
-                )
-        except Exception as e:
-            self.log(f"Failed to fetch group details: {e}", level="warning")
-            groups = [Group(uid=g, name=g) for g in raw_groups if g]
+        unresolved = [group_id for group_id in raw_groups if group_id not in self._groups_cache]
+        if unresolved:
+            try:
+                for group_info in self.client.get_host_groups(unresolved):
+                    group_id = group_info.get("id")
+                    if group_id:
+                        self._groups_cache[group_id] = Group(
+                            uid=group_id,
+                            name=group_info.get("name", "Unknown"),
+                            desc=group_info.get("description") or None,
+                        )
+            except Exception as e:
+                self.log(f"Failed to fetch group details: {e}", level="warning")
 
-        return groups if groups else None
+            # Fall back on the identifier for whatever the API did not return, and cache
+            # that too so a missing scope does not retry (and re-log) on every device.
+            for group_id in unresolved:
+                self._groups_cache.setdefault(group_id, Group(uid=group_id, name=group_id))
+
+        return [self._groups_cache[group_id] for group_id in raw_groups]
 
     def get_location(self, device: CrowdStrikeDevice) -> GeoLocation | None:
         """
@@ -380,10 +392,26 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
 
         return device_ocsf
 
+    def post_assets_to_api(self, assets: AssetList, asset_connector_api_url: str) -> dict[str, str] | None:
+        """Push a batch and remember whether it made it through."""
+        response = super().post_assets_to_api(assets, asset_connector_api_url)
+        if response is None:
+            # The batch was dropped, so the devices it carried were never ingested: hold
+            # the checkpoint back so the next cycle walks the whole listing again.
+            self._push_failed = True
+        return response
+
+    def asset_fetch_cycle(self) -> None:
+        """Run a fetch cycle, then commit the checkpoint if it collected everything."""
+        super().asset_fetch_cycle()
+        # Every batch of the cycle has been pushed by now, so this is the first moment we
+        # know the run was complete. An interrupted cycle raises and never gets here.
+        self.update_checkpoint()
+
     def update_checkpoint(self) -> None:
         """Update the checkpoint with the latest device ID."""
         self.log("Updating the device id !!", level="info")
-        if self._latest_id is None:
+        if self._latest_id is None or self._push_failed:
             return
         with self.context as cache:
             cache["most_recent_device_id"] = self._latest_id
@@ -393,16 +421,27 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
         """
         Generator that yields device information from CrowdStrike API.
         Uses pagination and checkpoint to fetch only new devices.
+
+        The checkpoint is only advanced once the whole listing has been walked. The SDK
+        calls `update_checkpoint` after every batch it pushes, so remembering the newest
+        device id up front would make any interruption of the run (pod restart, API
+        error, rate limit) skip every device it had not reached yet, forever.
         """
         last_first_uuid = self.most_recent_device_id
+        newest_uuid: str | None = None
         uuids_batch: list[str] = []
+
+        # Nothing is collected yet: the pushes happening during this walk must not commit
+        # a checkpoint.
+        self._latest_id = None
+        self._push_failed = False
 
         for idx, device_uuid in enumerate(self.client.list_devices_uuids(limit=self.LIMIT, sort="first_seen.desc")):
             if idx == 0:
                 if device_uuid == last_first_uuid:
                     self.log("No device has been added !!", level="info")
                     return
-                self._latest_id = device_uuid
+                newest_uuid = device_uuid
 
             # Stop before the last seen device id
             if last_first_uuid and device_uuid == last_first_uuid:
@@ -421,11 +460,16 @@ class CrowdstrikeDeviceAssetConnector(AssetConnector):
             for device_info in self.client.get_devices_infos(uuids_batch):
                 yield CrowdStrikeDevice.model_validate(device_info)
 
+        # The whole listing was walked: remember where we stopped. It is committed at the
+        # end of the cycle, once every batch has been pushed.
+        self._latest_id = newest_uuid
+
     def get_assets(self) -> Generator[DeviceOCSFModel, None, None]:
         """
         Main generator that yields OCSF-formatted device assets.
         """
         self.log("Start the getting assets generator !!", level="info")
+        self._groups_cache = {}
         for device in self.next_devices():
             mapped = self.map_device_fields(device)
             if mapped is not None:  # pragma: no branch

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -92,7 +92,6 @@ class ApiClient(requests.Session):
 
         still_fetching_items = True
         pagination: dict | None = None
-        previous_cursor: str | None = None
 
         while still_fetching_items:
             new_params = dict(params)
@@ -104,6 +103,8 @@ class ApiClient(requests.Session):
                 # Otherwise, fallback on the offset parameter if defined
                 elif "offset" in pagination:
                     new_params["offset"] = pagination["offset"]
+
+            requested_cursor = new_params.get("offset") if cursor_pagination else None
 
             response = self.request(method=method, url=url, params=new_params, **kwargs)
 
@@ -117,29 +118,30 @@ class ApiClient(requests.Session):
             if errors:
                 msg = f"The API returns the following errors: \n{errors}"
                 raise HTTPError(msg, response=response)  # type: ignore[call-arg]
-            yield from content.get("resources") or []
 
             pagination = content.get("meta", {}).get("pagination")
-            if pagination:
-                if pagination.get("after"):
-                    still_fetching_items = True
-                elif cursor_pagination:
-                    # Follow the continuation token until the API stops handing back a new one
-                    cursor = pagination.get("offset")
-                    still_fetching_items = bool(cursor) and cursor != previous_cursor
-                    previous_cursor = cursor
-                else:
-                    offset = pagination.get("offset")
-                    limit = pagination.get("limit")
-                    total = pagination.get("total")
-                    still_fetching_items = (
-                        isinstance(offset, int)
-                        and isinstance(limit, int)
-                        and isinstance(total, int)
-                        and offset < total
-                    )
+
+            if pagination and pagination.get("after"):
+                still_fetching_items = True
+            elif cursor_pagination:
+                # Follow the continuation token until the API stops handing back a new one
+                cursor = (pagination or {}).get("offset")
+                if requested_cursor is not None and cursor == requested_cursor:
+                    # The API handed back the token it was given: the scroll is not
+                    # advancing, so this page only repeats the previous one. Drop it.
+                    return
+                still_fetching_items = bool(cursor)
+            elif pagination:
+                offset = pagination.get("offset")
+                limit = pagination.get("limit")
+                total = pagination.get("total")
+                still_fetching_items = (
+                    isinstance(offset, int) and isinstance(limit, int) and isinstance(total, int) and offset < total
+                )
             else:
                 still_fetching_items = False
+
+            yield from content.get("resources") or []
 
     def request_graphql_endpoint(
         self,

--- a/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
+++ b/CrowdStrikeFalcon/crowdstrike_falcon/client/__init__.py
@@ -41,9 +41,17 @@ class ApiClient(requests.Session):
     def get_url(self, endpoint: str) -> str:
         return urljoin(self._base_url, endpoint.lstrip("/"))
 
-    def request_endpoint(self, method: str, endpoint: str, **kwargs) -> Generator[Any, None, None]:
+    def request_endpoint(
+        self, method: str, endpoint: str, cursor_pagination: bool = False, **kwargs
+    ) -> Generator[Any, None, None]:
         """
         Send the request and handle the response
+
+        Args:
+            cursor_pagination: the endpoint returns an opaque continuation token in
+                `meta.pagination.offset` instead of a numeric offset
+                (e.g. /devices/queries/devices-scroll/v1). Numeric offsets are capped
+                at 10 000 results by the API, tokens are not.
         """
         params = kwargs.pop("params", {})
 
@@ -51,6 +59,7 @@ class ApiClient(requests.Session):
 
         still_fetching_items = True
         pagination: dict | None = None
+        previous_cursor: str | None = None
 
         while still_fetching_items:
             new_params = dict(params)
@@ -82,6 +91,11 @@ class ApiClient(requests.Session):
             if pagination:
                 if pagination.get("after"):
                     still_fetching_items = True
+                elif cursor_pagination:
+                    # Follow the continuation token until the API stops handing back a new one
+                    cursor = pagination.get("offset")
+                    still_fetching_items = bool(cursor) and cursor != previous_cursor
+                    previous_cursor = cursor
                 else:
                     offset = pagination.get("offset")
                     limit = pagination.get("limit")
@@ -263,10 +277,13 @@ class CrowdstrikeFalconClient(ApiClient):
         )
 
     def list_devices_uuids(self, limit: int, sort: str, **kwargs) -> Generator[str, None, None]:
+        # devices-scroll (token pagination) instead of devices/v1: the latter refuses
+        # limit + offset above 10 000, which silently caps large tenants.
         yield from self.request_endpoint(
             "GET",
-            "/devices/queries/devices/v1",
+            "/devices/queries/devices-scroll/v1",
             params={"limit": limit, "sort": sort},
+            cursor_pagination=True,
             **kwargs,
         )
 

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "CrowdStrike Falcon is a cloud-native cybersecurity platform known for its advanced threat detection, endpoint protection, and real-time response capabilities. It leverages AI and machine learning to protect against malware and sophisticated cyberattacks.",
-  "version": "1.25.19",
+  "version": "1.25.20",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/CrowdStrikeFalcon/manifest.json
+++ b/CrowdStrikeFalcon/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrowdStrike Falcon",
   "slug": "crowdstrike-falcon",
   "description": "CrowdStrike Falcon is a cloud-native cybersecurity platform known for its advanced threat detection, endpoint protection, and real-time response capabilities. It leverages AI and machine learning to protect against malware and sophisticated cyberattacks.",
-  "version": "1.25.18",
+  "version": "1.25.19",
   "configuration": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
@@ -356,6 +356,7 @@ def test_is_device_compliant(connector):
     assert connector.is_device_compliant(non_compliant) is False
     assert connector.is_device_compliant(CrowdStrikeDevice()) is None
 
+
 def test_get_groups_reuses_cached_group_details(connector):
     mock_client = Mock()
     mock_client.get_host_groups.return_value = [{"id": "group1", "name": "Group One"}]

--- a/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
+++ b/CrowdStrikeFalcon/tests/asset_connectors/test_device_asset_connector.py
@@ -1,14 +1,16 @@
-import pytest
 from unittest.mock import Mock
+
+import pytest
+from sekoia_automation.asset_connector.models.ocsf.device import (
+    DeviceTypeId,
+    DeviceTypeStr,
+    OSTypeId,
+    OSTypeStr,
+)
+from sekoia_automation.asset_connector.models.ocsf.group import Group
 
 from crowdstrike_falcon.asset_connectors.crowdstrike_device_model import CrowdStrikeDevice, PolicyEntry
 from crowdstrike_falcon.asset_connectors.device_assets import CrowdstrikeDeviceAssetConnector
-from sekoia_automation.asset_connector.models.ocsf.device import (
-    OSTypeId,
-    OSTypeStr,
-    DeviceTypeId,
-    DeviceTypeStr,
-)
 
 
 class _DummyContext:
@@ -352,3 +354,201 @@ def test_is_device_compliant(connector):
     assert connector.is_device_compliant(compliant) is True
     assert connector.is_device_compliant(non_compliant) is False
     assert connector.is_device_compliant(CrowdStrikeDevice()) is None
+
+
+def test_next_devices_does_not_checkpoint_before_the_walk_completes(connector):
+    """Regression: an interrupted run must not commit a checkpoint (SekoiaLab/integration#1846).
+
+    The SDK calls update_checkpoint() after every batch it pushes, so a checkpoint set
+    at the start of the walk makes the next cycle skip every device the interrupted run
+    never reached.
+    """
+    connector.LIMIT = 2
+    client = Mock()
+    client.list_devices_uuids.return_value = iter(["u5", "u4", "u3", "u2"])
+    client.get_devices_infos.side_effect = lambda batch: [{"device_id": b} for b in batch]
+    connector.client = client
+
+    devices = connector.next_devices()
+    # Consume the first batch only, as an interrupted cycle would
+    next(devices)
+    connector.update_checkpoint()
+
+    assert connector._latest_id is None
+    assert "most_recent_device_id" not in connector.context.store
+
+    # Draining the generator completes the walk and releases the checkpoint
+    list(devices)
+    connector.update_checkpoint()
+    assert connector.context.store["most_recent_device_id"] == "u5"
+
+
+def test_next_devices_resumes_full_listing_after_an_interrupted_run(connector):
+    uuids = ["u5", "u4", "u3", "u2"]
+    connector.LIMIT = 2
+    client = Mock()
+    client.get_devices_infos.side_effect = lambda batch: [{"device_id": b} for b in batch]
+    connector.client = client
+
+    # Cycle 1 dies after the first batch
+    client.list_devices_uuids.return_value = iter(uuids)
+    devices = connector.next_devices()
+    assert next(devices).device_id == "u5"
+    devices.close()
+
+    # Cycle 2 still sees the whole listing
+    client.list_devices_uuids.return_value = iter(uuids)
+    assert [d.device_id for d in connector.next_devices()] == uuids
+
+
+def test_get_groups_resolves_each_group_once_across_devices(connector):
+    mock_client = Mock()
+    mock_client.get_host_groups.return_value = [{"id": "group1", "name": "Group One"}]
+    connector.client = mock_client
+
+    for _ in range(3):
+        groups = connector.get_groups(CrowdStrikeDevice(groups=["group1"]))
+        assert [g.name for g in groups] == ["Group One"]
+
+    mock_client.get_host_groups.assert_called_once_with(["group1"])
+
+
+def test_get_groups_only_looks_up_unknown_groups(connector):
+    mock_client = Mock()
+    mock_client.get_host_groups.side_effect = [
+        [{"id": "group1", "name": "Group One"}],
+        [{"id": "group2", "name": "Group Two"}],
+    ]
+    connector.client = mock_client
+
+    connector.get_groups(CrowdStrikeDevice(groups=["group1"]))
+    groups = connector.get_groups(CrowdStrikeDevice(groups=["group1", "group2"]))
+
+    assert [g.name for g in groups] == ["Group One", "Group Two"]
+    assert mock_client.get_host_groups.call_args_list[-1].args[0] == ["group2"]
+
+
+def test_get_groups_caches_the_fallback_so_a_failing_lookup_is_not_retried(connector):
+    mock_client = Mock()
+    mock_client.get_host_groups.side_effect = Exception("403 Forbidden")
+    connector.client = mock_client
+
+    for _ in range(3):
+        groups = connector.get_groups(CrowdStrikeDevice(groups=["group1"]))
+        assert [(g.uid, g.name) for g in groups] == [("group1", "group1")]
+
+    mock_client.get_host_groups.assert_called_once()
+
+
+def test_get_assets_resets_the_group_cache_between_cycles(connector):
+    connector._groups_cache = {"stale": Group(uid="stale", name="Stale")}
+    client = Mock()
+    client.list_devices_uuids.return_value = iter([])
+    connector.client = client
+
+    assert list(connector.get_assets()) == []
+    assert connector._groups_cache == {}
+
+
+def test_update_checkpoint_held_back_when_a_batch_was_dropped(connector):
+    """A batch Sekoia refused was never ingested, so the run must be replayed."""
+    connector._latest_id = "u5"
+    connector._push_failed = True
+
+    connector.update_checkpoint()
+
+    assert "most_recent_device_id" not in connector.context.store
+
+
+def test_post_assets_to_api_flags_a_dropped_batch(connector, monkeypatch):
+    monkeypatch.setattr(CrowdstrikeDeviceAssetConnector.__bases__[0], "post_assets_to_api", lambda *a, **kw: None)
+    assert connector.post_assets_to_api(Mock(), "https://api.fake") is None
+    assert connector._push_failed is True
+
+
+def test_asset_fetch_cycle_commits_the_checkpoint_once_every_batch_is_pushed(connector, monkeypatch):
+    def fake_cycle(self):
+        self._latest_id = "u5"
+
+    monkeypatch.setattr(CrowdstrikeDeviceAssetConnector.__bases__[0], "asset_fetch_cycle", fake_cycle)
+
+    connector.asset_fetch_cycle()
+
+    assert connector.context.store["most_recent_device_id"] == "u5"
+
+
+class _PersistentContext:
+    """Behaves like PersistentJSON: survives across fetch cycles."""
+
+    def __init__(self):
+        self.store = {}
+
+    def __enter__(self):
+        return self.store
+
+    def __exit__(self, *args):
+        pass
+
+
+def _install_push_session(connector, statuses):
+    """Mock the Sekoia push; `statuses` gives the status code of each POST."""
+    pushed = []
+    codes = iter(statuses)
+
+    def post(url, json=None, timeout=None):
+        res = Mock()
+        res.status_code = next(codes)
+        res.headers = {}
+        res.json.return_value = {}
+        if res.status_code == 200:
+            pushed.append(len(json["items"]))
+        return res
+
+    session = Mock()
+    session.post.side_effect = post
+    connector.__dict__["_http_session"] = session
+    return pushed
+
+
+def test_asset_fetch_cycle_replays_an_interrupted_backfill(connector):
+    """SekoiaLab/integration#1846: a run cut short must not strand the devices it missed."""
+    total, batch = 200, 100
+    connector.LIMIT = batch
+    connector.configuration = {
+        "sekoia_base_url": "https://api.fake.sekoia.io/",
+        "sekoia_api_key": "fake_api_key",
+        "batch_size": batch,
+        "frequency": 0,
+    }
+    connector.module.connector_configuration_uuid = "adcd0095-0f3d-4699-8621-158977b6c2c3"
+    connector.context = _PersistentContext()
+
+    uuids = [f"dev-{i:03d}" for i in range(total)]  # first_seen.desc
+    client = Mock()
+    client.get_devices_infos.side_effect = lambda ids: [
+        {"device_id": u, "hostname": f"host-{u}", "platform_name": "Windows"} for u in ids
+    ]
+    connector.client = client
+
+    # Cycle 1: the second batch is refused, so nothing may be checkpointed
+    client.list_devices_uuids.return_value = iter(uuids)
+    pushed = _install_push_session(connector, [200, 500])
+    connector.asset_fetch_cycle()
+
+    assert pushed == [batch]
+    assert "most_recent_device_id" not in connector.context.store
+
+    # Cycle 2: the whole listing is walked again, no device is lost
+    client.list_devices_uuids.return_value = iter(uuids)
+    pushed = _install_push_session(connector, [200] * 5)
+    connector.asset_fetch_cycle()
+
+    assert sum(pushed) == total
+    assert connector.context.store["most_recent_device_id"] == "dev-000"
+
+    # Cycle 3: everything is collected, the checkpoint short-circuits the run
+    client.list_devices_uuids.return_value = iter(uuids)
+    pushed = _install_push_session(connector, [200] * 5)
+    connector.asset_fetch_cycle()
+
+    assert pushed == []

--- a/CrowdStrikeFalcon/tests/client/test_client.py
+++ b/CrowdStrikeFalcon/tests/client/test_client.py
@@ -314,4 +314,5 @@ def test_list_devices_uuids_stops_on_a_repeated_scroll_token():
             },
         )
 
-        assert list(client.list_devices_uuids(limit=1, sort="first_seen.desc")) == ["u1", "u1"]
+        # The stuck page is dropped, not replayed
+        assert list(client.list_devices_uuids(limit=1, sort="first_seen.desc")) == ["u1"]

--- a/CrowdStrikeFalcon/tests/client/test_client.py
+++ b/CrowdStrikeFalcon/tests/client/test_client.py
@@ -200,3 +200,56 @@ def test_find_indicators():
 
         indicators = client.find_indicators(fql_filter=f"source:Sekoia.io")
         assert list(indicators) == ["519b7236-8ed2-4c63-b5c4-0f72dc3f187e", "f6d85700-1b5b-450f-8df1-a8317fe7f137"]
+
+
+def test_list_devices_uuids_follows_the_scroll_token_past_the_offset_cap():
+    """devices/v1 refuses limit + offset above 10 000, devices-scroll uses a token."""
+    base_url = "https://my.fake.sekoia"
+    client = CrowdstrikeFalconClient(base_url, "foo", "bar")
+
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST", f"{base_url}/oauth2/token", json={"access_token": "t", "token_type": "bearer", "expires_in": 1799}
+        )
+
+        mock.register_uri(
+            "GET",
+            f"{base_url}/devices/queries/devices-scroll/v1?limit=2&sort=first_seen.desc",
+            json={
+                "errors": [],
+                "meta": {"pagination": {"limit": 2, "total": 3, "offset": "scroll-token-1"}},
+                "resources": ["u1", "u2"],
+            },
+        )
+        mock.register_uri(
+            "GET",
+            f"{base_url}/devices/queries/devices-scroll/v1" "?limit=2&sort=first_seen.desc&offset=scroll-token-1",
+            json={
+                "errors": [],
+                "meta": {"pagination": {"limit": 2, "total": 3, "offset": ""}},
+                "resources": ["u3"],
+            },
+        )
+
+        assert list(client.list_devices_uuids(limit=2, sort="first_seen.desc")) == ["u1", "u2", "u3"]
+
+
+def test_list_devices_uuids_stops_on_a_repeated_scroll_token():
+    base_url = "https://my.fake.sekoia"
+    client = CrowdstrikeFalconClient(base_url, "foo", "bar")
+
+    with requests_mock.Mocker() as mock:
+        mock.register_uri(
+            "POST", f"{base_url}/oauth2/token", json={"access_token": "t", "token_type": "bearer", "expires_in": 1799}
+        )
+        mock.register_uri(
+            "GET",
+            f"{base_url}/devices/queries/devices-scroll/v1",
+            json={
+                "errors": [],
+                "meta": {"pagination": {"limit": 1, "total": 9, "offset": "stuck"}},
+                "resources": ["u1"],
+            },
+        )
+
+        assert list(client.list_devices_uuids(limit=1, sort="first_seen.desc")) == ["u1", "u1"]


### PR DESCRIPTION
Relates to [1846](https://github.com/SekoiaLab/integration/issues/1846)

## Summary by Sourcery

Ensure CrowdStrike Falcon device synchronization reliably processes large inventories and recovers from interrupted or failed collection cycles.

Bug Fixes:
- Prevent interrupted or partially failed device collection cycles from advancing the checkpoint and permanently skipping uncollected devices.
- Use CrowdStrike’s scroll-based device listing to support inventories beyond the numeric pagination limit.

Enhancements:
- Cache host-group lookups for each collection cycle to reduce API calls and repeated permission warnings.

Tests:
- Add regression coverage for checkpoint handling, failed batch replay, host-group caching, and scroll-token pagination.