### PR TITLE
fix(microsoft_defender): update minimum frequency

### DIFF
--- a/MicrosoftDefender/CHANGELOG.md
+++ b/MicrosoftDefender/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-08-18 - 1.3.7
+
+### Changed
+
+- Update the minimum frequency value from 1 second to 3 hours (10800 seconds) for the device asset connector to avoid excessive API calls and potential throttling.
+
 ## 2026-08-18 - 1.3.6
 
 ### Fixed

--- a/MicrosoftDefender/connector_microsoft_defender_device_assets.json
+++ b/MicrosoftDefender/connector_microsoft_defender_device_assets.json
@@ -16,7 +16,7 @@
       "frequency": {
         "type": "integer",
         "description": "Batch frequency in seconds",
-        "minimum": 1,
+        "minimum": 10800,
         "default": 86400
       },
       "sekoia_api_key": {

--- a/MicrosoftDefender/manifest.json
+++ b/MicrosoftDefender/manifest.json
@@ -50,6 +50,6 @@
   "categories": [
     "Endpoint"
   ],
-  "version": "1.3.6",
+  "version": "1.3.7",
   "supports_validation": true
 }


### PR DESCRIPTION
## Summary by Sourcery

Set the Microsoft Defender device asset connector minimum frequency to three hours.

Enhancements:
- Increase the Microsoft Defender device asset connector minimum polling frequency to three hours to reduce excessive API calls and avoid throttling.

Chores:
- Bump the Microsoft Defender connector version to 1.3.7 and update its changelog.