### PR TITLE
fix(asset_connectors): fix vendor name field

### DIFF
--- a/AWS/CHANGELOG.md
+++ b/AWS/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-09-04 - 1.38.1
+
+### Fixed
+
+- Fix device asset connector: stop setting `device.vendor_name` to "Amazon Web Services" for EC2 instances; AWS is the cloud provider, not the hardware vendor of the underlying physical device (which is not exposed by the EC2 API)
+
 ## 2026-07-31 - 1.38.0
 
 ### Added

--- a/AWS/asset_connector/device_assets.py
+++ b/AWS/asset_connector/device_assets.py
@@ -368,7 +368,8 @@ class AwsDeviceAssetConnector(AwsAssetsConnector):
             hypervisor = instance.Hypervisor
 
             # Extract vendor and model from instance type
-            vendor_name = "Amazon Web Services"
+            # vendor_name is left as None: AWS is the cloud provider, not the hardware vendor
+            # of the underlying physical device (which is not exposed via the EC2 API).
             model = instance.InstanceType
 
             # Extract autoscale group from tags
@@ -415,7 +416,7 @@ class AwsDeviceAssetConnector(AwsAssetsConnector):
                 subnet=subnet,
                 domain=domain,
                 hypervisor=hypervisor,
-                vendor_name=vendor_name,
+                vendor_name=None,
                 model=model,
                 boot_time=boot_time_timestamp,
                 created_time=created_timestamp,

--- a/AWS/asset_connector/device_mapping.yml
+++ b/AWS/asset_connector/device_mapping.yml
@@ -330,12 +330,6 @@ mapping:
       logic: "Direct mapping (e.g., 'xen', 'nitro')"
       description: "Hypervisor type"
 
-    - source: "static: Amazon Web Services"
-      target: "device.vendor_name"
-      type: "string"
-      logic: "Always 'Amazon Web Services'"
-      description: "Device vendor name"
-
     - source: "InstanceType"
       target: "device.model"
       type: "string"
@@ -414,7 +408,6 @@ mapping:
             "hostname": "ec2-11-22-44-66.compute-1.amazonaws.com",
             "type": "Server",
             "type_id": 1,
-            "vendor_name": "Amazon Web Services",
             "ip": "1.2.3.4",
             "model": "t3.medium",
             "image_id": "ami-0c55b159cbfafe1f0",

--- a/AWS/manifest.json
+++ b/AWS/manifest.json
@@ -30,7 +30,7 @@
   "name": "AWS",
   "uuid": "b4462429-6f0f-42b5-87b8-430111697d28",
   "slug": "aws",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "categories": ["Cloud Providers"],
   "supports_validation": true
 }

--- a/HarfangLab/CHANGELOG.md
+++ b/HarfangLab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-09-04 - 1.31.11
+
+### Fixed
+
+- Fix device asset connector: remove incorrect `vendor_name` value ("HarfangLab") from the device inventory mapping sample; `vendor_name` should reflect the device hardware vendor, not the product name
+
 ## 2026-08-27 - 1.31.10
 
 ### Fixed

--- a/HarfangLab/harfanglab/asset_connector/device_mapping.yml
+++ b/HarfangLab/harfanglab/asset_connector/device_mapping.yml
@@ -587,7 +587,6 @@ mapping:
             "hostname": "testhostaname1",
             "type": "Desktop",
             "type_id": 1,
-            "vendor_name": "HarfangLab",
             "ip": "1.2.2.5",
             "domain": "TestGROUP",
             "subnet": "255.255.255.0",

--- a/HarfangLab/manifest.json
+++ b/HarfangLab/manifest.json
@@ -26,7 +26,7 @@
   "name": "HarfangLab",
   "uuid": "8380240b-61a4-48b7-93e4-044a7ee2309b",
   "slug": "harfanglab",
-  "version": "1.31.10",
+  "version": "1.31.11",
   "categories": [
     "Endpoint"
   ],

--- a/HolmSecurity/CHANGELOG.md
+++ b/HolmSecurity/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-09-04
+
+### Fixed
+
+- Fix device asset connector: stop setting `device.vendor_name` to the product name ("Holm Security") for network assets; `vendor_name` must represent the device hardware vendor, not the scanning tool
+
 ## [1.3.0] - 2026-08-20
 
 ### Added

--- a/HolmSecurity/holm_security/asset_connector/device_assets.py
+++ b/HolmSecurity/holm_security/asset_connector/device_assets.py
@@ -177,7 +177,6 @@ class HolmSecurityDeviceAssetConnector(AssetConnector):
             created_time=self._to_epoch(asset.created),
             last_seen_time=self._to_epoch(asset.last_detected),
             is_managed=False,
-            vendor_name=self.PRODUCT_NAME,
             risk_score=asset.risk_score if asset.risk_score else None,
             risk_level=risk_level,
             risk_level_id=risk_level_id,

--- a/HolmSecurity/holm_security/asset_connector/device_mapping.yml
+++ b/HolmSecurity/holm_security/asset_connector/device_mapping.yml
@@ -419,7 +419,6 @@ mapping:
             "created_time": 1751387820.667844,
             "last_seen_time": 1751532453.0,
             "is_managed": false,
