### PR TITLE
update 1password connector

### DIFF
--- a/1Password/CHANGELOG.md
+++ b/1Password/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2026-09-11 - 1.1.6
+
+### Fixed
+
+- Fix duplicated events by stopping pagination when the API reports `has_more=false` instead of re-using the reset cursor
+
 ## 2026-07-30 - 1.1.5
 
 ### Changed

--- a/1Password/manifest.json
+++ b/1Password/manifest.json
@@ -26,7 +26,7 @@
   "name": "1Password",
   "uuid": "56f9e1f6-95ba-45ed-867b-44fb3183934d",
   "slug": "one-password",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "categories": [
     "Applicative"
   ]

--- a/1Password/onepassword_modules/connector_1password_epm.py
+++ b/1Password/onepassword_modules/connector_1password_epm.py
@@ -88,6 +88,13 @@ class OnePasswordEndpoint(Thread):
                 EVENTS_LAG.labels(intake_key=self.connector.configuration.intake_key, type=self.name).set(0)
                 return
 
+            # Stop once the API signals there are no more pages. The cursor returned with
+            # `has_more=false` is a reset cursor meant for the next polling cycle; re-using it
+            # here would re-deliver already-seen events and produce duplicates.
+            if not page.get("has_more", False):
+                EVENTS_LAG.labels(intake_key=self.connector.configuration.intake_key, type=self.name).set(0)
+                return
+
             data = {"cursor": page["cursor"]}
             response = self.client.post(url, json=data)
 

--- a/1Password/tests/test_1password_epm_connector.py
+++ b/1Password/tests/test_1password_epm_connector.py
@@ -120,6 +120,35 @@ def test_next_batch_without_events(trigger, message_1, message_2):
         mock_time.sleep.assert_called_once_with(44)
 
 
+def test_next_batch_stops_on_last_page(trigger, message_1):
+    # A final page carrying events with `has_more=False` must not trigger an extra
+    # request with the reset cursor, which would re-deliver already-seen events.
+    trigger.from_date = 1645668000000
+    worker = SignInAttemptsEndpoint(connector=trigger)
+
+    last_page = {**message_1, "cursor": "CURSOR_LAST", "has_more": False}
+
+    with (
+        requests_mock.Mocker() as mock_requests,
+        patch("onepassword_modules.connector_1password_epm.time") as mock_time,
+    ):
+        mock_requests.post(
+            "https://example.com/api/v1/signinattempts",
+            [{"json": last_page}],
+        )
+
+        batch_duration = 16
+        start_time = 1666711174.0
+        end_time = start_time + batch_duration
+        mock_time.time.side_effect = [start_time, end_time, end_time]
+
+        worker.next_batch()
+
+        # Only the initial request is made; no follow-up with the reset cursor.
+        assert mock_requests.call_count == 1
+        assert trigger.push_events_to_intakes.call_count == 1
+
+
 def test_start_consumers(trigger):
     with patch("onepassword_modules.connector_1password_epm.OnePasswordEndpoint.start") as mock_start:
         consumers = trigger.start_consumers()


### PR DESCRIPTION
https://github.com/SekoiaLab/platform/issues/91934

## Summary by Sourcery

Stop 1Password event pagination at the final API page to prevent duplicate deliveries.

Bug Fixes:
- Prevent duplicate 1Password events by stopping pagination when the API indicates that no more pages are available.

Tests:
- Add coverage confirming that final pages do not trigger a follow-up request with a reset cursor.

Chores:
- Bump the 1Password connector version to 1.1.6 and record the fix in the changelog.