### PR TITLE
fix(MicrosoftActiveDirectory): skip user entries without attributes instead of aborting collection

### DIFF
--- a/MicrosoftActiveDirectory/CHANGELOG.md
+++ b/MicrosoftActiveDirectory/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-09-08 - 1.5.9
+
+### Fixed
+
+- The user asset connector now skips an LDAP entry that has no attributes instead of raising. The raise previously aborted the whole collection cycle and could get stuck re-hitting the same malformed entry every cycle.
+
 ## 2026-07-13 - 1.5.8
 
 ### Fixed

--- a/MicrosoftActiveDirectory/manifest.json
+++ b/MicrosoftActiveDirectory/manifest.json
@@ -32,7 +32,7 @@
   "name": "Microsoft Active Directory",
   "uuid": "b2d96259-af89-4f7a-ae6e-a0af2d2400f3",
   "slug": "microsoft-ad",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "categories": [
     "IAM"
   ],

--- a/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
+++ b/MicrosoftActiveDirectory/microsoft_ad/asset_connectors/user_assets.py
@@ -328,8 +328,11 @@ class MicrosoftADUserAssetConnector(AssetConnector, LDAPClient):
         for entry in self._entries():
             user_attributes = entry.get("attributes", {})
             if not user_attributes:
-                self.log("No user attributes found for user", level="error")
-                raise Exception("No user attributes found for user")
+                self.log(
+                    f"Skipping entry with no attributes (DN={entry.get('dn')})",
+                    level="warning",
+                )
+                continue
 
             user_created_at = user_attributes.get("whenCreated")
             if user_created_at:

--- a/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
+++ b/MicrosoftActiveDirectory/tests/asset_connectors/test_user_assets.py
@@ -257,6 +257,21 @@ def test_get_users_generator(connector):
     assert connector._latest_time == "20240101120000.0Z"
 
 
+def test_get_users_generator_skips_entries_without_attributes(connector):
+    bad_entry = {"dn": "CN=Broken,DC=example,DC=com", "attributes": {}}
+    good_entry = {
+        "dn": "CN=Test User,DC=example,DC=com",
+        "attributes": {"userPrincipalName": "test@example.com", "whenCreated": datetime(2024, 1, 1, 12, 0, 0)},
+    }
+
+    connector.ldap_client.extend.standard.paged_search.return_value = iter([bad_entry, good_entry])
+
+    users = list(connector.get_users_generator())
+
+    # The attribute-less entry is skipped instead of aborting the whole collection.
+    assert [u["dn"] for u in users] == ["CN=Test User,DC=example,DC=com"]
+
+
 def test_get_assets(connector):
     mock_user = {
         "dn": "CN=Asset User,DC=example,DC=com",


### PR DESCRIPTION
The Microsoft AD user asset connector could get stuck. A single AD entry with no usable attributes raised inside `get_users_generator`, and that iteration is not inside the per-user `try/except` of `get_assets`, so the exception propagated up to the SDK run loop and aborted the whole fetch cycle. When the bad entry came before any batch was pushed, the checkpoint did not advance, so every following cycle hit the same entry and aborted again, blocking all further user collection.

This logs and skips such an entry instead of raising, mirroring the per-item tolerance already used in `get_assets`. Adds a regression test and bumps the module to 1.5.9.

Tracked in SekoiaLab/platform#93188.

## Summary by Sourcery

Prevent malformed Microsoft Active Directory user entries from stopping user asset collection.

Bug Fixes:
- Skip LDAP user entries without attributes so malformed records no longer abort or block subsequent collection cycles.

Tests:
- Add regression coverage confirming attribute-less LDAP entries are skipped while valid users continue to be collected.

Chores:
- Bump the Microsoft Active Directory module version to 1.5.9 and document the fix.