-            "vendor_name": "Holm Security",
             "risk_score": 100,
             "risk_level": "Critical",
             "risk_level_id": 4,

--- a/HolmSecurity/manifest.json
+++ b/HolmSecurity/manifest.json
@@ -27,7 +27,7 @@
   "name": "Holm Security",
   "uuid": "23886dfe-89a9-4522-b1fb-6e2837e15390",
   "slug": "holm-security",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "categories": [
     "Network"
   ],

--- a/HolmSecurity/tests/asset_connector/test_device_assets.py
+++ b/HolmSecurity/tests/asset_connector/test_device_assets.py
@@ -373,7 +373,7 @@ def test_map_net_asset_fields(connector):
     assert device.name == "host-example01.example.com"
     assert device.ip == "192.0.2.20"
     assert device.is_managed is False
-    assert device.vendor_name == "Holm Security"
+    assert device.vendor_name is None
     assert device.risk_score == 100
     assert device.risk_level == "Critical"
     assert device.created_time == isoparse("2026-07-01T16:37:00.667844Z").timestamp()

--- a/SentinelOne/CHANGELOG.md
+++ b/SentinelOne/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-09-04 - 1.23.2
+
+### Fixed
+
+- Fix device asset connector: stop assigning the device `modelName` to `device.vendor_name`; `vendor_name` must represent the device hardware vendor, not the model
+
 ## 2026-07-29 - 1.23.1
 
 ### Fixed

--- a/SentinelOne/manifest.json
+++ b/SentinelOne/manifest.json
@@ -27,7 +27,7 @@
   "name": "SentinelOne",
   "uuid": "ff675e74-e5c1-47c8-a571-d207fc297464",
   "slug": "sentinelone",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "categories": [
     "Endpoint"
   ],

--- a/SentinelOne/sentinelone_module/asset_connector/device_assets.py
+++ b/SentinelOne/sentinelone_module/asset_connector/device_assets.py
@@ -349,7 +349,6 @@ class SentinelOneDeviceAssetConnector(AssetConnector):
             subnet=agent.groupIp,  # Network subnet/range (e.g., "31.155.5.x")
             network_interfaces=network_interfaces,
             model=agent.modelName,
-            vendor_name=agent.modelName,
             boot_time=boot_time,
             created_time=created_time,
             first_seen_time=first_seen_time,

--- a/SentinelOne/sentinelone_module/asset_connector/device_mapping.yml
+++ b/SentinelOne/sentinelone_module/asset_connector/device_mapping.yml
@@ -295,12 +295,6 @@ mapping:
       logic: "Direct mapping of device model name"
       description: "Device model name"
 
-    - source: "modelName"
-      target: "device.vendor_name"
-      type: "string"
-      logic: "Direct mapping of modelName as vendor_name (Device.vendor_name)"
-      description: "Device vendor name (mapped from modelName)"
-
     # DEVICE TIMESTAMPS
     - source: "createdAt"
       target: "device.created_time"
@@ -492,7 +486,6 @@ mapping:
             "type": "Desktop",
             "type_id": 2,
             "model": "Latitude 5540",
-            "vendor_name": "Latitude 5540",
             "ip": "192.168.1.100",
             "subnet": null,
             "is_managed": true,

--- a/SentinelOne/tests/asset_connector/test_device_assets.py
+++ b/SentinelOne/tests/asset_connector/test_device_assets.py
@@ -301,7 +301,7 @@ def test_map_fields_success(test_sentinelone_device_asset_connector, sample_agen
     assert result.device.ip == "31.155.5.7"
     assert result.device.subnet == "31.155.5.x"
     assert result.device.model == "Acme computers - 15x4k"
-    assert result.device.vendor_name == "Acme computers - 15x4k"
+    assert result.device.vendor_name is None
     assert result.device.is_managed is True
     assert result.device.is_compliant is True
     assert result.device.region == "Test Site"
@@ -416,7 +416,7 @@ def test_map_fields_minimal_agent(test_sentinelone_device_asset_connector):
 
     # These fields should always be set
     assert result.device.name == "MINIMAL-PC"
-    assert result.device.vendor_name is None  # modelName not provided in minimal agent
+    assert result.device.vendor_name is None
     assert result.device.is_managed is True
     assert result.device.created_time is not None
 


### PR DESCRIPTION
linked issue : [issue](https://github.com/SekoiaLab/integration/issues/1341)

## Summary by Sourcery

Correct device vendor attribution across asset connectors by leaving the hardware vendor unset when source data does not provide it.

Bug Fixes:
- Correct device asset connector mappings so `device.vendor_name` is no longer populated with cloud providers, security products, or device model names when the actual hardware vendor is unavailable.

Tests:
- Update asset connector tests and mapping examples to expect an unset device vendor name.

Chores:
- Bump AWS, HarfangLab, Holm Security, and SentinelOne connector versions and update their changelogs.